### PR TITLE
Fix 'error deleting playlist' dialogue

### DIFF
--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -594,7 +594,7 @@ function DeletePlaylist() {
 				if (xmlhttp.readyState == 4 && xmlhttp.status==200) 
 				{
 					var xmlDoc=xmlhttp.responseXML;
-                    status_xml = xmlDoc.getElementsByTagName("Status")[0];
+                    status_xml = xmlDoc.getElementsByTagName("Status")[0].textContent;
 
                     if (status_xml === "Failure" || status_xml !== "Success"){
                         //fail


### PR DESCRIPTION
Fix 'error deleting playlist' dialogue popping up even when playlists are deleted.