### PR TITLE
FSEQFile.cpp cleanup

### DIFF
--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -154,11 +154,6 @@ inline uint64_t GetTime(void) {
     return now_tv.tv_sec * 1000000LL + now_tv.tv_usec;
 }
 
-inline long long GetTimeMS(void) {
-    struct timeval now_tv;
-    gettimeofday(&now_tv, NULL);
-    return now_tv.tv_sec * 1000LL + now_tv.tv_usec / 1000;
-}
 inline long roundTo4(long i) {
     long remainder = i % 4;
     if (remainder == 0) {

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1413,7 +1413,7 @@ void V2FSEQFile::writeHeader() {
     uint8_t header[m_seqChanDataOffset];
     memset(header, 0, m_seqChanDataOffset);
 
-    // File identifier (PSEQ) - 4bytes
+    // File identifier (PSEQ) - 4 bytes
     header[0] = 'P';
     header[1] = 'S';
     header[2] = 'E';


### PR DESCRIPTION
- Removes an unused method `GetTimeMS(void)` to remove dead code and help lower the diff between fpp and xLight's `FSEQFile.cpp` implementation.
- Fixes spacing in a previously committed comment.

Super exciting stuff ;) 