### PR TITLE
fix: incorrect variable code in FSEQ format docs

### DIFF
--- a/docs/FSEQ_Sequence_File_Format.txt
+++ b/docs/FSEQ_Sequence_File_Format.txt
@@ -56,8 +56,8 @@ Variable Length Headers in FSEQ  spec
   - 'sp' - Sequence Producer
     vh[0] = low byte of variable header length
     vh[1] = high byte of variable header length
-    vh[2] = 'm'
-    vh[3] = 'f'
+    vh[2] = 's'
+    vh[3] = 'p'
     vh[4-Len] = NULL terminated string of producer of the fseq file
                ex: "xLights Macintosh 2019.22"
 


### PR DESCRIPTION
`docs/FSEQ_Sequence_File_Format.txt` accidentally has the 2 byte code for `sp` (Sequence Producer) set to `mf`. Looks like a simple copy/paste error from the above mf (media filename) example.