### PR TITLE
 Add error_log output for fppjson - SaveScript

### DIFF
--- a/www/fppjson.php
+++ b/www/fppjson.php
@@ -1609,7 +1609,9 @@ function SaveScript()
 
 		if (file_exists($filename))
 		{
-			if (@file_put_contents($filename, $content))
+            $script_writable = is_writable($filename);
+            $script_save_result = @file_put_contents($filename, $content);
+			if ($script_save_result !== FALSE)
 			{
 				$result['saveStatus'] = "OK";
 				$result['scriptName'] = $data['scriptName'];
@@ -1618,12 +1620,15 @@ function SaveScript()
 			else
 			{
 				$result['saveStatus'] = "Error updating file";
-			}
+                error_log("SaveScript: Error updating file - " . $data['scriptName'] . " ($filename) " . " -> Error: " . $script_save_result);
+                error_log("SaveScript: Error updating file - " . $data['scriptName'] . " ($filename) " . " -> isWritable: " . $script_writable);
+            }
 		}
 		else
 		{
 			$result['saveStatus'] = "Error, file does not exist";
-		}
+            error_log("SaveScript: Error, file does not exist - " . $data['scriptName'] . " -> " . $filename);
+        }
 	}
 	else
 	{

--- a/www/fppjson.php
+++ b/www/fppjson.php
@@ -1610,8 +1610,12 @@ function SaveScript()
 		if (file_exists($filename))
 		{
             $script_writable = is_writable($filename);
+            $script_directory_writable = is_writable($settings['scriptDirectory']);
+
+            //error output is silenced by @, function returns false on failure, it doesn't return true
             $script_save_result = @file_put_contents($filename, $content);
-			if ($script_save_result !== FALSE)
+            //check result is not a error
+			if ($script_save_result !== false)
 			{
 				$result['saveStatus'] = "OK";
 				$result['scriptName'] = $data['scriptName'];
@@ -1620,8 +1624,9 @@ function SaveScript()
 			else
 			{
 				$result['saveStatus'] = "Error updating file";
-                error_log("SaveScript: Error updating file - " . $data['scriptName'] . " ($filename) " . " -> Error: " . $script_save_result);
+                error_log("SaveScript: Error updating file - " . $data['scriptName'] . " ($filename) ");
                 error_log("SaveScript: Error updating file - " . $data['scriptName'] . " ($filename) " . " -> isWritable: " . $script_writable);
+                error_log("SaveScript: Error updating file - " . $data['scriptName'] . " ($filename) " . " -> Scripts directory is writable: " . $script_directory_writable);
             }
 		}
 		else

--- a/www/fppjson.php
+++ b/www/fppjson.php
@@ -1609,9 +1609,6 @@ function SaveScript()
 
 		if (file_exists($filename))
 		{
-            $script_writable = is_writable($filename);
-            $script_directory_writable = is_writable($settings['scriptDirectory']);
-
             //error output is silenced by @, function returns false on failure, it doesn't return true
             $script_save_result = @file_put_contents($filename, $content);
             //check result is not a error
@@ -1623,6 +1620,9 @@ function SaveScript()
 			}
 			else
 			{
+                $script_writable = is_writable($filename);
+                $script_directory_writable = is_writable($settings['scriptDirectory']);
+
 				$result['saveStatus'] = "Error updating file";
                 error_log("SaveScript: Error updating file - " . $data['scriptName'] . " ($filename) ");
                 error_log("SaveScript: Error updating file - " . $data['scriptName'] . " ($filename) " . " -> isWritable: " . $script_writable);


### PR DESCRIPTION
errors from file_put_contents are suppressed.
Made some small changes to try get these errors out into log files, may be useful in debugging issues.
Made slight change to the 'if' logic that was checking the result of file_put_contents, function doesn't return true but number of bytes written, false on failure.