### PR TITLE
Fix a typo in log.c preventing args from being logged properly.

### DIFF
--- a/bin/log.c
+++ b/bin/log.c
@@ -31,7 +31,7 @@ void _LogWrite(char *file, int line, const char *format, ...)
 		logFile = fopen(filename, "a");
 		fprintf(logFile, "%s  %s:%d:",timeStr, file, line);
 		va_start(arg, format);
-		fprintf(logFile, format, arg);
+		vfprintf(logFile, format, arg);
 		va_end(arg);
 
 		fclose(logFile);


### PR DESCRIPTION
A typo used fprintf() instead of vfprintf() causing arguments to not
be properly output to the log.
