### PR TITLE
Increase panel width limit from 16 to 24 for Colorlight

### DIFF
--- a/src/channeloutput/PanelMatrix.h
+++ b/src/channeloutput/PanelMatrix.h
@@ -30,7 +30,7 @@
 #include "ColorOrder.h"
 
 #define MAX_MATRIX_OUTPUTS    12
-#define MAX_PANELS_PER_OUTPUT 16
+#define MAX_PANELS_PER_OUTPUT 24
 #define MAX_MATRIX_PANELS    (MAX_MATRIX_OUTPUTS * MAX_PANELS_PER_OUTPUT)
 
 typedef struct ledPanel {

--- a/www/co-ledPanels.php
+++ b/www/co-ledPanels.php
@@ -452,7 +452,7 @@ function InitializeLEDPanels()
 			(channelOutputsLookup["LEDPanelMatrix"].subType == 'LinsnRv9'))
 		{
 			LEDPanelOutputs = 12;
-			LEDPanelPanelsPerOutput = 16;
+			LEDPanelPanelsPerOutput = 24;
 		}
     }
 


### PR DESCRIPTION
Change has been tested on 18 panel wide Colorlight matrix, 24 is an arbitrary number, much like 16 was.