### PR TITLE
Issue 499: Fixes special character in Universe name

### DIFF
--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -1393,7 +1393,7 @@ function RemovePlaylistEntry()	{
                 postData.channelOutputs.push(output);
             }
             var fileName = input ? 'universeInputs' : 'universeOutputs';
-            var postDataString = 'command=setChannelOutputs&file='+ fileName +'&data={' + JSON.stringify(postData) + '}';
+            var postDataString = 'command=setChannelOutputs&file='+ fileName +'&data={' + encodeURIComponent(JSON.stringify(postData)) + '}';
             
             $.post("fppjson.php", postDataString).done(function(data) {
                                                        $.jGrowl("E1.31 Universes Saved");


### PR DESCRIPTION
Fixes issue #499 on the fpp GUI by property encoding the JSON before passing as a URI parameter. 

I don't have an experience with Vixon, so I'm unclear if that is a Vixon problem or a FPP problem. 