### PR TITLE
Fix BBB RTC not registering correctly issue - bbb-stretch-v1.x

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -911,11 +911,11 @@ setupBBBRTC () {
 			# BBB has onboard clock as rtc0 so we need to use rtc1
 			echo ds1307 0x68 > /sys/class/i2c-adapter/i2c-2/new_device
 			
-			# i2c busss have swapped around or even by design since the last image
-			# i2c-1 was where the RTC before, nothing can be found on i2c-1 now
+			# i2c buses have swapped around or even by design since the last image
+			# i2c-1 was where the RTC sat before, nothing can be found on i2c-1 now
 			# devices now show on i2c-2
 
-			##if result is anything but 0, then it filed. try the 1st i2c bus
+			##if result is anything but 0, then command failed. try the load RTC on 1st i2c bus
 			if [ $? -ne 0 ]
 			then
 				echo ds1307 0x68 > /sys/class/i2c-adapter/i2c-1/new_device

--- a/scripts/functions
+++ b/scripts/functions
@@ -909,8 +909,20 @@ setupBBBRTC () {
 		2)
 			# DS1307 chip
 			# BBB has onboard clock as rtc0 so we need to use rtc1
-			echo ds1307 0x68 > /sys/class/i2c-adapter/i2c-1/new_device
-			echo "FPP - Configuring RTC, Setting to DS1307/i2c-1"
+			echo ds1307 0x68 > /sys/class/i2c-adapter/i2c-2/new_device
+			
+			# i2c busss have swapped around or even by design since the last image
+			# i2c-1 was where the RTC before, nothing can be found on i2c-1 now
+			# devices now show on i2c-2
+
+			##if result is anything but 0, then it filed. try the 1st i2c bus
+			if [ $? -ne 0 ]
+			then
+				echo ds1307 0x68 > /sys/class/i2c-adapter/i2c-1/new_device
+				echo "FPP - Configuring RTC, Setting to DS1307/i2c-1"
+			else
+				echo "FPP - Configuring RTC, Setting to DS1307/i2c-2"
+			fi
 			;;
 		*)
 			# None

--- a/scripts/piRTC
+++ b/scripts/piRTC
@@ -23,6 +23,10 @@ else
 	fi
 fi
 
+#sleep and wait for things to settle after setting creating the i2c device
+#without this the system date isn't changed, presumably because the RTC isn't ready
+sleep 10
+
 if [[ $1 == "set" ]]
 then
   hwclock -w -f ${RTCDEVICE} &>/dev/null
@@ -32,4 +36,3 @@ else
 fi
 
 sleep 2
-


### PR DESCRIPTION
added a sleep delay to piRTC to let thing settle down before using hwclock

changed i2c buses for setupBBBRTC the method in functions.
Added crude if statement to check if result from previous command is non 0. tested by making it assign i2c-1 first, it fails and does i2c-2. Reversed the order to avoid false positives in the startup log

It seems that in the latest image, and for whatever reason the i2c bus
numbering has switched around. this could be by design or how things are
designed / processed during boot.
Made the script try to configure the i2c-2 bus first then try the i2c-1 bus

In the BBB 1.5 image I did have a RTC working without issue.. I did google issue about the i2c buses changing (1 to 2) found 2 examples but no explanation. I can only assume that this is down to the OS and how it registers/sets up the i2c interfaces