### PR TITLE
Allow Ethernet configurations without GW specified

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -114,7 +114,11 @@ SetupFPPNetworkConfigViaConnMann() {
         if [ "$PROTO" = "dhcp" ]; then
             echo "IPv4=dhcp"  >> $TMPFILE
         else
-            echo "IPv4=$ADDRESS/$NETMASK/$GATEWAY" >> $TMPFILE
+            if [ "x$GATEWAY" != "x" ]; then
+                echo "IPv4=$ADDRESS/$NETMASK/$GATEWAY" >> $TMPFILE
+            else
+                echo "IPv4=$ADDRESS/$NETMASK" >> $TMPFILE
+            fi
         fi
 
 


### PR DESCRIPTION
Allow Ethernet configurations without GW specified, if no GW is
specified with the old code then there is a trailing forward slash and
seems connman freaks out about it. Interface won't get configured.

Have tested going from DHCP. to static with GW and then to static without GW, and DHCP to static with no GW. Seems to work as intended now.