### PR TITLE
Update mixer volume when fppd starts. Issue #65.

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -33,6 +33,9 @@
 #include <string.h>
 #include <strings.h>
 #include <getopt.h>
+#include <sys/stat.h>
+#include <ctype.h>
+#include "common.h"
 
 
 char *fpp_bool_to_string[] = { "false", "true", "default" };
@@ -340,7 +343,7 @@ int parseArguments(int argc, char **argv)
 				settings.daemonize = true;
 				break;
 			case 'v': //volume
-				settings.volume = atoi(optarg);
+				setVolume (atoi(optarg));
 				break;
 			case 'm': //mode
 				if ( strcmp(optarg, "player") == 0 )
@@ -476,7 +479,7 @@ int loadSettings(const char *filename)
 			else if ( strcmp(key, "volume") == 0 )
 			{
 				if ( strlen(value) )
-					settings.volume = atoi(value);
+					setVolume(atoi(value));
 				else
 					fprintf(stderr, "Failed to load volume setting from config file\n");
 			}
@@ -900,12 +903,18 @@ unsigned int getControlMinor(void)
 
 void setVolume(int volume)
 {
+	char buffer [40];
+	
 	if ( volume < 0 )
 		settings.volume = 0;
 	else if ( volume > 100 )
 		settings.volume = 100;
 	else
 		settings.volume = volume;
+
+	snprintf(buffer, 40, "amixer set PCM %d%% >/dev/null 2>&1", (50+ volume / 2));
+	LogDebug(VB_SETTING,"Volume change: %d \n", volume);	
+	system(buffer);
 }
 
 /*

--- a/www/fppxml.php
+++ b/www/fppxml.php
@@ -214,10 +214,11 @@ function SetVolume()
 	{
 		$vol = "99";	
 	}
-	
-	$vol = 50 + ($vol/2);
-	
+		
 	$status=SendCommand('v,' . $vol . ',');
+
+	$vol = 50 + ($vol/2);
+
 	$status=exec("amixer set PCM -- " . $vol . "%");
 
 	EchoStatusXML($status);


### PR DESCRIPTION
When parameters are extracted from command line or setting file, the function setVolume is called.
In setVolume, command "amixer set PCM xx%" is performed to apply the volume.
In fppxml.php, send to fpp the real value (0-100), and not the value for amixer (50 to 100).
Add missing headers inclusion in settings.c

Works fine in my configuration. If code seems good, can be used for fpp.
(I will keep this fix for me until we have an official one)
Stephane
