### PR TITLE
Fix for #512 : Channel output - DMX-Open Do not send the number of dx channel defined in the UI

### DIFF
--- a/src/channeloutput/USBDMX.cpp
+++ b/src/channeloutput/USBDMX.cpp
@@ -177,7 +177,7 @@ int USBDMXOutput::RawSendDataOpen(unsigned char *channelData)
 	// Then need to sleep a minimum of 8us
 	usleep(20);
 
-	write(m_fd, m_outputData, 513);
+	write(m_fd, m_outputData, m_channelCount+1);
 
 	return m_channelCount;
 }


### PR DESCRIPTION
Here is a proposed fix for the Issue #512 
