### PR TITLE
Add Apache modules mod_proxy_html and mod_headers to FPP_Install.sh to fix Docker build

### DIFF
--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -1036,6 +1036,8 @@ a2enmod cgi
 a2enmod rewrite
 a2enmod proxy
 a2enmod proxy_http
+a2enmod proxy_html
+a2enmod headers
 
 
 # Fix name of Apache default error log so it gets rotated by our logrotate config


### PR DESCRIPTION
The change to apache2.site in dcbb109c8df71cbce63f0e7cdf2a5df3d1f9acb5
requires these modules. This change adds those modules and fixes the
Docker build.