### PR TITLE
enh: cleanup V1/ESEQ file reading

### DIFF
--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -552,9 +552,9 @@ void V1FSEQFile::writeHeader() {
         writePos += len;
     }
 
-    // Validate final write position does not exceed channel data offset
-    if (writePos > m_seqChanDataOffset) {
-        LogErr(VB_SEQUENCE, "Final write position (%d) exceeds channel data offset (%d)! This means the header size failed to compute an accurate buffer size.", writePos, m_seqChanDataOffset);
+    // Validate final write position matches expected channel data offset
+    if (roundTo4(writePos) != m_seqChanDataOffset) {
+        LogErr(VB_SEQUENCE, "Final write position (%d, roundTo4 = %d) does not match channel data offset (%d)! This means the header size failed to compute an accurate buffer size.\n", writePos, roundTo4(writePos), m_seqChanDataOffset);
     }
 
     // Write full header at once
@@ -1516,9 +1516,9 @@ void V2FSEQFile::writeHeader() {
         writePos += len;
     }
 
-    // Validate final write position does not exceed channel data offset
-    if (writePos > m_seqChanDataOffset) {
-        LogErr(VB_SEQUENCE, "Final write position (%d) exceeds channel data offset (%d)! This means the header size failed to compute an accurate buffer size.", writePos, m_seqChanDataOffset);
+    // Validate final write position matches expected channel data offset
+    if (roundTo4(writePos) != m_seqChanDataOffset) {
+        LogErr(VB_SEQUENCE, "Final write position (%d, roundTo4 = %d) does not match channel data offset (%d)! This means the header size failed to compute an accurate buffer size.\n", writePos, roundTo4(writePos), m_seqChanDataOffset);
     }
 
     // Write full header at once

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -237,7 +237,7 @@ FSEQFile* FSEQFile::openFSEQFile(const std::string &fn) {
     }
 
     // Validate the 4 byte file format identifier is supported
-    if ((tmpData[0] != 'P' && tmpData[0] != 'F' && tmpData[0] != 'E')
+    if ((tmpData[0] != 'P' && tmpData[0] != 'F' && tmpData[0] != V1ESEQ_HEADER_IDENTIFIER)
         || tmpData[1] != 'S'
         || tmpData[2] != 'E'
         || tmpData[3] != 'Q') {
@@ -1403,6 +1403,7 @@ V2FSEQFile::V2FSEQFile(const std::string &fn, CompressionType ct, int cl)
 {
     m_seqVersionMajor = V2FSEQ_MAJOR_VERSION;
     m_seqVersionMinor = V2FSEQ_MINOR_VERSION;
+    
     createHandler();
 }
 void V2FSEQFile::writeHeader() {

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -297,7 +297,7 @@ FSEQFile* FSEQFile::createFSEQFile(const std::string &fn,
     } else if (version == V2FSEQ_MAJOR_VERSION) {
         return new V2FSEQFile(fn, ct, level);
     }
-    LogErr(VB_SEQUENCE, "Error creating FSEQ file. Unknown version: %d", version);
+    LogErr(VB_SEQUENCE, "Error creating FSEQ file (%s), unknown version %d\n", fn.c_str(), version);
     return nullptr;
 }
 std::string FSEQFile::getMediaFilename(const std::string &fn) {

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1556,7 +1556,7 @@ m_handler(nullptr)
             m_compressionType = CompressionType::zlib;
             break;
             default:
-            LogErr(VB_SEQUENCE, "Unknown compression type: %d", (int)header[20]);
+            LogErr(VB_SEQUENCE, "Unknown compression type: %d\n", (int)header[20]);
         }
 
         // readPos tracks the reader index for variable length data past the fixed header size
@@ -1592,7 +1592,7 @@ m_handler(nullptr)
             // For uncompressed blocks, maxBlocks should always be 0 and m_frameOffsets initially empty
             m_frameOffsets.push_back(std::pair<uint32_t, uint64_t>(0, m_seqChanDataOffset));
         } else if (m_frameOffsets.size() == 0) {
-            LogErr(VB_SEQUENCE, "FSEQ file corrupt: did not load any block references from header.");
+            LogErr(VB_SEQUENCE, "FSEQ file corrupt: did not load any block references from header.\n");
 
             // File is flagged as compressed but no compression blocks were read
             // The file is likely corrupted, read the full channel data as a single block as a recovery attempt
@@ -1619,7 +1619,7 @@ m_handler(nullptr)
         uint16_t headerSize = read2ByteUInt(&header[8]);
 
         if (readPos != headerSize) {
-            LogErr(VB_SEQUENCE, "Read position (%d) does not match expected header size %d!", readPos, headerSize);
+            LogErr(VB_SEQUENCE, "Read position (%d) does not match expected header size %d!\n", readPos, headerSize);
         }
         
         // Read timestamp based UUID - 8 bytes

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1646,7 +1646,6 @@ void V2FSEQFile::dumpInfo(bool indent) {
         ind[0] = 0;
     }
 
-    LogDebug(VB_SEQUENCE, "%sSequence File Information\n", ind);
     LogDebug(VB_SEQUENCE, "%scompressionType       : %d\n", ind, m_compressionType);
     LogDebug(VB_SEQUENCE, "%snumBlocks             : %d\n", ind, m_handler->computeMaxBlocks());
     // Commented out to declutter the logs ... we can add it back in if we start seeing issues

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -474,6 +474,9 @@ V1FSEQFile::V1FSEQFile(const std::string &fn)
 }
 
 void V1FSEQFile::writeHeader() {
+    // Additional file format documentation available at:
+    // https://github.com/FalconChristmas/fpp/blob/master/docs/FSEQ_Sequence_File_Format.txt#L1
+
     // Compute headerSize to include the header and variable headers
     int headerSize = V1FSEQ_HEADER_SIZE;
     headerSize += m_variableHeaders.size() * FSEQ_VARIABLE_HEADER_SIZE;
@@ -552,22 +555,14 @@ void V1FSEQFile::writeHeader() {
     write(header, m_seqChanDataOffset);
 
     LogDebug(VB_SEQUENCE, "Setup for writing v1 FSEQ\n");
-    dumpInfo(false);
+    dumpInfo(true);
 }
 
 V1FSEQFile::V1FSEQFile(const std::string &fn, FILE *file, const std::vector<uint8_t> &header)
 : FSEQFile(fn, file, header) {
-
-    // m_seqNumUniverses = (header[20])       + (header[21] << 8);
-    // m_seqUniverseSize = (header[22])       + (header[23] << 8);
-    // m_seqGamma         = header[24];
-    // m_seqColorEncoding = header[25];
-
-    // 0 = header[26]
-    // 0 = header[27]
     parseVariableHeaders(header, V1FSEQ_HEADER_SIZE);
 
-    //use the last modified time for the uniqueId
+    // Use the last modified time for the uniqueId
     struct stat stats;
     fstat(fileno(file), &stats);
     m_uniqueId = stats.st_mtime;
@@ -1537,7 +1532,8 @@ m_handler(nullptr)
         uint32_t modelStart = read4ByteUInt(&header[12]);
 
         m_compressionType = CompressionType::none;
-        //ESEQ files use 1 based start channels, we need 0 based
+
+        // ESEQ files use 1 based start channels, offset to start at 0
         m_sparseRanges.push_back(std::pair<uint32_t, uint32_t>(modelStart ? modelStart - 1 : modelStart, modelLen));
     } else {
         //24-31 - timestamp/uuid/identifier

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -280,7 +280,7 @@ FSEQFile* FSEQFile::openFSEQFile(const std::string &fn) {
         file = new V2FSEQFile(fn, seqFile, header);
     } else {
         LogErr(VB_SEQUENCE, "Error opening FSEQ file (%s), unknown version %d.%d\n", fn.c_str(), seqVersionMajor, seqVersionMinor);
-        DumpHeader("File header:", headerPeek, bytesRead);
+        DumpHeader("File header:", &header[0], bytesRead);
         fclose(seqFile);
         return nullptr;
     }

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -309,16 +309,16 @@ std::string FSEQFile::getMediaFilename() const {
     return "";
 }
 
+static const int FSEQ_DEFAULT_STEP_TIME = 50;
+
 FSEQFile::FSEQFile(const std::string &fn)
     : m_filename(fn),
     m_seqNumFrames(0),
     m_seqChannelCount(0),
-    m_seqStepTime(50),
+    m_seqStepTime(FSEQ_DEFAULT_STEP_TIME),
     m_variableHeaders(),
     m_uniqueId(0),
     m_seqFileSize(0),
-    m_seqVersionMajor(1),
-    m_seqVersionMinor(0),
     m_memoryBuffer(),
     m_seqChanDataOffset(0),
     m_memoryBufferPos(0)

--- a/src/fseq/FSEQFile.cpp
+++ b/src/fseq/FSEQFile.cpp
@@ -1530,10 +1530,10 @@ m_handler(nullptr)
     if (header[0] == V1ESEQ_HEADER_IDENTIFIER) {
         m_compressionType = CompressionType::none;
 
-        // ESEQ files use 1 based start channels, offset to start at 0
-        uint32_t modelLen = read4ByteUInt(&header[16]);
         uint32_t modelStart = read4ByteUInt(&header[12]);
+        uint32_t modelLen = read4ByteUInt(&header[16]);
 
+        // ESEQ files use 1 based start channels, offset to start at 0
         m_sparseRanges.push_back(std::pair<uint32_t, uint32_t>(modelStart ? modelStart - 1 : modelStart, modelLen));
     } else {
         switch (header[20]) {
@@ -1575,7 +1575,7 @@ m_handler(nullptr)
             // This pre-buffers the first compression block
             if (i == 0) {
                 preload(m_seqChanDataOffset, length);
-            }            
+            }
         }
 
         if (m_compressionType == CompressionType::none) {


### PR DESCRIPTION
- Adapts my previous V2FSEQ#writeHeader simplification & optimization PR (https://github.com/FalconChristmas/fpp/pull/640) to V1FSEQ#writeHeader
- Moves ESEQ related magic numbers to named constants
- Reorganized V2FSEQFile's buffer constructor to read by index in ascending order
- Added read validation to prevent index overflows
- Fixed outdated comments and added additional comments explaining preexisting behavior
- When peeking into a FSEQ file, it reduces the initial read to 8 bytes from 48. 8 bytes ensures it only loads the necessary fields (format identifier, version fields and channel data offset) instead of the full header plus garbage data. As it did previously, the code still does an additional read for the full header once it has validated the initial 8 byte peek. Reading up to 48 instead of simply 8 isn't useful since it re-seeks back to index 0 and re-reads, and there is still fadvise calls for the initial 1kb of the file.
- Fixes a DumpHeader error where it was using a previous buffer but an updated bytesRead value.
- Tightens writePos validation to match the exact value instead of a less than comparison.