### PR TITLE
Update fppLCD.py to use /home/fpp/media if available

### DIFF
--- a/scripts/lcd/fppLCD.py
+++ b/scripts/lcd/fppLCD.py
@@ -126,6 +126,11 @@ class fppLCD():
                           "Timeout         ")
 
   def Initialize(self):
+  
+    if os.path.exists("/home/fpp/media"):
+      self.PLAYLIST_DIRECTORY = "/home/fpp/media/playlists/";
+      self.SETTINGS_FILE = "/home/fpp/media/settings";
+  
     strColorIndex = self.readSetting("piLCD_BackColor")
     if strColorIndex.isdigit():
       self.BackgroundColor = int(strColorIndex);


### PR DESCRIPTION
The current script doesn't work if you use the 'FPP 2.0 install script' to build FPP install (I have a RPi 2), and this is because the LCD settings path for self.PLAYLIST_DIRECTORY and self.SETTINGS_FILE is hardcoded to '/home/pi/media'

I added a little check at init to use '/home/fpp/media' if it exists, otherwise it will just use the default  value of already set in the script for backwards compatibility.
