### PR TITLE
Multisync Page hang / Stops responding fix

### DIFF
--- a/www/fppjson.php
+++ b/www/fppjson.php
@@ -78,7 +78,10 @@ return;
 /////////////////////////////////////////////////////////////////////////////
 
 function returnJSON($arr) {
-	header( "Content-Type: application/json");
+	//preemptively close the session
+    session_write_close();
+
+    header( "Content-Type: application/json");
 
 	echo json_encode($arr);
 
@@ -240,13 +243,60 @@ function GetFPPStatusJson()
 {
 	global $args;
 
-	if (isset($args['ip']))
+	//close the session before we start, this removes the session lock and lets other scripts run
+    session_write_close();
+
+    //Default json to be returned
+    $default_return_json = array(
+        'fppd' => 'unknown',
+        'status' => -1,
+        'status_name' => 'unknown',
+        'current_playlist' =>
+            [
+                'playlist' => '',
+                'type' => '',
+                'index' => '0',
+                'count' => '0'
+            ],
+        'current_sequence' => '',
+        'current_song' => '',
+        'seconds_played' => '0',
+        'seconds_remaining' => '0',
+        'time_elapsed' => '00:00',
+        'time_remaining' => '00:00'
+    );
+
+    //if the ip= argument supplied
+    if (isset($args['ip']))
 	{
 		header( "Content-Type: application/json");
 
-		echo file_get_contents("http://" . $args['ip'] . "/fppjson.php?command=getFPPstatus");
+		//validate IP address is a valid IPv4 address - possibly overkill but have seen IPv6 addresses polled
+        if (filter_var($args['ip'], FILTER_VALIDATE_IP)) {
+        	//Make the request
+            $request_content = @file_get_contents("http://" . $args['ip'] . "/fppjson.php?command=getFPPstatus");
+            //check we have valid data
+            if ($request_content === FALSE) {
+            	//check the response header
+				//check for a 401 - Unauthorized response
+				if(stristr($http_response_header[0],'401')){
+					//set a reason so we can inform the user
+                    $default_return_json['reason'] = "Cannot Access - Web GUI Password Set";
+				}
+				error_log("GetFPPStatusJson failed for IP: " . $args['ip'] . " " . json_encode($http_response_header));
+                //error return default response
+				echo json_encode($default_return_json);
+            } else {
+            	//return the actual FPP Status of the device
+                echo $request_content;
+            }
+        } else {
+            error_log("GetFPPStatusJson failed for IP: " . $args['ip'] . " ");
+            //IPv6 (in rare case it happens) return default response
+            echo json_encode($default_return_json);
+        }
 
-		exit(0);
+        exit(0);
 	}
 	else
 	{
@@ -255,29 +305,16 @@ function GetFPPStatusJson()
 		if($status == false || $status == 'false') {
      	
 			$status=exec("if ps cax | grep -q git_pull; then echo \"updating\"; else echo \"false\"; fi");
-     
-			returnJSON([
-					'fppd' => 'Not Running',
-					'status' => -1,
-					'status_name' => $status == 'updating' ? $status : 'stopped',
-					'current_playlist' => [
-						'playlist' => '',
-						'type'     => '',
-						'index'    => '0',
-						'count'    => '0'
-					],
-					'current_sequence'  => '',
-					'current_song'      => '',
-					'seconds_played'    => '0',
-					'seconds_remaining' => '0',
-					'time_elapsed'      => '00:00',
-					'time_remaining'    => '00:00',
-				]);
+
+            $default_return_json['fppd'] = "Not Running";
+            $default_return_json['status_name'] = $status == 'updating' ? $status : 'stopped';
+
+            returnJSON($default_return_json);
 		}
 
 		$data = parseStatus($status);
 
-		returnJson($data);
+        returnJSON($data);
 	}
 }
 

--- a/www/multisync.php
+++ b/www/multisync.php
@@ -79,6 +79,15 @@ include 'common/menuHead.inc';
 			{
 				status = 'Stopped';
 			}
+            else if (data.status_name == 'unknown')
+            {
+                status = '-';
+                if(typeof (data.reason) !== 'undefined'){
+                    DialogError("Get FPP System Status", "Get Status Failed for " + ip + "\n " + data.reason);
+                }else{
+                    DialogError("Get FPP System Status", "Get Status Failed for " + ip);
+                }
+            }
 			else if (data.status_name == 'idle')
 			{
 				if (data.mode_name == 'remote')
@@ -183,7 +192,7 @@ include 'common/menuHead.inc';
 				"<td>" + data[i].IP + "</td>" +
 				"<td>" + data[i].Platform + "</td>" +
 				"<td>" + fppMode + "</td>" +
-				"<td id='" + rowID + "_status'></td>" +
+				"<td id='" + rowID + "_status' align='center'></td>" +
 				"<td id='" + rowID + "_elapsed'></td>" +
 				"<td id='" + rowID + "_files'></td>" +
 				"</tr>";


### PR DESCRIPTION
Issue is to do with PHP sessions and session locking. nginx runs scripts super quick and we end up with read locks on the PHP session. This is worse when you have a lot of FPP devices that need polling, we end up with 6+ get getFPPStatus requests all firing off at once

Fix is to close the session before we start any FPPStatus work (we don't need it anyway) and at the beginning of returnJSON.
Closing the session in getFPPStatus fixes the issue, attempting to mitigate edge cases with closing in returnJSON also.

Added in minor handling of errors with file_get_contents
Added reason for a failed read when the remote device has a WebGUI password via a 'unknown' status
![image](https://user-images.githubusercontent.com/799998/37341162-2ab10804-270c-11e8-8d10-7035ce1fdc17.png)

Will backport this into v1.x as it was happening there, rarely but it did happen - also session related under apache

closes #356 
related in part #283 