### PR TITLE
Update uploadfile.php to be Apache Proxy "friendly"

### DIFF
--- a/www/uploadfile.php
+++ b/www/uploadfile.php
@@ -8,13 +8,13 @@ require_once('config.php');
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title><? echo $pageTitle; ?></title>
 
-<link  href="/jquery/jQuery-Upload-File/css/uploadfile.min.css" rel="stylesheet">
+<link  href="jquery/jQuery-Upload-File/css/uploadfile.min.css" rel="stylesheet">
 
-<script src="/jquery/jQuery-Form-Plugin/js/jquery.form.js"></script>
-<script src="/jquery/jQuery-Upload-File/js/jquery.uploadfile.min.js"></script>
+<script src="jquery/jQuery-Form-Plugin/js/jquery.form.js"></script>
+<script src="jquery/jQuery-Upload-File/js/jquery.uploadfile.min.js"></script>
 
-<script type="text/javascript" src="/jquery/Spin.js/spin.js"></script>
-<script type="text/javascript" src="/jquery/Spin.js/jquery.spin.js"></script>
+<script type="text/javascript" src="jquery/Spin.js/spin.js"></script>
+<script type="text/javascript" src="jquery/Spin.js/jquery.spin.js"></script>
 
 <script>
     $(function() {
@@ -381,7 +381,7 @@ h2 {
 $(document).ready(function()
 {
 	$("#fileuploader").uploadFile({
-		url:"/jqupload.php",
+		url:"jqupload.php",
 		fileName:"myfile",
 		multiple: true,
 		autoSubmit: true,


### PR DESCRIPTION
The "/" at the beginning of the URLs were not relative paths, breaking things when in an a proxy configuration. ex: https://www.example.com/falcon/

Using a proxy configuration allows me to add SSL, ACLs, and authentication when accessing the UI remotely.

On the File Manager page, the Upload Files section would not show the "Select Files" button.

NOTE... this is my first "pull request" and am open to feedback if there is a better protocol.