### PR TITLE
Add note on LED Panel Layout

### DIFF
--- a/www/co-ledPanels.php
+++ b/www/co-ledPanels.php
@@ -843,7 +843,8 @@ if ($settings['Platform'] == "Raspberry Pi") {
                                                                   
                     <br>
               <b>Notes and hints:</b>
-              <ul><li>When wiring panels, divide the panels across as many outputs as possible.  Shorter chains on more outputs will have higher refresh than longer chains on fewer outputs.</li>
+              <ul><li>LED Panel Layout orientation is as if viewed from the front of the panels.</li>
+	      <li>When wiring panels, divide the panels across as many outputs as possible.  Shorter chains on more outputs will have higher refresh than longer chains on fewer outputs.</li>
               <li>If not using all outputs, use all the outputs from 1 up to what is needed.   Data is always sent on outputs up to the highest configured, even if no panels are attached.</li>
   <?
   if ($settings['Platform'] == "Raspberry Pi") {


### PR DESCRIPTION
Simple note to advise users that the orientation for LED Panel Layout is as viewed from the front. Common error for many users.