### PR TITLE
Add */playlist/sequence/secondsTotal MQTT message

### DIFF
--- a/docs/MQTT.txt
+++ b/docs/MQTT.txt
@@ -22,6 +22,7 @@ FPP will published the following sub_topics (using the full topic format) if MQT
 */playlist/section/status - either “New”, “LeadIn”, “MainPlayList”, “LeadOut”, or {null} if nothing playing
 */playlist/sectionPosition/status - The numeric position of the item currently playing in the playlist section (zero based)
 */playlist/sequence/status - Name of current sequence file playing. Can be {null}.
+*/playlist/sequence/secondsTotal - The duration of the current sequence file playing, in seconds.  Can be {null}.
 
 */playlist/media/title - Title of the audio / video media being displayed
 */playlist/media/status - filename of the current audio/movie

--- a/src/playlist/PlaylistEntrySequence.cpp
+++ b/src/playlist/PlaylistEntrySequence.cpp
@@ -96,8 +96,14 @@ int PlaylistEntrySequence::StartPlaying(void)
     m_startTme = GetTimeMS();
     LogDebug(VB_PLAYLIST, "Started Sequence, ID: %s\n", m_sequenceName.c_str());
 
-	if (mqtt)
+	if (mqtt) {
 		mqtt->Publish("playlist/sequence/status", m_sequenceName);
+		if (m_duration > 0) {
+			mqtt->Publish("playlist/sequence/secondsTotal", m_duration / 1000);
+		} else {
+			mqtt->Publish("playlist/sequence/secondsTotal", "");
+		}
+	}
 
 	return PlaylistEntryBase::StartPlaying();
 }
@@ -111,8 +117,10 @@ int PlaylistEntrySequence::Process(void)
 		FinishPlay();
         m_prepared = false;
 
-		if (mqtt)
+		if (mqtt) {
 			mqtt->Publish("playlist/sequence/status", "");
+			mqtt->Publish("playlist/sequence/secondsTotal", "");
+		}
     } else if (m_adjustTiming) {
         long long now = GetTimeMS();
         int total = (now - m_startTme);
@@ -132,8 +140,10 @@ int PlaylistEntrySequence::Stop(void)
     
 	sequence->CloseSequenceFile();
     m_prepared = false;
-	if (mqtt)
+	if (mqtt) {
 		mqtt->Publish("playlist/sequence/status", "");
+		mqtt->Publish("playlist/sequence/secondsTotal", "");
+	}
 
 	return PlaylistEntryBase::Stop();
 }


### PR DESCRIPTION
This change adds a */playlist/sequence/secondsTotal MQTT message which is populated with the duration of the current sequence identified in */playlist/sequence/status.  Value defaults to empty if no sequence is playing.

I have been using FPP's MQTT messages to support an [ESP8266 based "press for music"](https://github.com/tygunn/PressForMusic) sign which activates outdoor speakers for the duration of a user specified number of songs.  It works great, however it would be useful to know the duration of the sequence for things like pulsing a "time is almost up" warning light, etc.

The periodic publishing of the detailed playlist does work, however I find it ends up being a bit chatty for a simple use-case like this.