### PR TITLE
70-persistent-net.rules not found throws sed error

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -35,7 +35,8 @@ SetupDefaultNetworkConfig () {
 
 	cp /etc/wpa_supplicant/wpa_supplicant.conf.default /etc/wpa_supplicant/wpa_supplicant.conf
 
-	sed -i '/ NAME="wlan/d' /etc/udev/rules.d/70-persistent-net.rules
+	persistent_net_rules="/etc/udev/rules.d/70-persistent-net.rules"
+	[ $persistent_net ] && sed -i '/ NAME="wlan/d' $persistent_net_rules
 
 	if [ ! -f "/etc/resolv.conf.default" ]
 	then


### PR DESCRIPTION
I updated the script to check if file exists prior to running sed against it. However, I am assuming this file should exist if it is being edited and is on a fresh FPP image.