### PR TITLE
Changed install script detection for OrangePi

### DIFF
--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -176,7 +176,7 @@ then
 elif [ ! -z "$(grep sun50iw1p1 /proc/cpuinfo)" ]
 then
 	FPPPLATFORM="Pine64"
-elif uname -a | grep -q -i orangepi
+elif [ ! -z "$(grep sun8i /proc/cpuinfo)" ]
 then
 	FPPPLATFORM="OrangePi"
 elif [ "x${OSID}" = "xdebian" ]


### PR DESCRIPTION
Based off cpuinfo. Should be good for H2, H3 and H8 processors. This covers all orange series except the PC 2 model which has an H5. Could add sun50i for that.