### PR TITLE
Added feature to periodically publish FPP status via MQTT

### DIFF
--- a/docs/MQTT.txt
+++ b/docs/MQTT.txt
@@ -26,6 +26,55 @@ FPP will published the following sub_topics (using the full topic format) if MQT
 */playlist/media/title - Title of the audio / video media being displayed
 */playlist/media/status - filename of the current audio/movie
 */playlist/media/artist - The artist listing in the audio / video file being played
+*/playlist_details - If the MQTT Publish Frequence option (Advanced settings) is > 0 then a JSON file is published based on the duration (seconds) specified. 
+
+
+Message Example for playlist_details
+---------------------------------------------
+Note: Currently FPP only allows one active Playlist and for each Playlist, one active "item".  However,
+this will be increased in the future.  Thus activePlaylist and currentItems return list of entries. 
+The sample currentItems below shows 3 records (one for the 3 most common types) but until concurrent
+entries in a Playlist are allowed, only one will be displayed in real life.
+
+{  
+   "status" : "playing",    // playing or idle
+   "activePlaylist" : [  
+      {  
+         "playlistName" : "Name of current playlist",
+         "repeat" : 1,     // 0 if playist is not repating, 1 if repeating
+         "currentItems" : [
+            {
+               "type": "both",
+               "sequenceName" : "Name of current sequence file playing.",
+               "mediaTitle" : "Title of the audio / video media being displayed",
+               "mediaName" : "filename of the current audio/movie",
+               "mediaArtist" : "The artist listing in the audio / video file being played",
+               "secondsRemaining" : 33,
+               "secondsTotal" : 54,
+               "secondsElapsed" : 21
+            },
+            {
+               "type": "sequence",
+               "sequenceName" : "Name of current sequence file playing.",
+               "secondsRemaining" : 33,
+               "secondsTotal" : 54,
+               "secondsElapsed" : 21
+            },
+            {
+               "type": "media",
+               "mediaTitle" : "Title of the audio / video media being displayed",
+               "mediaName" : "filename of the current audio/movie",
+               "mediaArtist" : "The artist listing in the audio / video file being played",
+               "secondsRemaining" : 33,
+               "secondsTotal" : 54,
+               "secondsElapsed" : 21
+            }
+         ]       
+      }
+   ]
+}
+
+
 
 FPP Subscribed subtopics
 ---------------------------------------------

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -31,6 +31,8 @@
 
 #include "mosquitto.h"
 
+void * RunMqttPublishThread(void *data);
+
 class MosquittoClient {
   public:
   	MosquittoClient(const std::string &host, const int port, const std::string &topicPrefix);
@@ -45,6 +47,8 @@ class MosquittoClient {
 	void LogCallback(void *userdata, int level, const char *str);
 	void MessageCallback(void *obj, const struct mosquitto_message *message);
 
+	void PublishStatus(); 
+
   private:
 	std::string m_host;
 	int         m_port;
@@ -55,6 +59,7 @@ class MosquittoClient {
 
 	struct mosquitto *m_mosq;
 	pthread_mutex_t   m_mosqLock;
+	pthread_t         m_mqtt_publish_t;
 
 	// Topics we want to take action on
 	std::string m_topicPlaylist;

--- a/src/playlist/Playlist.cpp
+++ b/src/playlist/Playlist.cpp
@@ -1045,6 +1045,30 @@ Json::Value Playlist::GetCurrentEntry(void)
 	return result;
 }
 
+Json::Value Playlist::GetMqttStatusJSON(void){
+
+	Json::Value result;
+	result["status"] = m_currentState; // Works because single playlist
+	Json::Value playlistArray =  Json::Value(Json::arrayValue);
+
+	if (m_currentState != "idle") {
+		Json::Value entryArray =  Json::Value(Json::arrayValue);
+		Json::Value playlist;
+		// Only one entry right now.
+		Json::Value playlistEntry = m_currentSection->at(m_sectionPosition)->GetMqttStatus();
+		entryArray.append(playlistEntry);
+
+		playlist["name"] = m_name;
+		playlist["repeat"] = m_repeat;
+		playlist["currentItems"] = entryArray;
+		playlistArray.append(playlist); 
+
+	}
+
+	result["activePlaylists"] = playlistArray;
+	return result;
+}
+
 /*
  *
  */

--- a/src/playlist/Playlist.h
+++ b/src/playlist/Playlist.h
@@ -134,6 +134,7 @@ class Playlist {
 
 	int                FileHasBeenModified(void);
 	std::string        ReplaceMatches(std::string in);
+	Json::Value        GetMqttStatusJSON(); // Returns Status as JSON
 
   private:
 	int                ReloadPlaylist(void);

--- a/src/playlist/PlaylistEntryBase.cpp
+++ b/src/playlist/PlaylistEntryBase.cpp
@@ -211,6 +211,15 @@ void PlaylistEntryBase::Dump(void)
 /*
  *
  */
+Json::Value PlaylistEntryBase::GetMqttStatus(void)
+{
+	Json::Value result;
+	result["type"]       = m_type;
+	result["playOnce"]   = m_playOnce;
+
+	return result;
+}
+
 Json::Value PlaylistEntryBase::GetConfig(void)
 {
 	Json::Value result = m_config;

--- a/src/playlist/PlaylistEntryBase.h
+++ b/src/playlist/PlaylistEntryBase.h
@@ -54,6 +54,8 @@ class PlaylistEntryBase {
 
 	virtual Json::Value GetConfig(void);
 
+	virtual Json::Value GetMqttStatus(void);
+
 	virtual std::string ReplaceMatches(std::string in);
 
 	int          GetPlaylistEntryID(void) { return m_playlistEntryID; }

--- a/src/playlist/PlaylistEntryBoth.cpp
+++ b/src/playlist/PlaylistEntryBoth.cpp
@@ -25,6 +25,10 @@
 
 #include "log.h"
 #include "PlaylistEntryBoth.h"
+#include "mediadetails.h"
+#include "Sequence.h"
+
+extern MediaDetails	 mediaDetails;
 
 PlaylistEntryBoth::PlaylistEntryBoth(PlaylistEntryBase *parent)
   : PlaylistEntryBase(parent),
@@ -175,3 +179,26 @@ Json::Value PlaylistEntryBoth::GetConfig(void)
 	return result;
 }
 
+Json::Value PlaylistEntryBoth::GetMqttStatus(void)
+{
+	Json::Value result = PlaylistEntryBase::GetMqttStatus();
+    	if (m_mediaEntry) {
+        	result["secondsRemaining"] = m_mediaEntry->m_secondsRemaining;
+        	result["secondsTotal"] = m_mediaEntry->m_secondsTotal;
+        	result["secondsElapsed"] = m_mediaEntry->m_secondsElapsed;
+		result["mediaName"] = m_mediaEntry->GetMediaName();
+
+	}
+	if (m_sequenceEntry) {
+		result["sequenceName"]     = m_sequenceEntry->GetSequenceName();
+        	result["secondsRemaining"] = sequence->m_seqSecondsRemaining;
+        	result["secondsTotal"] = sequence->m_seqDuration;
+        	result["secondsElapsed"] = sequence->m_seqSecondsElapsed;
+	}
+
+       	result["mediaTitle"] = mediaDetails.title;
+       	result["mediaArtist"] = mediaDetails.artist;
+
+
+	return result;
+}

--- a/src/playlist/PlaylistEntryBoth.h
+++ b/src/playlist/PlaylistEntryBoth.h
@@ -46,6 +46,7 @@ class PlaylistEntryBoth : public PlaylistEntryBase {
 	void Dump(void);
 
 	Json::Value GetConfig(void);
+	Json::Value GetMqttStatus(void);
 
 	std::string GetSequenceName(void) { return m_sequenceName; }
 	std::string GetMediaName(void)    { return m_mediaName; }

--- a/src/playlist/PlaylistEntryMedia.cpp
+++ b/src/playlist/PlaylistEntryMedia.cpp
@@ -397,3 +397,15 @@ Json::Value PlaylistEntryMedia::GetConfig(void)
 	return result;
 }
 
+Json::Value PlaylistEntryMedia::GetMqttStatus(void)
+{
+	Json::Value result = PlaylistEntryBase::GetMqttStatus();
+	result["secondsElapsed"]    = mediaOutputStatus.secondsElapsed;
+	result["secondsRemaining"]  = mediaOutputStatus.secondsRemaining;
+	result["secondsTotal"]      = mediaOutputStatus.secondsTotal;
+	result["mediaName"]         = m_mediaFilename;
+	result["mediaTitle"]        = mediaDetails.title;
+	result["mediaArtist"]       = mediaDetails.artist;
+
+	return result;
+}

--- a/src/playlist/PlaylistEntryMedia.h
+++ b/src/playlist/PlaylistEntryMedia.h
@@ -48,6 +48,7 @@ class PlaylistEntryMedia : public PlaylistEntryBase {
 	void Dump(void);
 
 	Json::Value GetConfig(void);
+	Json::Value GetMqttStatus(void);
 
 	std::string GetMediaName(void) { return m_mediaFilename; }
 

--- a/src/playlist/PlaylistEntrySequence.cpp
+++ b/src/playlist/PlaylistEntrySequence.cpp
@@ -158,4 +158,13 @@ Json::Value PlaylistEntrySequence::GetConfig(void)
 
 	return result;
 }
+Json::Value PlaylistEntrySequence::GetMqttStatus(void) {
+	Json::Value result = PlaylistEntryBase::GetMqttStatus();
+	result["sequenceName"]     = m_sequenceName;
+	result["secondsElapsed"]   = sequence->m_seqSecondsElapsed;
+	result["secondsRemaining"] = sequence->m_seqSecondsRemaining;
+	result["secondsTotal"] = sequence->m_seqDuration;
+
+	return result;
+}
 

--- a/src/playlist/PlaylistEntrySequence.h
+++ b/src/playlist/PlaylistEntrySequence.h
@@ -44,6 +44,8 @@ class PlaylistEntrySequence : public PlaylistEntryBase {
 	void Dump(void);
 
 	Json::Value GetConfig(void);
+	Json::Value GetMqttStatus(void);
+
 
 	std::string GetSequenceName(void) { return m_sequenceName; }
 

--- a/www/advancedsettings.php
+++ b/www/advancedsettings.php
@@ -235,10 +235,16 @@ If
                 </tr>
                 <tr>
                     <td >CA File (Optional):</td>
-                    <td ><? PrintSettingTextSaved("MQTTCaFile", 1, 0, 64, 32, "", ""); ?></td>
+		    <td ><? PrintSettingTextSaved("MQTTCaFile", 1, 0, 64, 32, "", ""); ?></td>
+                </tr>
+                <tr>
+                    <td >MQTT Publish Frequency (Optional):</td>
+		    <td ><? PrintSettingTextSaved("MQTTFrequency", 1, 0, 8, 8, "", "0"); ?></td>
+                </tr>
 	    </table>
 	    MQTT events will be published to "$prefix/falcon/player/$hostname/" with playlist events being in the "playlist" subtopic. <br/>
-            CA file is the full path to the signer certificate.  Only needed if using mqtts server that is self signed.<br/><br/>
+	    CA file is the full path to the signer certificate.  Only needed if using mqtts server that is self signed.<br/>
+	    Publish Frequence should be zero (disabled) or the number of seconds between periodic mqtt publish events<br/><br/>
 FPP will respond to certain events:
 <div class="fppTableWrapper">
 <table width = "100%" border="0" cellpadding="1" cellspacing="1">


### PR DESCRIPTION
When enabled, periodically publish the current status (including current playlist and current entry) every xx seconds via MQTT.   Implementation was discussed here: https://falconchristmas.com/forum/index.php/topic,10865.msg98199.htm 