### PR TITLE
[Playlists] Fix playlist delete function

### DIFF
--- a/www/fppxml.php
+++ b/www/fppxml.php
@@ -2109,8 +2109,25 @@ function DeletePlaylist()
 	$name = $_GET['name'];
 	check($name, "name", __FUNCTION__);
 
-	unlink($playlistDirectory . '/' . $name);
-	EchoStatusXML('Success');
+    //Check if the file exists, old playlists don't have extensions
+    $playlist_exists = file_exists($playlistDirectory . '/' . $name);
+
+    if($playlist_exists){
+        //then just delete the file
+        $delete_status = unlink($playlistDirectory . '/' . $name);
+    }	else{
+        //if it doesn't exist, then add .json to the filename
+        //All Playlists in FPP v2 are json files
+        $name = $name . '.json';
+        //
+        $delete_status = unlink($playlistDirectory . '/' . $name);
+    }
+
+    if($delete_status == true){
+        EchoStatusXML('Success');
+    }else{
+        EchoStatusXML('Failure');
+    }
 }
 
 function DeleteEntry()

--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -593,8 +593,15 @@ function DeletePlaylist() {
 			xmlhttp.onreadystatechange = function () {
 				if (xmlhttp.readyState == 4 && xmlhttp.status==200) 
 				{
-					var xmlDoc=xmlhttp.responseXML; 
-          PopulatePlaylists("playList");
+					var xmlDoc=xmlhttp.responseXML;
+                    status_xml = xmlDoc.getElementsByTagName("Status")[0];
+
+                    if (status_xml === "Failure" || status_xml !== "Success"){
+                        //fail
+                        DialogError("Failed to delete Playlist","Failed to delete Playlist '" + name.value + "'.")
+					}
+
+                    PopulatePlaylists("playList");
 					var firstPlaylist = document.getElementById("playlist0");
 					if ( firstPlaylist )
 						PopulatePlayListEntries(firstPlaylist.innerHTML,true);


### PR DESCRIPTION
Added a check to see if file exists first, if it does it's likely the
user is deleting a older v1 playlist (CSV without a extension).

If the file doesn't exist, append .json onto the filename we're supplied
and try to delete. All v2 playlists are json files with the approriate
extension.
Also added ability to return failure XML status for playlist deletes.

Added a popup dialog when playlist deletes fail