### PR TITLE
Updated Co-Other for new output types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ external/rasclock/Module.symvers
 external/rasclock/rtc-pcf2127a.*
 external/rasclock/.rtc-pcf2127a.*
 external/rasclock/.tmp_versions/*
+external/RF24/librf24-bcm.*
 plugins/
 .idea/
 ._*

--- a/src/channeloutput/MCP23017.cpp
+++ b/src/channeloutput/MCP23017.cpp
@@ -121,7 +121,13 @@ int MCP23017Output::Init(Json::Value config)
 
 	m_deviceID = config["deviceID"].asInt();
 
-    i2c = new I2CUtils(1, 0x20);
+	if (m_deviceID < 0x20 || m_device > 0x27)
+	{
+		LogErr(VB_CHANNELOUT, "Invalid MSCP23017 Address: %X\n", m_deviceID);
+		return 0;
+	}
+
+    i2c = new I2CUtils(1, m_deviceID);
 	if (!i2c->isOk())
 	{
 		LogErr(VB_CHANNELOUT, "Error opening I2C device for MCP23017 output\n");
@@ -188,7 +194,7 @@ void MCP23017Output::DumpConfig(void)
 {
 	LogDebug(VB_CHANNELOUT, "MCP23017Output::DumpConfig()\n");
 
-	LogDebug(VB_CHANNELOUT, "    deviceID: %d\n", m_deviceID);
+	LogDebug(VB_CHANNELOUT, "    deviceID: %X\n", m_deviceID);
 
 	ChannelOutputBase::DumpConfig();
 }

--- a/src/channeloutput/generic_spi.cpp
+++ b/src/channeloutput/generic_spi.cpp
@@ -1,0 +1,195 @@
+/*
+ *   Generic SPI handler for Falcon Player (FPP)
+ *
+ *   Copyright (C) 2013-2018 the Falcon Player Developers
+ *      Initial development by:
+ *      - David Pitts (dpitts)
+ *      - Tony Mace (MyKroFt)
+ *      - Mathew Mrosko (Materdaddy)
+ *      - Chris Pinkham (CaptainMurdoch)
+ *      For additional credits and developers, see credits.php.
+ *
+ *   The Falcon Player (FPP) is free software; you can redistribute it
+ *   and/or modify it under the terms of the GNU General Public License
+ *   as published by the Free Software Foundation; either version 2 of
+ *   the License, or (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <thread>
+
+#include "common.h"
+#include "log.h"
+#include "settings.h"
+
+#include "generic_spi.h"
+
+#define MAX_CHANNELS 16777215
+
+#ifdef PLATFORM_PI
+#	define MIN_SPI_SPEED_HZ 32000
+#	define MAX_SPI_SPEED_HZ 125000000
+#elif PLATFORM_BBB
+//TODO need to confirm these
+#	define MIN_SPI_SPEED_HZ 1500
+#	define MAX_SPI_SPEED_HZ 48000000
+#else
+//not sure what other platforms could be used, using safe values here
+#	define MIN_SPI_SPEED_HZ 50000
+#	define MAX_SPI_SPEED_HZ 100000
+#endif
+
+
+
+extern "C" {
+    GenericSPIOutput *createGenericSPIOutput(unsigned int startChannel,
+                                           unsigned int channelCount) {
+        return new GenericSPIOutput(startChannel, channelCount);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/*
+ *
+ */
+GenericSPIOutput::GenericSPIOutput(unsigned int startChannel, unsigned int channelCount)
+  : ThreadedChannelOutputBase(startChannel, channelCount),
+	m_port(-1),
+	m_speed_hz(0),
+    m_spi(nullptr)
+{
+	LogDebug(VB_CHANNELOUT, "GenericSPIOutput::GenericSPIOutput(%u, %u)\n",
+		startChannel, channelCount);
+
+	m_maxChannels = MAX_CHANNELS;
+}
+
+/*
+ *
+ */
+GenericSPIOutput::~GenericSPIOutput()
+{
+	LogDebug(VB_CHANNELOUT, "GenericSPIOutput::~GenericSPIOutput()\n");
+    if (m_spi) {
+        delete m_spi;
+    }
+}
+
+/*
+ *
+ */
+
+int GenericSPIOutput::Init(Json::Value config) {
+    char configStr[2048];
+    ConvertToCSV(config, configStr);
+    return Init(configStr);
+}
+
+int GenericSPIOutput::Init(char *configStr)
+{
+	LogDebug(VB_CHANNELOUT, "GenericSPIOutput::Init('%s')\n", configStr);
+
+	std::vector<std::string> configElems = split(configStr, ';');
+
+	for (int i = 0; i < configElems.size(); i++) {
+		std::vector<std::string> elem = split(configElems[i], '=');
+		if (elem.size() < 2)
+			continue;
+
+		if (elem[0] == "device") {
+			LogDebug(VB_CHANNELOUT, "Using %s for SPI output\n",
+				elem[1].c_str());
+
+			if (elem[1] == "spidev0.0")
+				m_port = 0;
+			else if (elem[1] == "spidev0.1")
+				m_port = 1;
+		} 
+		else if (elem[0] == "speed")
+		{
+			//input page ask for speed in khz
+			int config_speed = 1000*std::stoi(elem[1]);
+			if (config_speed < MIN_SPI_SPEED_HZ)
+				m_speed_hz = MIN_SPI_SPEED_HZ;
+			else if (config_speed > MAX_SPI_SPEED_HZ)
+				m_speed_hz = MAX_SPI_SPEED_HZ;
+			else
+				m_speed_hz = config_speed;
+		}
+	}
+
+	if (m_port == -1) {
+		LogErr(VB_CHANNELOUT, "Invalid Config String: %s\n", configStr);
+		return 0;
+	}
+
+	LogDebug(VB_CHANNELOUT, "Using SPI Port %d\n", m_port);
+
+    m_spi = new SPIUtils(m_port, m_speed_hz);
+    if (!m_spi->isOk()) {
+		LogErr(VB_CHANNELOUT, "Unable to open SPI device\n") ;
+        delete m_spi;
+        m_spi = nullptr;
+		return 0;
+	}
+
+	return ThreadedChannelOutputBase::Init(configStr);
+}
+
+
+/*
+ *
+ */
+int GenericSPIOutput::Close(void)
+{
+	LogDebug(VB_CHANNELOUT, "GenericSPIOutput::Close()\n");
+
+	return ThreadedChannelOutputBase::Close();
+}
+void GenericSPIOutput::GetRequiredChannelRange(int &min, int & max) {
+    min = m_startChannel;
+    max = min + m_channelCount - 1;
+}
+
+/*
+ *
+ */
+int GenericSPIOutput::RawSendData(unsigned char *channelData)
+{
+	LogDebug(VB_CHANNELOUT, "GenericSPIOutput::RawSendData(%p)\n", channelData);
+
+    if (!m_spi) {
+        return 0;
+    }
+    
+	m_spi->xfer(channelData, nullptr, m_channelCount);
+
+	return m_channelCount;
+}
+
+/*
+ *
+ */
+void GenericSPIOutput::DumpConfig(void)
+{
+	LogDebug(VB_CHANNELOUT, "GenericSPIOutput::DumpConfig()\n");
+
+	LogDebug(VB_CHANNELOUT, "    port    : %d\n", m_port);
+
+	ThreadedChannelOutputBase::DumpConfig();
+}
+

--- a/src/channeloutput/generic_spi.h
+++ b/src/channeloutput/generic_spi.h
@@ -1,0 +1,55 @@
+/*
+ *   Generic SPI handler for Falcon Player (FPP)
+ *
+ *   Copyright (C) 2013-2018 the Falcon Player Developers
+ *      Initial development by:
+ *      - David Pitts (dpitts)
+ *      - Tony Mace (MyKroFt)
+ *      - Mathew Mrosko (Materdaddy)
+ *      - Chris Pinkham (CaptainMurdoch)
+ *      For additional credits and developers, see credits.php.
+ *
+ *   The Falcon Player (FPP) is free software; you can redistribute it
+ *   and/or modify it under the terms of the GNU General Public License
+ *   as published by the Free Software Foundation; either version 2 of
+ *   the License, or (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GENERIC_SPI_H
+#define _GENERIC_SPI_H
+
+#include "ThreadedChannelOutputBase.h"
+#include "util/SPIUtils.h"
+
+class GenericSPIOutput : public ThreadedChannelOutputBase {
+  public:
+	GenericSPIOutput(unsigned int startChannel, unsigned int channelCount);
+	~GenericSPIOutput();
+
+    virtual int Init(Json::Value config);
+
+	int Init(char *configStr);
+
+	int Close(void);
+
+	int RawSendData(unsigned char *channelData);
+
+	void DumpConfig(void);
+
+    virtual void GetRequiredChannelRange(int &min, int & max);
+
+  private:
+    SPIUtils       *m_spi;
+	int            m_port;
+	int			   m_speed_hz;
+};
+
+#endif

--- a/src/makefiles/libfpp-co-SPI-Generic.mk
+++ b/src/makefiles/libfpp-co-SPI-Generic.mk
@@ -1,0 +1,12 @@
+ifeq '$(ARCH)' 'Raspberry Pi'
+
+OBJECTS_fpp_co_Generic_SPI_so += channeloutput/generic_spi.o
+LIBS_fpp_co_Generic_SPI_so=-L. -lfpp
+
+TARGETS += libfpp-co-Generic-SPI.so
+OBJECTS_ALL+=$(OBJECTS_fpp_co_Generic_SPI_so)
+
+libfpp-co-Generic-SPI.so: $(OBJECTS_fpp_co_Generic_SPI_so) libfpp.so
+	$(CCACHE) $(CC) -shared $(CFLAGS_$@) $(OBJECTS_fpp_co_Generic_SPI_so) $(LIBS_fpp_co_Generic_SPI_so) $(LDFLAGS) $(LDFLAGS_fpp_co_Generic_SPI_so) -o $@
+
+endif

--- a/www/co-other-modules.php
+++ b/www/co-other-modules.php
@@ -113,30 +113,7 @@ function CreateSelect(optionArray = ["No Options"], currentValue, selectTitle, d
 }
 
 function DeviceSelect(deviceArray = ["No Devices"], currentValue) {
-	var result = "Port: <select class='device'>";
-
-	if (currentValue == "")
-		result += "<option value=''>-- Port --</option>";
-
-	var found = 0;
-	for (var key in deviceArray) {
-		result += "<option value='" + key + "'";
-	
-		if (currentValue == key) {
-			result += " selected";
-			found = 1;
-		}
-
-		result += ">" + deviceArray[key] + "</option>";
-	}
-
-	if ((currentValue != '') &&
-		(found == 0)) {
-		result += "<option value='" + currentValue + "'>" + currentValue + "</option>";
-	}
-	result += "</select>";
-
-	return result;
+    return CreateSelect (deviceArray, currentValue, "Port", "-- Port --", "device");
 }
 
 
@@ -220,6 +197,8 @@ class SPIWS2801Device extends OtherBaseDevice {
 
 }
 
+/////////////////////////////////////////////////////////////////////////////
+// I2C Output
 class I2COutput extends OtherBaseDevice {
 
     constructor(name="I2C-Output", friendlyName="I2C Output", maxChannels=512, fixedChans=false, minAddr, maxAddr) {
@@ -254,6 +233,37 @@ class I2COutput extends OtherBaseDevice {
     }        
 }
 
+/////////////////////////////////////////////////////////////////////////////
+// Generic SPI Output
+class GenericSPIDevice extends OtherBaseDevice {
+    
+    constructor(name="generic_spi", friendlyName="Generic SPI", maxChannels=16777215, fixedChans=false, devices=SPIDevices, config={speed: 50000}) {
+        super(name, friendlyName, maxChannels, fixedChans, devices, config);
+    }
+
+    PopulateHTMLRow(config) {
+        var result = super.PopulateHTMLRow(config);
+        result += " Speed (khz): <input type='number' name='speed' min='1' max='999999' class='speed' value='"+config.speed+"'>";
+        return result;
+    }
+
+    GetOutputConfig(result, cell) {
+        result = super.GetOutputConfig(result, cell);
+        var speed = cell.find("select.speed").val();
+       
+        if (result == "" || speed == "")
+            return "";
+
+        result.speed = speed;
+
+        return result;
+    }
+
+}
+
+
+/////////////////////////////////////////////////////////////////////////////
+//populate the output devices
 var output_modules = [];
 
 //Outputs for all platforms
@@ -275,6 +285,7 @@ if ($settings['Platform'] == "Raspberry Pi")
 ?>
     output_modules.push(new SPIWS2801Device());
     output_modules.push(new I2COutput("MCP23017", "MCP23017", 16, false, 0x20, 0x27));
+    output_modules.push(new GenericSPIDevice());
 <?
 }
 ?>

--- a/www/co-other-modules.php
+++ b/www/co-other-modules.php
@@ -1,4 +1,13 @@
 <script>
+/*
+Quick instructions for adding new output types
+If needed extend a class to add input fields on the Output Config column.  Create a new object for the output type and it to the output_modules array at the bottom.  No need to edit co-other.php.
+Name = type, fpp uses this name to load the correct module
+friendlyName = is the display name for the type and is what is displayed in the Output Type column
+maxChannels = is the max channels that can be configured.  It is also the default channel count for a new row.
+fixChans = true when the output has a fixed channel count.
+*/
+
 /////////////////////////////////////////////////////////////////////////////
 //Base Class
 
@@ -283,6 +292,7 @@ if ($settings['Platform'] == "Raspberry Pi" || $settings['Platform'] == "BeagleB
 if ($settings['Platform'] == "Raspberry Pi")
 {
 ?>
+    //TODO need to see if these modules could run as is on the BeagleBone
     output_modules.push(new SPIWS2801Device());
     output_modules.push(new I2COutput("MCP23017", "MCP23017", 16, false, 0x20, 0x27));
     output_modules.push(new GenericSPIDevice());

--- a/www/co-other-modules.php
+++ b/www/co-other-modules.php
@@ -1,0 +1,209 @@
+<script>
+/////////////////////////////////////////////////////////////////////////////
+//Base Class
+
+class OtherBase {
+    constructor (name="Base-Type", friendlyName="Base Name", maxChannels=512, fixedChans=false, config = {}) {
+        this._typeName = name;
+        this._typeFriendlyName = friendlyName;
+        this._maxChannels = maxChannels;
+        this._fixedChans = fixedChans;
+        this._config = config;
+    }
+    
+    PopulateHTMLRow(config) {
+        var results = "";
+        return results;
+    }
+
+    AddNewRow() {
+        return this.PopulateHTMLRow(this._config);
+    }
+
+    GetOutputConfig(result, cell) {
+        return result;
+    }
+
+    SetDefaults(row) {
+        row.find("td input.count").val(this._maxChannels);
+        if(this._fixedChans)
+            row.find("td input.count").prop('disabled', true);
+    }
+
+    CanAddNewOutput() {
+        return true;
+    }
+
+    get typeName () {
+        return this._typeName;
+    }
+
+    get typeFriendlyName () {
+        return this._typeFriendlyName;
+    }
+
+    get maxChannels () {
+        return this._maxChannels;
+    }
+
+    get fixedChans () {
+        return this._fixedChans;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//Base Class for outputs with a "Port" device such as serial and SPI
+class OtherBaseDevice extends OtherBase {
+    constructor (name="Base-Type-Device", friendlyName="Base Device Name", maxChannels=512, fixedChans=false, devices=["No Devices"], config = {}) {
+        config.device = "";
+        super(name, friendlyName, maxChannels, fixedChans, config)
+        this._devices = devices;
+    }
+    
+    PopulateHTMLRow(config) {
+        var results = "";
+        results += DeviceSelect(this._devices, config.device);
+        return results;
+    }
+
+    GetOutputConfig(result, cell) {
+        var device = cell.find("select.device").val();
+
+        if (device == "")
+            return "";
+
+        result.device = device;
+        return result;
+    }
+
+    CanAddNewOutput() {
+        if (this._devices[0] == "No Devices" || Object.keys(this._devices).length == 0)
+            return false;
+        return true;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Misc. Support functions
+function DeviceSelect(deviceArray = ["No Devices"], currentValue) {
+	var result = "Port: <select class='device'>";
+
+	if (currentValue == "")
+		result += "<option value=''>-- Port --</option>";
+
+	var found = 0;
+	for (var key in deviceArray) {
+		result += "<option value='" + key + "'";
+	
+		if (currentValue == key) {
+			result += " selected";
+			found = 1;
+		}
+
+		result += ">" + deviceArray[key] + "</option>";
+	}
+
+	if ((currentValue != '') &&
+		(found == 0)) {
+		result += "<option value='" + currentValue + "'>" + currentValue + "</option>";
+	}
+	result += "</select>";
+
+	return result;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// SPI and Serial Devices
+
+var SPIDevices = new Array();
+<?
+        foreach(scandir("/dev/") as $fileName)
+        {
+            if (preg_match("/^spidev[0-9]/", $fileName)) {
+                echo "SPIDevices['$fileName'] = '$fileName';\n";
+            }
+        }
+?>
+
+var SerialDevices = new Array();
+<?
+	foreach(scandir("/dev/") as $fileName)
+	{
+		if ((preg_match("/^ttyS[0-9]+/", $fileName)) ||
+			(preg_match("/^ttyACM[0-9]+/", $fileName)) ||
+			(preg_match("/^ttyO[0-9]/", $fileName)) ||
+			(preg_match("/^ttyS[0-9]/", $fileName)) ||
+			(preg_match("/^ttyAMA[0-9]+/", $fileName)) ||
+			(preg_match("/^ttyUSB[0-9]+/", $fileName))) {
+			echo "SerialDevices['$fileName'] = '$fileName';\n";
+		}
+	}
+?>
+
+
+
+/////////////////////////////////////////////////////////////////////////////
+// WS2801 Output via SPI
+
+class SPIWS2801Device extends OtherBaseDevice {
+    
+    constructor() {
+        super("SPI-WS2801", "SPI-WS2801", 1530, false, SPIDevices, {pi36: 0});
+    }
+
+    PopulateHTMLRow(config) {
+        var result = super.PopulateHTMLRow(config);
+
+        result += " PI36: <input type=checkbox class='pi36'";
+        if (config.pi36)
+            result += " checked='checked'";
+
+        result += ">";
+
+        return result;
+    }
+
+    GetOutputConfig(result, cell) {
+        result = super.GetOutputConfig(result, cell);
+       
+        if (result == "")
+            return "";
+
+        var pi36 = 0;
+
+        if (cell.find("input.pi36").is(":checked"))
+            pi36 = 1;
+
+        result.pi36 = parseInt(pi36);
+
+        return result;
+        }
+
+}
+
+var output_modules = [];
+
+//Outputs for all platforms
+
+//Outputs for Raspberry Pi or Beagle
+<?
+if ($settings['Platform'] == "Raspberry Pi" || $settings['Platform'] == "BeagleBone Black")
+{
+?>
+
+
+<?
+}
+?>
+//Outputs for Raspberry Pi
+<?
+if ($settings['Platform'] == "Raspberry Pi")
+{
+?>
+	output_modules.push(new SPIWS2801Device());
+<?
+}
+?>
+
+
+</script>

--- a/www/co-other-modules.php
+++ b/www/co-other-modules.php
@@ -237,7 +237,7 @@ class I2COutput extends OtherBaseDevice {
 // Generic SPI Output
 class GenericSPIDevice extends OtherBaseDevice {
     
-    constructor(name="generic_spi", friendlyName="Generic SPI", maxChannels=16777215, fixedChans=false, devices=SPIDevices, config={speed: 50000}) {
+    constructor(name="generic_spi", friendlyName="Generic SPI", maxChannels=1048576, fixedChans=false, devices=SPIDevices, config={speed: 50000}) {
         super(name, friendlyName, maxChannels, fixedChans, devices, config);
     }
 
@@ -249,7 +249,7 @@ class GenericSPIDevice extends OtherBaseDevice {
 
     GetOutputConfig(result, cell) {
         result = super.GetOutputConfig(result, cell);
-        var speed = cell.find("select.speed").val();
+        var speed = cell.find("input.speed").val();
        
         if (result == "" || speed == "")
             return "";

--- a/www/co-other.php
+++ b/www/co-other.php
@@ -1182,8 +1182,8 @@ function PopulateChannelOutputTable(data) {
 				)
                 countDisabled = " disabled='disabled'";
 
-            newRow += "></td>" +
-                    "<td>" + type + "</td>" +
+            newRow += "></td>" +	
+					"<td>" + type + "</td>" +
                     "<td><input class='start' type=text size=6 maxlength=6 value='" + output.startChannel + "'></td>" +
                     "<td><input class='count' type=text size=6 maxlength=6 value='" + output.channelCount + "'" + countDisabled + "></td>" +
                     "<td>";
@@ -1405,6 +1405,7 @@ function SaveOtherChannelOutputs() {
 				DialogError("Save Channel Outputs", "Invalid" + output_module.typeFriendlyName + "Config");
 				return;
 			}
+			maxChannels = output_module.maxChannels;
 		}
 
 
@@ -1583,7 +1584,7 @@ function AddOtherOutput() {
 
 	///////new method
 	output_modules.forEach(function addOption(output_module) {
-		$('#outputType').append(new Option(output_module.typeName, output_module.typeFriendlyName));
+		$('#outputType').append(new Option(output_module.typeFriendlyName, output_module.typeName));
 	})
 
 }

--- a/www/co-other.php
+++ b/www/co-other.php
@@ -1182,11 +1182,15 @@ function PopulateChannelOutputTable(data) {
 				)
                 countDisabled = " disabled='disabled'";
 
-            newRow += "></td>" +	
-					"<td>" + type + "</td>" +
+			var typeFriendlyName = type;
+			if (output_module != undefined)
+					typeFriendlyName = output_module.typeFriendlyName;
+
+			newRow += "></td>" +	
+					"<td class='type'>" + typeFriendlyName + "<input class='type' type='hidden' name='type' value='" +type+ "'></td>" +
                     "<td><input class='start' type=text size=6 maxlength=6 value='" + output.startChannel + "'></td>" +
                     "<td><input class='count' type=text size=6 maxlength=6 value='" + output.channelCount + "'" + countDisabled + "></td>" +
-                    "<td>";
+                    "<td class='config'>";
 
             if ((type == "DMX-Pro") ||
                 (type == "DMX-Open") ||
@@ -1252,10 +1256,10 @@ function SaveOtherChannelOutputs() {
 		}
 
 		// Type
-		var type = $this.find("td:nth-child(3)").html();
+		var type = $this.find("input.type").val();
 
 		// User has not selected a type yet
-		if (type.indexOf("<select") >= 0) {
+		if (type.indexOf("None Selected") >= 0) {
 			DialogError("Save Channel Outputs",
 				"Output type must be selected on row " + rowNumber);
 			dataError = 1;
@@ -1527,7 +1531,12 @@ function OtherTypeSelected(selectbox) {
 		}
 	}
 
-	$row.find("td:nth-child(3)").html(type);
+	//add frindly type name if available
+	var typeFriendlyName = type;
+	if (output_module != undefined)
+			typeFriendlyName = output_module.typeFriendlyName;
+	$row.find("td.type").html(typeFriendlyName);
+	$row.find("td.type").append("<input class='type' type='hidden' name='type' value='" +type+ "'>");
 
 	AddOtherTypeOptions($row, type);
 }
@@ -1543,7 +1552,7 @@ function AddOtherOutput() {
 	var newRow = 
 		"<tr class='rowUniverseDetails'><td>" + (currentRows + 1) + "</td>" +
 			"<td><input class='act' type=checkbox></td>" +
-			"<td><select id='outputType' class='type' onChange='OtherTypeSelected(this);'>" +
+			"<td class='type'><select id='outputType' class='type' onChange='OtherTypeSelected(this);'>" +
 				"<option value=''>Select a type</option>" +
 				"<option value='DMX-Pro'>DMX-Pro</option>" +
 				"<option value='DMX-Open'>DMX-Open</option>" +
@@ -1574,7 +1583,7 @@ function AddOtherOutput() {
 				"<option value='VirtualDisplay'>Virtual Display</option>" +
 				"<option value='Triks-C'>Triks-C</option>" +
 				"<option value='USBRelay'>USBRelay</option>" +
-			"</select></td>" +
+			"</select><input class='type' type='hidden' name='type' value='None Selected'></td>" +
 			"<td><input class='start' type='text' size=6 maxlength=6 value='' style='display: none;'></td>" +
 			"<td><input class='count' type='text' size=6 maxlength=6 value='' style='display: none;'></td>" +
 			"<td> </td>" +


### PR DESCRIPTION
I have started on some projects for adding additional output types and saw an opportunity with co-other.php to hopefully make it easier and quicker to add new output types to the web frontend.  
My goals for these changes were:
1.  Not to fundamentally change how the table was being built
2.  Leave the code for the existing output types as is, as well as the actual code for building and saving the tables.
3.  Using Javascript's ES6 class functionality, have a quick method (reusing code) to create a new output types.
4.  Eliminate the need to update the create, populate, save, etc. functions in co-other everytime one adds a new output type 

In addition there are a few other small changes in my branch
1.  Backend and frontend code for a generic SPI output
2.  Using the new method added a frontend code for MSCP23017
3.  Made a small update in the backend code for MSCP23017 to remove the hard coded I2C address
4.  I moved the SPI-WS2801 frontend code to the new method as it was my test case.

Let me know if these things should be in their own pull request.