### PR TITLE
Add docker-compose.yml

### DIFF
--- a/Docker/Dockerfile.node
+++ b/Docker/Dockerfile.node
@@ -1,0 +1,5 @@
+FROM node:latest
+
+WORKDIR /opt/fpp/www
+RUN npm install -g gulp ; \
+    npm install

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -21,3 +21,11 @@ services:
       - "4048:4048/udp"
       - "5568:5568/udp"
       - "32320:32320/udp"
+
+  node:
+    build:
+      context: ../
+      dockerfile: ./Docker/Dockerfile.node
+    command: "gulp watch"
+    volumes:
+      - ../:/opt/fpp

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+
+# The `context` and 'volumes' directives are relative to THIS directory, while
+# the `dockerfile` directive is relative to the `context` directory.  For best
+# results, run the `docker-compose` command in the fpp/ root directory.
+#
+# fpp> docker-compose -f Docker/docker-compose.yml up
+
+services:
+  fpp:
+    build:
+      args:
+        - "EXTRA_INSTALL_FLAG=--skip-clone"
+      context: ../
+      dockerfile: ./Docker/Dockerfile
+    hostname: fpp-docker
+    volumes:
+      - ../:/opt/fpp
+    ports:
+      - "80:80/tcp"
+      - "4048:4048/udp"
+      - "5568:5568/udp"
+      - "32320:32320/udp"


### PR DESCRIPTION
Add `docker-compose.yml` and additional Dockerfiles to assist in local development.

The `fpp` container is the running container for the application and ui, while the `node` container is just for running `gulp watch` to reprocess the `scss` files.

Environment can be brought up with the following from the main `fpp/` directory.

```
docker-compose -f Docker/docker-compose.yml up
```

Sample logs:
```
❯ docker-compose -f Docker/docker-compose.yml up
Starting docker_fpp_1    ... done
Recreating docker_node_1 ... done
Attaching to docker_node_1, docker_fpp_1
fpp_1   | FPP - Setting up for the Falcon Player on the Debian platform
fpp_1   | FPP - Checking for required directories
fpp_1   | FPP - Clearing reboot flags
fpp_1   | FPP - Setting max IGMP memberships
fpp_1   | AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 172.18.0.3. Set the 'ServerName' directive globally to suppress this message
node_1  | [20:02:43] Using gulpfile /opt/fpp/www/gulpfile.js
node_1  | [20:02:43] Starting 'watch'...
node_1  | [20:02:52] Starting 'styles'...
node_1  | [20:02:52] Starting 'sass'...
node_1  | [20:02:54] Finished 'sass' after 1.52 s
node_1  | [20:02:54] Starting 'minifycss'...
node_1  | [20:02:55] Finished 'minifycss' after 881 ms
node_1  | [20:02:55] Finished 'styles' after 2.41 s
```