### PR TITLE
fix: index for compressionType in fseq header

### DIFF
--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1493,7 +1493,7 @@ m_handler(nullptr)
             m_compressionType = CompressionType::zlib;
             break;
             default:
-            LogErr(VB_SEQUENCE, "Unknown compression type: %d", (int)header[32]);
+            LogErr(VB_SEQUENCE, "Unknown compression type: %d", (int)header[20]);
         }
         
         uint32_t maxBlocks = header[21];


### PR DESCRIPTION
When switching on `header[20]` (fseq file compression type), the default case instead prints `header[32]` in its error message. `header[32]` corresponds to 1/4th of a `uint32` describing the first frame's index, which I'm assuming is not what we want to print.