### PR TITLE
Removed hard coded MQTT port and added support for CA File

### DIFF
--- a/src/fppd.c
+++ b/src/fppd.c
@@ -472,7 +472,7 @@ int main(int argc, char *argv[])
 	{
 		mqtt = new MosquittoClient(getSetting("MQTTHost"), getSettingInt("MQTTPort"), getSetting("MQTTPrefix"));
 
-		if (!mqtt || !mqtt->Init(getSetting("MQTTUsername"), getSetting("MQTTPassword")))
+		if (!mqtt || !mqtt->Init(getSetting("MQTTUsername"), getSetting("MQTTPassword"), getSetting("MQTTCaFile")))
 			exit(EXIT_FAILURE);
 
 		mqtt->Publish("version", getFPPVersion());

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -36,7 +36,7 @@ class MosquittoClient {
   	MosquittoClient(const std::string &host, const int port, const std::string &topicPrefix);
 	~MosquittoClient();
 
-	int  Init(const std::string &username, const std::string &password);
+	int  Init(const std::string &username, const std::string &password, const std::string &ca_file);
 
 	int  PublishRaw(const std::string &topic, const std::string &msg);
 	int  Publish(const std::string &subTopic, const std::string &msg);

--- a/www/advancedsettings.php
+++ b/www/advancedsettings.php
@@ -233,8 +233,12 @@ If
                     <td >MQTT Password:</td>
                     <td ><? PrintSettingPasswordSaved("MQTTPassword", 1, 0, 32, 32, "", ""); ?></td>
                 </tr>
+                <tr>
+                    <td >CA File (Optional):</td>
+                    <td ><? PrintSettingTextSaved("MQTTCaFile", 1, 0, 64, 32, "", ""); ?></td>
 	    </table>
-            MQTT events will be published to "$prefix/falcon/player/$hostname/" with playlist events being in the "playlist" subtopic. <br/>
+	    MQTT events will be published to "$prefix/falcon/player/$hostname/" with playlist events being in the "playlist" subtopic. <br/>
+            CA file is the full path to the signer certificate.  Only needed if using mqtts server that is self signed.<br/><br/>
 FPP will respond to certain events:
 <div class="fppTableWrapper">
 <table width = "100%" border="0" cellpadding="1" cellspacing="1">


### PR DESCRIPTION
That patch
1) Fixes a bug in MosquittoClient constructor that caused MQTT port to always be 1883 regardless of settings.

2) Adds optional support to include a certificate authority file. This is useful when using mqtts to a server with a self signed certificate and you want to verify it. 