### PR TITLE
ISSUE506: Don't delete PlayListEntries on call to Idle()

### DIFF
--- a/src/playlist/Playlist.cpp
+++ b/src/playlist/Playlist.cpp
@@ -765,7 +765,8 @@ void Playlist::SetIdle(void)
 	m_sectionPosition = 0;
 	m_repeat = 0;
 
-	Cleanup();
+	// Remoted per issue #506
+	//Cleanup();
 
 	if (mqtt)
 	{


### PR DESCRIPTION
I did some further testing of #506 and don't think Idle() should call Cleanup().   Removing caused NextItem() and PreviousItem() to work as expected.  I didn't find any other problems when testing via GUI or MQTT.