### PR TITLE
enh: improve V2 FSEQ header writing

### DIFF
--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1482,9 +1482,9 @@ void V2FSEQFile::writeHeader() {
         writePos += len;
     }
 
-    // Validate final write position matches expected channel data offset
-    if (writePos != m_seqChanDataOffset) {
-        LogErr(VB_SEQUENCE, "Final write position does not match channel data offset (%d)!", writePos, m_seqChanDataOffset);
+    // Validate final write position does not exceed channel data offset
+    if (writePos > m_seqChanDataOffset) {
+        LogErr(VB_SEQUENCE, "Final write position (%d) exceeds channel data offset (%d)! This means the header size failed to compute an accurate buffer size.", writePos, m_seqChanDataOffset);
     }
 
     // Write full header at once

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1397,8 +1397,8 @@ void V2FSEQFile::writeHeader() {
     int headerSize = V2FSEQ_HEADER_SIZE;
     headerSize += maxBlocks * V2FSEQ_COMPRESSION_BLOCK_SIZE;
     headerSize += m_sparseRanges.size() * V2FSEQ_SPARSE_RANGE_SIZE;
+    headerSize += m_variableHeaders.size() * V2FSEQ_VARIABLE_HEADER_SIZE;
     for (auto &a : m_variableHeaders) {
-        headerSize += V2FSEQ_VARIABLE_HEADER_SIZE;
         headerSize += a.data.size();
     }
 

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -456,8 +456,8 @@ static const int V1FSEQ_HEADER_SIZE = 28;
 V1FSEQFile::V1FSEQFile(const std::string &fn)
   : FSEQFile(fn), m_dataBlockSize(0)
 {
-	m_seqVersionMinor = V1FSEQ_MINOR_VERSION;
-	m_seqVersionMajor = V1FSEQ_MAJOR_VERSION;
+    m_seqVersionMinor = V1FSEQ_MINOR_VERSION;
+    m_seqVersionMajor = V1FSEQ_MAJOR_VERSION;
 }
 
 void V1FSEQFile::writeHeader() {
@@ -1547,9 +1547,12 @@ m_handler(nullptr)
             }
         }
         if (m_frameOffsets.size() == 0) {
-            //this is bad... not sure what we can do.  We'll force a "0" block to
-            //avoid a crash, but the data might not load correctly
-            LogErr(VB_SEQUENCE, "FSEQ file corrupt: did not load any block references from header.");
+            // FSEQ files with CompressionType::none will have a (safely) empty m_frameOffsets due to maxBlocks == 0
+            if (m_compressionType != CompressionType::none) {
+                //this is bad... not sure what we can do.  We'll force a "0" block to
+                //avoid a crash, but the data might not load correctly
+                LogErr(VB_SEQUENCE, "FSEQ file corrupt: did not load any block references from header.");
+            }
 
             m_frameOffsets.push_back(std::pair<uint32_t, uint64_t>(0, offset));
             offset += this->m_seqFileSize - offset;

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1457,6 +1457,7 @@ void V2FSEQFile::writeHeader() {
     writePos += maxBlocks * V2FSEQ_COMPRESSION_BLOCK_SIZE;
 
     // Sparse ranges
+    // 6 byte size (3 byte value + 3 byte value)
     for (auto &a : m_sparseRanges) {
         write3ByteUInt(&header[writePos], a.first);
         write3ByteUInt(&header[writePos + 3], a.second);
@@ -1475,8 +1476,8 @@ void V2FSEQFile::writeHeader() {
     }
 
     // Validate final write position matches expected channel data offset
-    if (m_seqChanDataOffset != writePos) {
-        LogErr(VB_SEQUENCE, "Channel data offset (%d) does not match final write position (%d)!", m_seqChanDataOffset, writePos);
+    if (writePos != m_seqChanDataOffset) {
+        LogErr(VB_SEQUENCE, "Final write position does not match channel data offset (%d)!", writePos, m_seqChanDataOffset);
     }
 
     // Write full header at once

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1468,6 +1468,10 @@ void V2FSEQFile::writeHeader() {
 		writePos += len;
     }
 
+	// Write full header
+	// This includes padding bytes to ensure m_seqChanDataOffset aligns with headerSize
+	write(header, headerSize);
+
     LogDebug(VB_SEQUENCE, "Setup for writing v2 FSEQ\n");
     dumpInfo(true);
 }

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1471,7 +1471,7 @@ void V2FSEQFile::writeHeader() {
         write2ByteUInt(&header[writePos], len);
         header[writePos + 2] = a.code[0];
         header[writePos + 3] = a.code[1];
-        memcpy(&header[writePos + 4], &a.data, a.data.size());
+        memcpy(&header[writePos + 4], &a.data[0], a.data.size());
         writePos += len;
     }
 

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1479,6 +1479,7 @@ void V2FSEQFile::writeHeader() {
 
 	// Write full header
 	// This includes padding bytes to ensure m_seqChanDataOffset aligns with headerSize
+	// If writePos extends past headerSize (in error), writing only headerSize prevents data overflow
 	write(header, headerSize);
 
     LogDebug(VB_SEQUENCE, "Setup for writing v2 FSEQ\n");

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -201,6 +201,12 @@ inline void write4ByteUInt(uint8_t* data, uint32_t v) {
     data[3] = (uint8_t)((v >> 24) & 0xFF);
 }
 
+static const int V1FSEQ_MINOR_VERSION = 0;
+static const int V1FSEQ_MAJOR_VERSION = 1;
+
+static const int V2FSEQ_MINOR_VERSION = 0;
+static const int V2FSEQ_MAJOR_VERSION = 2;
+
 FSEQFile* FSEQFile::openFSEQFile(const std::string &fn) {
 
     FILE *seqFile = fopen((const char *)fn.c_str(), "rb");
@@ -446,8 +452,6 @@ void FSEQFile::finalize() {
 }
 
 static const int V1FSEQ_HEADER_SIZE = 28;
-static const int V1FSEQ_MINOR_VERSION = 0;
-static const int V1FSEQ_MAJOR_VERSION = 1;
 
 V1FSEQFile::V1FSEQFile(const std::string &fn)
   : FSEQFile(fn), m_dataBlockSize(0)
@@ -465,7 +469,7 @@ void V1FSEQFile::writeHeader() {
     header[3] = 'Q';
 
     // data offset
-    uint32_t dataOffset = fixedHeaderLength;
+    uint32_t dataOffset = V1FSEQ_HEADER_SIZE;
     for (auto &a : m_variableHeaders) {
         dataOffset += a.data.size() + 4;
     }
@@ -475,7 +479,7 @@ void V1FSEQFile::writeHeader() {
     header[6] = m_seqVersionMinor; //minor
     header[7] = m_seqVersionMajor; //major
     // Fixed header length
-    write2ByteUInt(&header[8], fixedHeaderLength);
+    write2ByteUInt(&header[8], V1FSEQ_HEADER_SIZE);
     // Step Size
     write4ByteUInt(&header[10], m_seqChannelCount);
     // Number of Steps
@@ -643,8 +647,6 @@ uint32_t V1FSEQFile::getMaxChannel() const {
 }
 
 static const int V2FSEQ_HEADER_SIZE = 32;
-static const int V2FSEQ_MINOR_VERSION = 0;
-static const int V2FSEQ_MAJOR_VERSION = 2;
 static const int V2FSEQ_VARIABLE_HEADER_SIZE = 4;
 static const int V2FSEQ_SPARSE_RANGE_SIZE = 6;
 static const int V2FSEQ_COMPRESSION_BLOCK_SIZE = 8;

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -649,8 +649,9 @@ static const int V2FSEQ_VARIABLE_HEADER_SIZE = 4;
 static const int V2FSEQ_SPARSE_RANGE_SIZE = 6;
 static const int V2FSEQ_COMPRESSION_BLOCK_SIZE = 8;
 #if !defined(NO_ZLIB) || !defined(NO_ZSTD)
-static const int V2FSEQ_OUT_BUFFER_SIZE = 1024*1024; //1M output buffer
-static const int V2FSEQ_OUT_BUFFER_FLUSH_SIZE = 900 * 1024; //90% full, flush it
+static const int V2FSEQ_OUT_BUFFER_SIZE = 1024 * 1024; // 1MB output buffer
+static const int V2FSEQ_OUT_BUFFER_FLUSH_SIZE = 900 * 1024; // 90% full, flush it
+static const int V2FSEQ_OUT_COMPRESSION_BLOCK_SIZE = 64 * 1024; // 64KB blocks
 #endif
 
 class V2Handler {
@@ -780,8 +781,7 @@ public:
         }
         //determine a good number of compression blocks
         uint64_t datasize = m_file->getChannelCount() * m_file->getNumFrames();
-        uint64_t numBlocks = datasize;
-        numBlocks /= (64*1024); //at least 64K per block
+        uint64_t numBlocks = datasize / V2FSEQ_OUT_COMPRESSION_BLOCK_SIZE;
         if (numBlocks > 255) {
             //need a lot of blocks, use as many as we can
             numBlocks = 255;

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -704,7 +704,7 @@ public:
     virtual uint8_t getCompressionType() override { return 0;}
     virtual uint32_t computeMaxBlocks() override {return 0;}
     virtual std::string GetType() const override { return "No Compression"; }
-    virtual void prepareRead(uint32_t frame) {
+    virtual void prepareRead(uint32_t frame) override {
         FrameData *f = getFrame(frame);
         if (f) {
             delete f;

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -279,8 +279,11 @@ FSEQFile* FSEQFile::createFSEQFile(const std::string &fn,
                                    int level) {
     if (version == V1FSEQ_MAJOR_VERSION) {
         return new V1FSEQFile(fn);
+    } else if (version == V2FSEQ_MAJOR_VERSION) {
+        return new V2FSEQFile(fn, ct, level);
     }
-    return new V2FSEQFile(fn, ct, level);
+    LogErr(VB_SEQUENCE, "Error creating FSEQ file. Unknown version: %d", version);
+    return nullptr;
 }
 std::string FSEQFile::getMediaFilename(const std::string &fn) {
     std::unique_ptr<FSEQFile> file(FSEQFile::openFSEQFile(fn));

--- a/src/fseq/FSEQUtils.cpp
+++ b/src/fseq/FSEQUtils.cpp
@@ -197,6 +197,10 @@ int main(int argc, char *argv[]) {
                     merges.push_back(src);
                 }
             }
+
+            if (outputFilename == nullptr) {
+                return 0;
+            }
             
             FSEQFile *dest = FSEQFile::createFSEQFile(outputFilename,
                                                       fseqVersion,

--- a/src/fseq/FSEQUtils.cpp
+++ b/src/fseq/FSEQUtils.cpp
@@ -199,6 +199,11 @@ int main(int argc, char *argv[]) {
             }
 
             if (outputFilename == nullptr) {
+                if (!verbose) {
+                    printf("No output file defined!\n");
+                    printf("Use -v to enable verbose output printing for file information.\n");
+                }
+                delete src;
                 return 0;
             }
             

--- a/src/fseq/FSEQUtils.cpp
+++ b/src/fseq/FSEQUtils.cpp
@@ -28,7 +28,7 @@ void usage(char *appname) {
     printf("   -r (#-# | #+#)    - Channel Range.  Use - to separate start/end channel\n");
     printf("                            Use + to separate start channel + num channels\n");
     printf("   -n                - No Sparse. -r will only read the range, but the resulting fseq is not sparse.\n");
-    printf("   -j                - Output the fseq file metadata to json");
+    printf("   -j                - Output the fseq file metadata to json\n");
     printf("   -h                - This help output\n");
 }
 const char *outputFilename = nullptr;
@@ -188,7 +188,7 @@ int main(int argc, char *argv[]) {
                     printf("]");
                 }
             }
-            printf("}");
+            printf("}\n");
         } else {
             std::vector<FSEQFile *> merges;
             for (auto &f : mergeFseqs) {
@@ -203,7 +203,7 @@ int main(int argc, char *argv[]) {
                                                       compressionType,
                                                       compressionLevel);
             if (dest == nullptr) {
-                printf("Failed to create FSEQ file (returned nullptr)!");
+                printf("Failed to create FSEQ file (returned nullptr)!\n");
                 delete src;
                 return 1;
             }

--- a/src/fseq/FSEQUtils.cpp
+++ b/src/fseq/FSEQUtils.cpp
@@ -199,6 +199,12 @@ int main(int argc, char *argv[]) {
                                                       fseqVersion,
                                                       compressionType,
                                                       compressionLevel);
+            if (dest == nullptr) {
+                printf("Failed to create FSEQ file (returned nullptr)!");
+                delete src;
+                return 1;
+            }
+            
             if (ranges.empty()) {
                 ranges.push_back(std::pair<uint32_t, uint32_t>(0, 999999999));
             } else if (fseqVersion == 2 && sparse) {

--- a/src/fseq/FSEQUtils.cpp
+++ b/src/fseq/FSEQUtils.cpp
@@ -85,9 +85,12 @@ int parseArguments(int argc, char **argv) {
                     compressionType = V2FSEQFile::CompressionType::none;
                 } else if (strcmp(optarg, "zlib") == 0) {
                     compressionType = V2FSEQFile::CompressionType::zlib;
-                } else {
+                } else if (strcmp(optarg, "zstd") == 0) {
                     compressionType = V2FSEQFile::CompressionType::zstd;
-                }
+                } else {
+					printf("Unknown compression type: %s\n", optarg);
+					exit(EXIT_FAILURE);
+				}
                 break;
             case 'l':
                 compressionLevel = strtol(optarg, NULL, 10);

--- a/src/fseq/FSEQUtils.cpp
+++ b/src/fseq/FSEQUtils.cpp
@@ -88,9 +88,9 @@ int parseArguments(int argc, char **argv) {
                 } else if (strcmp(optarg, "zstd") == 0) {
                     compressionType = V2FSEQFile::CompressionType::zstd;
                 } else {
-					printf("Unknown compression type: %s\n", optarg);
-					exit(EXIT_FAILURE);
-				}
+                    printf("Unknown compression type: %s\n", optarg);
+                    exit(EXIT_FAILURE);
+                }
                 break;
             case 'l':
                 compressionLevel = strtol(optarg, NULL, 10);


### PR DESCRIPTION
This PR simplifies the V2 FSEQ header writing process.
- Moves magic numbers into const fields to reduce duplication and potential mismatches. (I'm not familiar with C++ idioms, should these be preprocessor definitions instead?)
- Builds header as a single buffer. This avoids allocating additional buffers and write calls for things like writing sparse ranges, compression blocks, variable headers and alignment bytes.
- Shuffle field assignments to be in descending order by index for code readability.
- Improve write validation to note alignment mismatches or overflows.
- Fix incorrect documentation and add new comments & references.
- Prevent defaulting behavior from matching invalid major version values to major version 2. (Since `FSEQFile.cpp`/`FSEQFile.h` are used by xLights, I've cross checked their usage and they already properly validate the version parameter input, so this is a non-issue for their implementation.)
- Added missing newline breaks to fsequtils to correct output errors with bash & zsh.
- Fixes fsequtils segfaulting when outputFilename is null (which occurs whenever you simply want to print verbose information about a file without outputting to a new file).
- Fixes uncompressed V2FSEQ files from printing a corrupted file warning when `m_sparseRanges` is empty.