### PR TITLE
Account for long names of SSIDs

### DIFF
--- a/www/networkconfig.php
+++ b/www/networkconfig.php
@@ -145,7 +145,7 @@ function printTetheringInterfaces() {
     PrintSettingSelect("Tether Interface", "TetherInterface", 0, 1, $tiface, $tinterfaces);
 }
 function printWifiNetworks() {
-    $networksRaw = explode("\n",trim(shell_exec("connmanctl services  | colrm 1 4")));
+    $networksRaw = explode("\n",trim(shell_exec("connmanctl services | grep wifi | perl -nle 'm/\s+(.*)\s+wifi_.*/; print $1 if $1'")));
     echo "<datalist id='eth_ssids'>\n";
     foreach ($networksRaw as $iface) {
         $if2 = explode(" ", $iface);


### PR DESCRIPTION
The current SSID search tool assumes that SSID names are nicely formatted into columns separated by spaces.  This change will use a perl regex one liner to address that.  

Proposed fix for https://github.com/FalconChristmas/fpp/issues/855