### PR TITLE
Fix owner on installed scripts

### DIFF
--- a/scripts/installScript
+++ b/scripts/installScript
@@ -15,6 +15,10 @@ wget -q -O ${SCRIPT} https://raw.githubusercontent.com/FalconChristmas/fpp-scrip
 # Grab out any Install Actions defined in the script and execute them
 grep "^# InstallAction:" ${SCRIPT} | sed -e "s/.*InstallAction: //" > /var/tmp/installactions.sh
 
+# Make fpp owner of the script (initially created with root as owner),
+# fixes after reboot, change owner so user can edit file straight away
+chown fpp:fpp ${SCRIPT}
+
 if [ -s /var/tmp/installactions.sh ]
 then
 	/bin/bash /var/tmp/installactions.sh


### PR DESCRIPTION
Fix owner on installed script.

When scripts are installed the owner is root, users can't edit the file
via the GUI, upon reboot the owner is changed to fpp and everything is
fine.
Small change to fix owner so user can edit file straight away.