### PR TITLE
Updated fppLCD.py to use /home/fpp/media if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ external/rasclock/rtc-pcf2127a.*
 external/rasclock/.rtc-pcf2127a.*
 external/rasclock/.tmp_versions/*
 plugins/
+.idea/

--- a/scripts/lcd/fppLCD.py
+++ b/scripts/lcd/fppLCD.py
@@ -24,7 +24,7 @@ class fppLCD():
     self.PLAYLIST_DIRECTORY = "/home/pi/media/playlists/"
     self.SETTINGS_FILE = "/home/pi/media/settings"
 	#Alternate location
-	self.PLAYLIST_DIR_ALT = "/home/fpp/media/playlists/"
+    self.PLAYLIST_DIR_ALT = "/home/fpp/media/playlists/"
     self.SETTINGS_DIR_ALT= "/home/fpp/media/settings"
 	
     self.DIRECTION_LEFT = 0

--- a/scripts/lcd/fppLCD.py
+++ b/scripts/lcd/fppLCD.py
@@ -126,6 +126,11 @@ class fppLCD():
                           "Timeout         ")
 
   def Initialize(self):
+
+    if os.path.exists("/home/fpp/media"):
+      self.PLAYLIST_DIRECTORY = "/home/fpp/media/playlists/";
+      self.SETTINGS_FILE = "/home/fpp/media/settings";
+
     strColorIndex = self.readSetting("piLCD_BackColor")
     if strColorIndex.isdigit():
       self.BackgroundColor = int(strColorIndex);

--- a/scripts/lcd/fppLCD.py
+++ b/scripts/lcd/fppLCD.py
@@ -20,9 +20,13 @@ class fppLCD():
     self.THIS_DIRECTORY = directory
 
     self.BACK_COLOR = 0
+	#Directory locations
     self.PLAYLIST_DIRECTORY = "/home/pi/media/playlists/"
     self.SETTINGS_FILE = "/home/pi/media/settings"
-
+	#Alternate location
+	self.PLAYLIST_DIR_ALT = "/home/fpp/media/playlists/"
+    self.SETTINGS_DIR_ALT= "/home/fpp/media/settings"
+	
     self.DIRECTION_LEFT = 0
     self.DIRECTION_RIGHT = 1
     self.MAX_CHARS = 16
@@ -126,10 +130,10 @@ class fppLCD():
                           "Timeout         ")
 
   def Initialize(self):
-
+	#Check the new fpp user directory exists
     if os.path.exists("/home/fpp/media"):
-      self.PLAYLIST_DIRECTORY = "/home/fpp/media/playlists/";
-      self.SETTINGS_FILE = "/home/fpp/media/settings";
+      self.PLAYLIST_DIRECTORY = self.PLAYLIST_DIR_ALT;
+      self.SETTINGS_FILE = self.SETTINGS_DIR_ALT;
 
     strColorIndex = self.readSetting("piLCD_BackColor")
     if strColorIndex.isdigit():

--- a/www/backup.php
+++ b/www/backup.php
@@ -1,0 +1,466 @@
+<?php $skipJSsettings = 1; //because config.php outputs JS which it shouldn't be doing anyway ?>
+<?php require_once('common.php'); ?>
+<?php
+//TODO Backup/Restore of events
+//TODO Backup/Restore of scripts
+//TODO fppMode in general settings file handling
+
+/**
+ * Define entries map for backup/restore area select lists
+ */
+$system_config_aras = array(
+    'all' => array('friendly_name' => 'All', 'file' => false),
+    'channelOutputsJSON' => array('friendly_name' => 'Channel Outputs (RGBMatrix)', 'file' => $settings['channelOutputsJSON']),
+    'channeloutputs' => array('friendly_name' => 'Channel Outputs (Other eg, LOR, Renard, Tricks-C)', 'file' => $settings['channelOutputsFile']),
+    'channelmemorymaps' => array('friendly_name' => 'Channel Memory Maps', 'file' => $settings['channelMemoryMapsFile']),
+    'email' => array('friendly_name' => 'Email', 'file' => false),
+    'schedule' => array('friendly_name' => 'Schedule', 'file' => $scheduleFile),
+    'settings' => array('friendly_name' => 'Settings', 'file' => $settingsFile),
+    'timezone' => array('friendly_name' => 'Timezone', 'file' => $timezoneFile),
+//    'pixelnetDMX' => array('friendly_name' => 'FPP Pixlenet/DMX', 'file' => $pixelnetFile),
+    'universes' => array('friendly_name' => 'Universes', 'file' => $universeFile),
+//    'wlan' => array('friendly_name' => 'WLAN', 'file' => $settings['configDirectory']. "/interface.wlan0")
+
+);
+
+$keepMasterSlaveSettings = null;
+$keepNetworkSettings = null;
+
+//list of settings restored
+$settings_restored = array();
+$restore_done = false;
+
+/**
+ * Handle POST for download or restore
+ * Check which submit button was pressed
+ */
+if (isset($_POST['btnDownloadConfig'])) {
+    //Backup area value
+    if (isset($_POST['backuparea']) && !empty($_POST['backuparea'])) {
+        $area = $_POST['backuparea'];
+        //this value *SHOULD* directly match a key in $system_config_aras
+
+        //temp data
+        $tmp_settings_data = array();
+
+        if (array_key_exists($area, $system_config_aras)) {
+
+            //Create a copy of the areas array to manipulate
+            $tmp_config_areas = $system_config_aras;
+
+            //Generate backup for selected area
+            if (strtolower($area) == "all") {
+                //combine all backup areas into a single file
+
+                //remove the 'all' key and do some processing of areas array
+
+                unset($tmp_config_areas['all']);
+                //remove email as its in the general settings file
+                unset($tmp_config_areas['email']);
+
+                foreach ($tmp_config_areas as $key => $key_data) {
+                    $setting_file = $key_data['file'];
+
+                    if ($setting_file !== false && file_exists($setting_file)) {
+                        if ($key == "settings") {
+                            //parse ini
+                            $file_data = parse_ini_string(file_get_contents($setting_file));
+                        } else {
+                            $file_data = file_get_contents($setting_file);
+                        }
+
+                        //TODO issue with new lines
+
+                        $tmp_settings_data[$key] = $file_data;
+                    }
+                }
+            } else if (strtolower($area) == "email") {
+                //special treatment for email settings as they are inside the general settings file
+                $email_settings = array(
+                    'emailenable' => $settings['emailenable'],
+                    'emailguser' => $settings['emailguser'],
+                    'emailfromtext' => $settings['emailfromtext'],
+                    'emailtoemail' => $settings['emailtoemail']
+                );
+
+                $tmp_settings_data['email'] = $email_settings;
+            } else {
+                //All other backup areas
+                $setting_file = $tmp_config_areas[$area]['file'];
+
+                if ($setting_file !== false && file_exists($setting_file)) {
+                    if ($key == "settings") {
+                        //parse ini properly
+                        $file_data = parse_ini_string(file_get_contents($setting_file));
+                    } else {
+
+                        $file_data = file_get_contents($setting_file);
+                    }
+
+                    $tmp_settings_data[$key] = $file_data;
+                }
+            }
+
+            //DO IT!
+            if (!empty($tmp_settings_data)) {
+                do_backup_download($tmp_settings_data, $area);
+            }
+        }
+    }
+
+} else if (isset($_POST['btnRestoreConfig'])) {
+
+    //RESTORE
+    if (isset($_POST['restorearea']) && !empty($_POST['restorearea'])) {
+        $restore_area = $_POST['restorearea'];
+
+        if (isset($_POST['keepExitingNetwork']) && !empty($_POST['keepExitingNetwork'])) {
+            $keepNetworkSettings = $_POST['keepExitingNetwork'];
+        }
+        if (isset($_POST['keepMasterSlave']) && !empty($_POST['keepMasterSlave'])) {
+            $keepMasterSlaveSettings = $_POST['keepMasterSlave'];
+        }
+
+        //this value *SHOULD* directly match a key in $system_config_aras
+        if (array_key_exists($restore_area, $system_config_aras)) {
+            //Do something with the uploaded file to restore it
+
+            if (array_key_exists('conffile', $_FILES)) {
+
+                //data is stored by area and keyed the same as $system_config_aras
+                //read file, decode json
+                //parse each area and write settings
+
+                $rstfname = $_FILES['conffile']['name'];
+                $rstftmp_name = $_FILES['conffile']['tmp_name'];
+                //file contents
+                $file_contents = file_get_contents($rstftmp_name);
+                $file_contents_decoded = json_decode($file_contents, true);
+
+                //successful decode
+                if ($file_contents_decoded !== FALSE) {
+                    if (strtolower($restore_area) == "all") {
+
+                        //read each area and process it
+                        foreach ($file_contents_decoded as $restore_area_key => $area_data) {
+                            process_restore_data($restore_area_key, $area_data);
+                        }
+                    } else if (strtolower($restore_area) == "email") {
+
+                        if (array_key_exists('email', $file_contents_decoded)) {
+                            $emailguser = $file_contents_decoded['settings']['emailguser'];
+                            $emailgpass = "";//Not available when doing anything except full backups
+                            $emailfromtext = $file_contents_decoded['settings']['emailfromtext'];
+                            $emailtoemail = $file_contents_decoded['settings']['emailtoemail'];
+
+                            $settings_restored[] = $restore_area;
+
+                            SaveEmailConfig($emailguser, $emailgpass, $emailfromtext, $emailtoemail);
+                        } else if (array_key_exists('settings', $file_contents_decoded)) {
+                            $emailguser = $file_contents_decoded['settings']['emailguser'];
+                            $emailgpass = $file_contents_decoded['settings']['emailgpass'];
+                            $emailfromtext = $file_contents_decoded['settings']['emailfromtext'];
+                            $emailtoemail = $file_contents_decoded['settings']['emailtoemail'];
+
+                            $settings_restored[] = $restore_area;
+
+                            SaveEmailConfig($emailguser, $emailgpass, $emailfromtext, $emailtoemail);
+                        }
+
+                    } else {
+                        //Process specific restore areas, this work almost like the 'all' area
+                        //general settings, but only a matching area is cherry picked
+
+                        //If the key exists in the decoded data
+                        if (array_key_exists($restore_area, $file_contents_decoded)) {
+                            $restore_area_key = $restore_area;
+                            $area_data = $file_contents_decoded[$restore_area_key];
+                            process_restore_data($restore_area, $area_data);
+                        }
+                    }
+
+                    //All processed
+                    $restore_done = true;
+                } else {
+                    error_log("The backup " . $rstfname . " could not be decoded properly.");
+                }
+            }
+        }
+    }
+}
+
+
+/**
+ * Function to look after backup restoration
+ */
+function process_restore_data($restore_area, $area_data)
+{
+    global $system_config_aras, $keepMasterSlaveSettings, $keepNetworkSettings, $settings_restored;
+    global $args;
+
+    require_once('fppjson.php');
+    require_once('fppxml.php');
+
+    $restore_area_key = $restore_area;
+
+    if ($restore_area_key == "channelOutputsJSON") {
+        //Overwrite channel outputs JSON
+        $channel_outputs_json_filepath = $system_config_aras['channelOutputsJSON']['file'];
+        file_put_contents($channel_outputs_json_filepath, $area_data);
+    }
+
+    if ($restore_area_key == "channeloutputs") {
+        //Overwrite channel outputs JSON
+        $channel_outputs_filepath = $system_config_aras['channeloutputs']['file'];
+        file_put_contents($channel_outputs_filepath, $area_data);
+    }
+
+    if ($restore_area_key == "channelmemorymaps") {
+        //Overwrite channel outputs JSON
+        $channelmemorymaps_filepath = $system_config_aras['channelmemorymaps']['file'];
+        file_put_contents($channelmemorymaps_filepath, $area_data);
+    }
+
+    if ($restore_area_key == "schedule") {
+        //Overwrite the schedule file and bump FPPD to reload it
+        $schedule_filepath = $system_config_aras['universes']['file'];
+        file_put_contents($schedule_filepath, $area_data);
+        FPPDreloadSchedule();
+    }
+
+    if ($restore_area_key == "settings") {
+        $ini_string = parse_ini_string($area_data);
+
+        if (is_array($ini_string)) {
+
+
+            foreach ($ini_string as $setting_name => $setting_value) {
+                //check if we can change it (default value is checked - true)
+                if ($setting_name == "fppMode") {
+                    if ($keepMasterSlaveSettings == false) {
+                        WriteSettingToFile($setting_name, $setting_value);
+                    }
+                } else {
+                    WriteSettingToFile($setting_name, $setting_value);
+                }
+
+                //Do special things that require some sort of system change
+                //eg. changing piRTC fire off a shell command to set it up
+                if ($setting_name == 'piRTC') {
+                    SetPiRTC($setting_value);
+                } else if ($setting_name == "PI_LCD_Enabled") {
+                    if ($setting_value == 1) {
+                        $_GET['enabled'] = "true";
+                    } else {
+                        $_GET['enabled'] = "false";
+                    }
+                    SetPiLCDenabled();
+                } else if ($setting_name == "AudioOutput") {
+                    $args['value'] = $setting_value;
+                    SetAudioOutput();
+                } else if ($setting_name == "volume") {
+                    $_GET['volume'] = trim($setting_value);
+                    SetVolume();
+                } else if ($setting_name == "NTP") {
+                    SetNTPState($setting_value);
+                }
+            }
+        } else {
+            error_log("RESTORE: Cannot read Settings INI settings. Attempted to parse " . json_encode($area_data));
+        }
+    }
+
+    if ($restore_area_key == "timezone") {
+        SetTimezone($area_data);
+    }
+
+//  if ($restore_area_key == "pixelnetDMX") {
+//  }
+
+    if ($restore_area_key == "universes") {
+        //Just overwrite the universes file
+        $universe_filepath = $system_config_aras['universes']['file'];
+        file_put_contents($universe_filepath, $area_data);
+    }
+
+    $settings_restored[] = $restore_area;
+}
+
+
+function SetTimezone($timezone_setting)
+{
+    global $mediaDirectory, $SUDO;
+    //TODO: Check timezone for validity
+    $timezone = urldecode($timezone_setting);
+    error_log("RESTORE: Changing timezone to '" . $timezone . "'.");
+    exec($SUDO . " bash -c \"echo $timezone > /etc/timezone\"", $output, $return_val);
+    unset($output);
+    //TODO: check return
+    exec($SUDO . " dpkg-reconfigure -f noninteractive tzdata", $output, $return_val);
+    unset($output);
+    //TODO: check return
+    exec(" bash -c \"echo $timezone > $mediaDirectory/timezone\"", $output, $return_val);
+    unset($output);
+    //TODO: check return
+}
+
+function SetPiRTC($pi_rtc_setting)
+{
+    global $SUDO, $fppDir;
+
+    $piRTC = $pi_rtc_setting;
+    WriteSettingToFile("piRTC", $piRTC);
+    exec($SUDO . " $fppDir/scripts/piRTC set");
+    error_log("RESTORE: Set RTC:" . $piRTC);
+}
+
+/**
+ * Starts the download in the browser
+ * @param $settings_data array of settings data
+ * @param $area Area the download was for
+ */
+function do_backup_download($settings_data, $area)
+{
+    global $settings;
+
+    //Once we have all the settings, process the array and dump it back to the user
+    //filename
+    $backup_fname = $settings['HostName'] . "_" . $area . "-settings_" . date("YmdHis") . ".json";
+    $backup_local_fpath = $settings['configDirectory'] . "/" . $backup_fname;
+
+    //Write data into backup file
+    file_put_contents($backup_local_fpath, json_encode($settings_data));
+
+    ///Generate the headers to prompt browser to start download
+    header("Content-Disposition: attachment; filename=\"" . $backup_fname . "\"");
+    header("Content-Type: application/json");
+    header("Content-Length: " . filesize($backup_local_fpath));
+    header("Connection: close");
+    //Output the file
+    readfile($backup_local_fpath);
+    //die
+    exit;
+}
+
+/**
+ * Generate backup/restore area select list
+ * @param string $area_name Either backuparea or restorearea for either section
+ * @return string
+ */
+function backup_gen_select($area_name = "backuparea")
+{
+    global $system_config_aras;
+
+    $select_html = "<select name=\"$area_name\" id=\"$area_name\">";
+    foreach ($system_config_aras as $item => $item_options) {
+        $select_html .= "<option value=" . $item . ">" . $item_options['friendly_name'] . "</option>";
+    }
+    $select_html .= "</select>";
+
+    return $select_html;
+}
+
+?>
+
+<!DOCTYPE html>
+<html>
+<head>
+    <?php include 'common/menuHead.inc'; ?>
+
+    <title><? echo $pageTitle; ?></title>
+</head>
+<body>
+<div id="bodyWrapper">
+    <?php include 'menu.inc'; ?>
+    <br/>
+
+    <form action="backup.php" method="post" name="frmBackup" enctype="multipart/form-data">
+
+        <div id="global" class="settings">
+            <fieldset>
+                <legend>FPP Settings Backup</legend>
+                <?php if ($restore_done == true) {
+                    ?>
+                    <div id="restoreSuccessFlag">Backup Restored. A Reboot May Be Required</div>
+                    <div id="restoreSuccessFlag">What was
+                        restored: <?php echo implode(", ", $settings_restored); ?></div>
+                <?php
+                }
+                ?>
+                <fieldset>
+                    <legend>Backup Configuration</legend>
+                    Click this button to download the system configuration in JSON format.
+                    <br/>
+
+                    <table width="100%">
+                        <tr>
+                            <td width="25%">Backup Area</td>
+                            <td width="75%"><?php echo backup_gen_select('backuparea'); ?></td>
+                        </tr>
+                        <tr>
+                            <td width="25%"></td>
+                            <td width="75%">
+                                <input name="btnDownloadConfig" type="Submit" style="width:30%" class="buttons"
+                                       value="Download Configuration">
+                            </td>
+                        </tr>
+
+                    </table>
+                </fieldset>
+                <br/>
+                <fieldset>
+                    <legend>Restore Configuration</legend>
+                    Open a configuration JSON file and click the button below to restore the
+                    configuration.
+                    <br/>
+                    <table width="100%">
+
+                        <!--                        <tr>-->
+                        <!--                            <td width="35%"><b>Keep Existing Network Settings</b></td>-->
+                        <!--                            <td width="65%">-->
+                        <!--                                <input name="keepExitingNetwork"-->
+                        <!--                                       type="checkbox"-->
+                        <!--                                       checked="true">-->
+                        <!--                            </td>-->
+                        <!--                        <tr/>-->
+
+                        <tr>
+                            <td width="35%"><b>Keep Existing Master/Slave Settings</b></td>
+                            <td width="65%">
+                                <input name="keepMasterSlave"
+                                       type="checkbox"
+                                       checked="true">
+                            </td>
+                        <tr/>
+
+                        <tr>
+                            <td width="25%">Restore Area</td>
+                            <td width="75%">
+                                <?php echo backup_gen_select('restorearea'); ?></td>
+                        <tr/>
+
+                        <tr>
+                            <td width="25%"></td>
+                            <td width="75%">
+                                <input name="conffile" type="file" class="formbtn" id="conffile" size="50"
+                                       autocomplete="off"></td>
+                        <tr/>
+
+                        <tr>
+                            <td width="25%"></td>
+
+                            <td width="75%">
+                                <input name="btnRestoreConfig" type="Submit" style="width:30%" class="buttons"
+                                       value="Restore  Configuration">
+                            </td>
+                        </tr>
+                    </table>
+
+                </fieldset>
+            </fieldset>
+        </div>
+    </form>
+
+    <?php include 'common/footer.inc'; ?>
+</body>
+</html>

--- a/www/common.php
+++ b/www/common.php
@@ -292,6 +292,10 @@ echo "
 <input type='button' class='buttons' id='save$setting' onClick='save" . $setting . "();' value='Save'>\n";
 }
 
+/**
+ * Toggles NTP service state
+ * @param $state Boolean True to Enable, False to Disable
+ */
 function SetNTPState($state){
     WriteSettingToFile("NTP",$state);
 
@@ -314,6 +318,13 @@ function SetNTPState($state){
     }
 }
 
+/**
+ * Generates appropriate files and settings for exim4
+ * @param $emailguser String Gmail Username
+ * @param $emailgpass String Gmail Password
+ * @param $emailfromtext String Mail From address (eg. fpp01@example.com)
+ * @param $emailtoemail String Destination email address
+ */
 function SaveEmailConfig($emailguser, $emailgpass, $emailfromtext, $emailtoemail){
     global $exim4Directory;
 

--- a/www/config.php
+++ b/www/config.php
@@ -56,6 +56,7 @@ $scheduleFile      = $mediaDirectory . "/schedule";
 $bytesFile         = $mediaDirectory . "/bytesReceived";
 $remapFile         = $mediaDirectory . "/channelremap";
 $exim4Directory    = $mediaDirectory . "/exim4";
+$timezoneFile      = $mediaDirectory. "/timezone";
 $volume            = 0;
 $emailenable       = "0";
 $emailguser		   = "";

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -648,6 +648,18 @@ fieldset
 	background:#CCC;
 }
 
+#restoreSuccessFlag{
+    display: block;
+    background-color: forestgreen;
+    color: #FFFFFF;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    font-size: 18px;
+    font-weight: bold;
+    text-align: center;
+    width: 100%;
+}
+
 .bad
 {
 	font-weight: bold;

--- a/www/email.php
+++ b/www/email.php
@@ -30,28 +30,12 @@ if ( isset($_POST['emailtoemail']) && !empty($_POST['emailtoemail']) )
   $emailtoemail = $_POST['emailtoemail'];
   WriteSettingToFile("emailtoemail",$emailtoemail);
 }
-if ( ( isset($_POST['emailguser']) && !empty($_POST['emailguser']) ) && 
+if ( ( isset($_POST['emailguser']) && !empty($_POST['emailguser']) ) &&
    ( isset($_POST['emailgpass']) && !empty($_POST['emailgpass']) ) &&
    ( isset($_POST['emailfromtext']) && !empty($_POST['emailfromtext']) ) &&
    ( isset($_POST['emailtoemail']) && !empty($_POST['emailtoemail']) ))
 {
-
-    $fp = fopen($exim4Directory . '/passwd.client', 'w');
-    fwrite($fp, "# password file used when the local exim is authenticating to a remote host as a client.\n");
-    fwrite($fp, "#\n");
-    fwrite($fp, "*.google.com:" . $emailguser . ":" . $emailgpass . "\n");
-    fwrite($fp, "smtp.gmail.com:" . $emailguser . ":" . $emailgpass . "\n");
-    fclose($fp);
-	exec("sudo cp " . $exim4Directory . "/passwd.client /etc/exim4/");
-	exec("sudo update-exim4.conf");
-    exec ("sudo /etc/init.d/exim4 restart");
-	$cmd="sudo chfn -f \"" . $emailfromtext . "\" pi";
-	exec($cmd);
-    $fp = fopen($exim4Directory . '/aliases', 'w');
-	fwrite($fp, "mailer-daemon: postmaster\npostmaster: root\nnobody: root\nhostmaster: root\nusenet: root\nnews: root\nwebmaster: root\nwww: root\nftp: root\nabuse: root\nnoc: root\nsecurity: root\nroot: pi\n");
-	fwrite($fp, "pi: " . $emailtoemail . "\n");
-	fclose($fp);
-	exec("sudo cp " . $exim4Directory . "./aliases /etc/");
+    SaveEmailConfig($emailguser, $emailgpass, $emailfromtext, $emailtoemail);
 }
 
 ?>

--- a/www/menu.inc
+++ b/www/menu.inc
@@ -92,6 +92,7 @@ function list_plugin_entries($menu)
           <li><a href="multisync.php">MultiSync</a></li>
           <?php list_plugin_entries("status"); ?>
           <li><a href="settings.php">FPP Settings</a></li>
+          <li><a href="backup.php">FPP Backup</a></li>
           <li><a href="email.php">Email Settings</a></li>
           <li><a href="events.php">Events</a></li>
           <li><a href="effects.php">Effects</a></li>

--- a/www/settings.php
+++ b/www/settings.php
@@ -109,7 +109,7 @@ function ToggleLCDNow()
 {
 	var enabled = $('#PI_LCD_Enabled').is(":checked");
 	$.get("fppxml.php?command=setPiLCDenabled&enabled="
-		+ enabled).fail(function() { alert("Failed to change audio output!") });
+		+ enabled).fail(function() { alert("Failed to enable LCD!") });
 }
 
 </script>

--- a/www/timeconfig.php
+++ b/www/timeconfig.php
@@ -46,23 +46,11 @@ unset($output);
 
 if ( isset($_POST['ntp']) && !empty($_POST['ntp']) && $_POST['ntp'] == "disabled" && $ntp )
 {
-  error_log("Disabling NTP because it's enabled and we were told to disable it.");
-  exec($SUDO . " service ntp stop", $output, $return_val);
-  unset($output);
-  //TODO: check return
-  exec($SUDO . " update-rc.d ntp remove", $output, $return_val);
-  unset($output);
-  //TODO: check return
+    SetNTPState(0);
 }
 elseif ( isset($_POST['ntp']) && !empty($_POST['ntp']) && $_POST['ntp'] == "enabled" && !$ntp )
 {
-  error_log("Enabling NTP because it's disabled and we were told to enable it.");
-  exec($SUDO . " update-rc.d ntp defaults", $output, $return_val);
-  unset($output);
-  //TODO: check return
-  exec($SUDO . " service ntp start", $output, $return_val);
-  unset($output);
-  //TODO: check return
+    SetNTPState(1);
 }
 
 if ( isset($_POST['timezone']) && !empty($_POST['timezone']) && urldecode($_POST['timezone']) != $current_tz )


### PR DESCRIPTION
The current script doesn't work if you use the 'FPP 2.0 install script'
to build FPP install (I have a RPi 2), and this is because the LCD
settings path for self.PLAYLIST_DIRECTORY and self.SETTINGS_FILE is
hardcoded to '/home/pi/media'

I added a little check at init to use '/home/fpp/media' if it exists,
otherwise it will just use the default value of already set in the
script.
