### PR TITLE
New Script to Power On/Off a Supported HDMI Device via CEC

### DIFF
--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -409,7 +409,7 @@ case "${OSVER}" in
                       libavcodec-dev libavformat-dev libswresample-dev libswscale-dev libavdevice-dev libavfilter-dev libtag1-dev \
                       vorbis-tools libgraphicsmagick++1-dev graphicsmagick-libmagick-dev-compat libmicrohttpd-dev \
                       libmosquitto-dev mosquitto-clients mosquitto libzstd-dev lzma zstd gpiod libgpiod-dev libjsoncpp-dev libcurl4-openssl-dev \
-                      fonts-freefont-ttf flex bison pkg-config libasound2-dev"
+                      fonts-freefont-ttf flex bison pkg-config libasound2-dev cec-utils"
 
         if [ "$FPPPLATFORM" == "Raspberry Pi" -o "$FPPPLATFORM" == "BeagleBone Black" ]; then
             PACKAGE_LIST="$PACKAGE_LIST firmware-realtek firmware-atheros firmware-ralink firmware-brcm80211 firmware-iwlwifi firmware-libertas firmware-zd1211 firmware-ti-connectivity python-daemon python-smbus"

--- a/scripts/cec-power-off.sh
+++ b/scripts/cec-power-off.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "standby 0" | cec-client -s

--- a/scripts/cec-power-on.sh
+++ b/scripts/cec-power-on.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "on 0" | cec-client -s


### PR DESCRIPTION
Adding two scripts that will power on and off a HDMI connected device if it supports CEC.  This is the same protocol that Chromecasts, FireTV, Receivers, and many other components use.