### PR TITLE
[Security] [UI] Implement basic authentication via PHP

### DIFF
--- a/www/about.php
+++ b/www/about.php
@@ -1,5 +1,6 @@
 <?php
 require_once('config.php');
+require_once('auth.php');
 
 $a = session_id();
 

--- a/www/advancedsettings.php
+++ b/www/advancedsettings.php
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-<?php require_once('common.php'); ?>
+<?php require_once('common.php');
+require_once('auth.php');
+?>
 <?php include 'common/menuHead.inc'; ?>
 <title><? echo $pageTitle; ?></title>
 </head>

--- a/www/auth.php
+++ b/www/auth.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once("config.php");
+
+$thisdir = dirname(__FILE__);
+$pw = file_exists("$mediaDirectory/uipasswd");
+$auth_success = FALSE;
+
+if($pw){
+	//auth is needed
+	if (isset($_SERVER['PHP_AUTH_USER'])) {
+		$hashstr = file_get_contents("$mediaDirectory/uipasswd");
+		if($hashstr === FALSE){
+			die("Password file exists but cannot be read!");
+		}
+		if($_SERVER['PHP_AUTH_USER'] == "admin" && password_verify($_SERVER['PHP_AUTH_PW'], $hashstr) === TRUE){
+			$auth_success = TRUE;
+		}
+	}
+	if($auth_success == FALSE){
+		header('WWW-Authenticate: Basic realm="FPP"');
+    		header('HTTP/1.0 401 Unauthorized');
+    		echo 'error: user not authenticated';
+    		exit;
+	}
+}
+?>

--- a/www/backup.php
+++ b/www/backup.php
@@ -1,5 +1,7 @@
 <?php $skipJSsettings = 1; ?>
-<?php require_once('common.php'); ?>
+<?php require_once('common.php'); 
+require_once('auth.php');
+?>
 <?php
 //TODO Backup/Restore of plugin settings
 //TODO Backup/Restore of WLAN interface settings (could be useful for cloning devices)

--- a/www/changelog.php
+++ b/www/changelog.php
@@ -1,5 +1,6 @@
 <?php
 require_once('config.php');
+require_once('auth.php');
 
 //ini_set('display_errors', 'On');
 error_reporting(E_ALL);

--- a/www/channeloutputs.php
+++ b/www/channeloutputs.php
@@ -2,6 +2,7 @@
 <head>
 <?php
 require_once("common.php");
+require_once('auth.php');
 require_once('universeentry.php');
 include 'common/menuHead.inc';
 ?>

--- a/www/channelremaps.php
+++ b/www/channelremaps.php
@@ -1,5 +1,6 @@
 <?php
 require_once("common.php");
+require_once('auth.php');
 
 ?>
 <html>

--- a/www/cliHelp.php
+++ b/www/cliHelp.php
@@ -2,6 +2,7 @@
 
 $skipJSsettings = 1;
 require_once("common.php");
+require_once('auth.php');
 
 DisableOutputBuffering();
 

--- a/www/credits.php
+++ b/www/credits.php
@@ -1,5 +1,6 @@
 <?php
 require_once('config.php');
+require_once('auth.php');
 
 $a = session_id();
 

--- a/www/cronjobs.php
+++ b/www/cronjobs.php
@@ -3,6 +3,7 @@
 <?php
 include 'common/menuHead.inc';
 require_once("config.php");
+require_once('auth.php');
 ?>
 <title><? echo $pageTitle; ?></title>
 <script>

--- a/www/developer.php
+++ b/www/developer.php
@@ -1,6 +1,7 @@
 <?php
 require_once('config.php');
 require_once('common.php');
+require_once('auth.php');
 
 $a = session_id();
 

--- a/www/docs.php
+++ b/www/docs.php
@@ -1,5 +1,6 @@
 <?php
 require_once('config.php');
+require_once('auth.php');
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/www/effects.php
+++ b/www/effects.php
@@ -4,6 +4,7 @@
 <?php
 include 'common/menuHead.inc';
 require_once('config.php');
+require_once('auth.php');
 ?>
 <script>
     $(function() {

--- a/www/email.php
+++ b/www/email.php
@@ -2,6 +2,7 @@
 <head>
 <?php
 require_once("config.php");
+require_once('auth.php');
 require_once("common.php");
 require_once('common/menuHead.inc');
 

--- a/www/events.php
+++ b/www/events.php
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<?php	include 'common.php'; ?>
+<?php	include('common.php');
+require_once('auth.php'); ?>
 <?php	include 'common/menuHead.inc'; ?>
 <script>
 		var TriggerEventSelected = "";

--- a/www/falcon.php
+++ b/www/falcon.php
@@ -1,5 +1,6 @@
 <?php
 require_once('config.php');
+require_once('auth.php');
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/www/fppjson.php
+++ b/www/fppjson.php
@@ -2,6 +2,7 @@
 
 $skipJSsettings = 1;
 require_once('common.php');
+require_once('auth.php');
 require_once('commandsocket.php');
 
 $a = session_id();

--- a/www/fppxml.php
+++ b/www/fppxml.php
@@ -2,6 +2,7 @@
 
 $skipJSsettings = 1;
 require_once('common.php');
+require_once('auth.php');
 
 require_once('playlistentry.php');
 require_once('universeentry.php');

--- a/www/gpio.php
+++ b/www/gpio.php
@@ -1,5 +1,6 @@
 <?php
 require_once("common.php");
+require_once('auth.php');
 
 ?>
 <html>

--- a/www/help.php
+++ b/www/help.php
@@ -1,5 +1,6 @@
 <?php
 require_once('config.php');
+require_once('auth.php');
 require_once('common.php');
 
 $helpPages = array(

--- a/www/index.php
+++ b/www/index.php
@@ -1,3 +1,6 @@
+<?php 
+require_once('auth.php');
+?>
 <!DOCTYPE html>
 <html>
 <head>

--- a/www/jqupload.php
+++ b/www/jqupload.php
@@ -18,6 +18,7 @@
 //////////////////////////////////////////////////////////////////////////////
 $skipJSsettings = 1; // need this so config doesn't print out JavaScrip arrays
 require_once('config.php');
+require_once('auth.php');
 
 $output_dir = $uploadDirectory . "/";
 

--- a/www/manualUpdate.php
+++ b/www/manualUpdate.php
@@ -1,6 +1,7 @@
 <?php
 
 $skipJSsettings = 1;
+require_once('auth.php');
 require_once("common.php");
 
 DisableOutputBuffering();

--- a/www/multisync.php
+++ b/www/multisync.php
@@ -1,3 +1,6 @@
+<?php
+require_once('auth.php');
+?>
 <html>
 <head>
 <?php

--- a/www/networkconfig.php
+++ b/www/networkconfig.php
@@ -1,3 +1,6 @@
+<?php
+require_once('auth.php');
+?>
 <!DOCTYPE html>
 <html>
 <head>

--- a/www/ping.php
+++ b/www/ping.php
@@ -1,6 +1,7 @@
 <?php
 
 $skipJSsettings = 1;
+require_once('auth.php');
 require_once("common.php");
 
 DisableOutputBuffering();

--- a/www/pixelnetdmx.php
+++ b/www/pixelnetdmx.php
@@ -1,4 +1,5 @@
 <?php
+require_once('auth.php');
 require_once('universeentry.php');
 $a = session_id();
 

--- a/www/pixeloverlaymodels.php
+++ b/www/pixeloverlaymodels.php
@@ -1,4 +1,5 @@
 <?php
+require_once('auth.php');
 require_once("common.php");
 
 ?>

--- a/www/playlists.php
+++ b/www/playlists.php
@@ -1,4 +1,5 @@
 <?php
+require_once('auth.php');
 require_once('config.php');
 require_once('playlistentry.php');
 //require_once('pi_functions.php');

--- a/www/plugin.php
+++ b/www/plugin.php
@@ -2,6 +2,7 @@
 
 if ( !isset($_GET['nopage']) ):
 
+require_once('auth.php');
 require_once("config.php");
 require_once("common.php");
 

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -1,3 +1,6 @@
+<?php
+require_once('auth.php');
+?>
 <!DOCTYPE html>
 <html>
 <head>

--- a/www/runEventScript.php
+++ b/www/runEventScript.php
@@ -1,6 +1,7 @@
 <?php
 
 $skipJSsettings = 1;
+require_once('auth.php');
 require_once("common.php");
 
 DisableOutputBuffering();

--- a/www/scheduler.php
+++ b/www/scheduler.php
@@ -1,4 +1,5 @@
 <?php
+require_once('auth.php');
 $a = session_id();
 
 if(empty($a))

--- a/www/scriptbrowser.php
+++ b/www/scriptbrowser.php
@@ -1,3 +1,6 @@
+<?php
+require_once('auth.php');
+?>
 <html>
 <head>
 <?php

--- a/www/settings.php
+++ b/www/settings.php
@@ -1,3 +1,6 @@
+<?php
+require_once('auth.php');
+?>
 <!DOCTYPE html>
 <html>
 <head>

--- a/www/syncRemotes.php
+++ b/www/syncRemotes.php
@@ -1,6 +1,7 @@
 <?php
 
 $skipJSsettings = 1;
+require_once('auth.php');
 require_once("common.php");
 
 DisableOutputBuffering();

--- a/www/testing.php
+++ b/www/testing.php
@@ -1,4 +1,5 @@
 <?php
+require_once('auth.php');
 require_once('config.php');
 require_once('common.php');
 

--- a/www/timeconfig.php
+++ b/www/timeconfig.php
@@ -1,4 +1,5 @@
 <?php
+require_once('auth.php');
 require_once('config.php');
 require_once('common.php');
 

--- a/www/troubleshooting.php
+++ b/www/troubleshooting.php
@@ -1,4 +1,5 @@
 <?php
+require_once('auth.php');
 require_once('troubleshootingCommands.php');
 ?>
 

--- a/www/troubleshootingText.php
+++ b/www/troubleshootingText.php
@@ -1,6 +1,7 @@
 <?php
 
 $skipJSsettings = 1;
+require_once('auth.php');
 
 require_once('troubleshootingCommands.php');
 

--- a/www/uipassword.php
+++ b/www/uipassword.php
@@ -1,25 +1,21 @@
 <?php
+require_once('auth.php');
 
 require_once("config.php");
 
 $thisdir = dirname(__FILE__);
 
-// No other checking here, we're assuming that since they're able to POST apache has
-// already taken care of validating a user.
 if ( !empty($_POST) && $_POST["password"] == "disabled" )
 {
-  shell_exec($SUDO . " rm -f $mediaDirectory/htaccess $thisdir/.htpasswd $thisdir/.htaccess");
+  unlink("$mediaDirectory/uipasswd");
 }
 
 if ( isset($_POST['password1']) && isset($_POST['password2']))
 {
   if (($_POST['password1'] != "") && ($_POST['password1'] == $_POST['password2']))
   {
-    // true - setup .htaccess & save it
-    file_put_contents("/var/tmp/htaccess", "AuthUserFile $thisdir/.htpasswd\nAuthType Basic\nAuthName admin\nRequire valid-user\n");
-    shell_exec($SUDO . " mv /var/tmp/htaccess $mediaDirectory/htaccess");
-    shell_exec($SUDO . " ln -snf $mediaDirectory/htaccess $thisdir/.htaccess");
-    shell_exec($SUDO . " htpasswd -cbd $thisdir/.htpasswd admin " . $_POST['password1']);
+    // true - hash the password & save it
+    file_put_contents("$mediaDirectory/uipasswd", password_hash($_POST['password1'], PASSWORD_DEFAULT));
   }
 }
 
@@ -39,7 +35,7 @@ function hide_if_equal($value1, $value2)
   }
 }
 
-$pw = file_exists("$mediaDirectory/htaccess");
+$pw = file_exists("$mediaDirectory/uipasswd");
 
 ?>
 

--- a/www/universes.php
+++ b/www/universes.php
@@ -1,4 +1,5 @@
 <?php
+require_once('auth.php');
 require_once('universeentry.php');
 $a = session_id();
 

--- a/www/uploadfile.php
+++ b/www/uploadfile.php
@@ -1,4 +1,5 @@
 <?php
+require_once('auth.php');
 require_once('config.php');
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">


### PR DESCRIPTION
UI authentication does not work since Apache to nginx migration. This changeset implements HTTP Basic authentication within the PHP code such that there is no longer any dependence on the HTTP server software itself for authentication. Furthermore, this could easily be modified to allow more granular access control, as well as to make certain pages always publicly accessible if desired.