### PR TITLE
[Scripts] Enhancement to upgrade_config

### DIFF
--- a/scripts/upgrade_config
+++ b/scripts/upgrade_config
@@ -34,8 +34,16 @@ do
 		then
 			echo "Upgrading config to version ${VERSION}"
 			(cd ${UPGRADEDIR}/${VERSION} && ./upgrade.sh)
-			CFGVERSION=${VERSION}
-			echo ${VERSION} > ${CFGVERSIONFILE}
+			if [ $? -eq 0 ]
+			then
+                CFGVERSION=${VERSION}
+                echo ${VERSION} > ${CFGVERSIONFILE}
+                echo ">>SUCCESS upgraded to config version ${VERSION}"
+			else
+                echo ">>FAILED to update to config version ${VERSION}"
+                echo "!!Config Version not up to date!!"
+                exit 0
+			fi
 		else
 			echo "Up to date at config version ${CFGVERSION}"
 			exit 0


### PR DESCRIPTION
In the event of say a permissions problem or syntax error in the upgrade script, that script fails but config_version is bumped and you can't run the upgrade again.

I've made a tiny change to the upgrade script, just checks the return code of the previous command and acts appropriately.

![image](https://user-images.githubusercontent.com/799998/38364758-321f6838-391d-11e8-94d3-abd9ae7029e3.png)

![image](https://user-images.githubusercontent.com/799998/38364742-2cdc9f62-391d-11e8-9cc3-2ccec591e0d1.png)

closes #365 