### PR TITLE
Settings Grid 

### DIFF
--- a/www/common.php
+++ b/www/common.php
@@ -221,7 +221,7 @@ function PrintSetting($setting, $callback = '', $options = Array(), $plugin = ''
         LoadPluginSettingInfos($plugin);
 
     if (!isset($settingInfos[$setting])) {
-        echo "<div class='tr'><div class='td td-colspan-2' colspan='2'><b>Invalid Setting: $setting</b></div></div>\n";
+        echo "<div class='row'><div class='td td-colspan-2' colspan='2'><b>Invalid Setting: $setting</b></div></div>\n";
         return;
     }
 
@@ -257,9 +257,9 @@ function PrintSetting($setting, $callback = '', $options = Array(), $plugin = ''
         $suffix = isset($s['suffix']) ? $s['suffix'] : '';
 
         if ($textOnRight)
-            echo "<div class='tr' id='" . $setting . "Row'><div class='td'>";
+            echo "<div class='row' id='" . $setting . "Row'><div class='col-lg'>";
         else
-            echo "<div class='tr' id='" . $setting . "Row'><div class='th'><span>" . $s['description'] . ":</span></div><div class='td'>";
+            echo "<div class='row' id='" . $setting . "Row'><div class='col-lg'><div class='description'>" . $s['description'] . ":</div></div><div class='col-lg'>";
 
         switch ($s['type']) {
             case 'select':
@@ -397,7 +397,7 @@ function PrintSettingGroup($group, $appendData = "", $prependData = "", $indent 
          (in_array('ALL', $g['platforms'])) ||
          (in_array($settings['Platform'], $g['platforms'])))) {
         echo "<h2>" . $g['description'] . "</h2>\n";
-        echo "<div class='settingsTable ";
+        echo "<div class='container settingsTable ";
 
         if ($indent)
             echo "settingsGroupTable'>\n";
@@ -405,10 +405,10 @@ function PrintSettingGroup($group, $appendData = "", $prependData = "", $indent 
             echo "'>\n";
 
         if ($prependData != "") {
-            if (preg_match("/<div class=tr>/", $prependData))
+            if (preg_match("/<div class=row>/", $prependData))
                 echo $prependData;
             else
-                echo "<div class=tr><div class='th' colspan=2>$prependData</div></div>\n";
+                echo "<div class=row><div class='col-lg' colspan=2>$prependData</div></div>\n";
         }
 
         foreach ($g['settings'] as $setting) {
@@ -419,10 +419,10 @@ function PrintSettingGroup($group, $appendData = "", $prependData = "", $indent 
         }
 
         if ($appendData != "") {
-            if (preg_match("/<div class=tr>/", $appendData))
+            if (preg_match("/<div class=row>/", $appendData))
                 echo $appendData;
             else
-                echo "<div class=tr><div class='th' colspan=2>$appendData</div></div>\n";
+                echo "<div class=row><div class='col-lg' colspan=2>$appendData</div></div>\n";
         }
 
         echo "</div><br>\n";

--- a/www/common.php
+++ b/www/common.php
@@ -259,7 +259,7 @@ function PrintSetting($setting, $callback = '', $options = Array(), $plugin = ''
         if ($textOnRight)
             echo "<div class='row' id='" . $setting . "Row'><div class='col-lg'>";
         else
-            echo "<div class='row' id='" . $setting . "Row'><div class='col-lg'><div class='description'>" . $s['description'] . ":</div></div><div class='col-lg'>";
+            echo "<div class='row' id='" . $setting . "Row'><div class='col-lg'><div class='description'>" . $s['description'] . "</div></div><div class='col-lg'>";
 
         switch ($s['type']) {
             case 'select':

--- a/www/css/fpp-bootstrap/src/_variables.scss
+++ b/www/css/fpp-bootstrap/src/_variables.scss
@@ -342,12 +342,11 @@ $hr-margin-y:                 $spacer !default;
 //
 // Shared variables that are reassigned to `$input-` and `$btn-` specific variables.
 
-$input-btn-padding-y:         .675rem !default;
+$input-btn-padding-y:         .33rem !default;
 $input-btn-padding-x:         1rem !default;
 $input-btn-font-family:       null !default;
 $input-btn-font-size:         $font-size-base !default;
 $input-btn-line-height:       $line-height-base !default;
-
 
 $input-btn-focus-width:         .25rem !default;
 $input-btn-focus-color-opacity: .25 !default;

--- a/www/css/fpp-bootstrap/src/fpp-bootstrap.scss
+++ b/www/css/fpp-bootstrap/src/fpp-bootstrap.scss
@@ -388,13 +388,14 @@ background: linear-gradient(90deg, $gray-100 0%, $gray-300 39%, $gray-300 57%, $
     background-color: $gray-light;
 }
 
-div.settingsTable{
-    display: flex;
+div.settingsTable div.row {
+    margin-top: .33em;
 }
-#settingsManagerTabsContent div.settingsTable{
-    flex-direction: column;
-    align-items: flex-start;
+
+div.settingsTable div.description {
+    margin-top: 10px;
 }
+
 div.settingsTable div.td, div.settingsTable div.th{
     margin-left: 1em;
     margin-right: 1em;
@@ -547,4 +548,8 @@ $fppTableExtraPadding:1.1em;
 
 .modal-dialog{
     margin-top:70px;
+}
+
+#settingsManagerTabsContent #ClockDate, #settingsManagerTabsContent #ClockTime {
+    width: 8em;
 }

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -935,37 +935,43 @@ body .sm-clean a .sub-arrow {
 	background-color: #F63939;
 	color: #fff !important;
   }
-  
-  .nav-link{
-	  text-decoration: none;
+
+  .nav-link {
+	text-decoration: none;
+    padding: 0.6rem 1em;
+  }
+
+  .nav-pills li {
+	margin-top: .2em;
+	text-align: center;
   }
 
   @media all and (max-width: 991px) {
 
  	.header{
 		padding-right:56px;
-	} 
+	}
 
 	[class*="navbar-expand-"]>.container,
 	[class*="navbar-expand-"]>.container-fluid {
 	  padding-left: 15px;
 	  padding-right: 15px;
 	}
-  
+
 	.dropdown-menu.show .dropdown-item.open+.dropdown-menu.show {
 	  right: 101% !important;
 	}
-  
+
 	.dropdown-menu.show .dropdown-item.open+.dropdown-menu.show .dropdown-item.open+.dropdown-menu,
 	.dropdown-menu.show .dropdown-item.open+.dropdown-menu.show .dropdown-item.open+.dropdown-menu.show {
 	  left: -165px !important;
 	}
-  
+
 	.navbar .navbar-collapse .navbar-nav>li.button-container {
 	  padding: 15px;
 	}
- 
-  
+
+
 	.navbar-collapse {
 	  position: fixed;
 	  display: block;

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -715,6 +715,10 @@ border-top-color: transparent;
     padding-left: 6px;
     padding-bottom: 6px;
 }
+div.settingsTable img.icon-help {
+	margin-top: 6px;
+}
+
 #footer{
 	position: relative;
 	text-align: center;
@@ -1511,11 +1515,6 @@ input[type=search].tablesorter-filter:disabled{
 }
 #CopyFlagsTable input {
 	margin: 0.4em;
-}
-.settingsManagerTimeContent{
-    display: flex;
-    flex-direction: row-reverse;
-	justify-content: flex-end;
 }
 
 @media(max-width:480px){

--- a/www/settings-playback.php
+++ b/www/settings-playback.php
@@ -3,11 +3,6 @@ $skipJSsettings = 1;
 require_once('common.php');
 ?>
 
-<table class='settingsTableWrapper'>
-    <tr><td>
 <?
 PrintSettingGroup('generalPlayback');
 ?>
-        </td>
-    </tr>
-</table>

--- a/www/settings-time.php
+++ b/www/settings-time.php
@@ -16,20 +16,11 @@ function GetTimeZone() {
 </script>
 
 <div class="settingsManagerTimeContent">
-    <div id="playerTime" class="statusTable d-flex">
-        <div>
-            <div class="labelHeading">FPP Time:</div>
-            <div id="currentTime" class="labelValue"></div>
-        </div>
-    </div>
-    <div>
         <?
         $extraData = "<input type='button' class='buttons' value='Lookup Time Zone' onClick='GetTimeZone();'>";
-        PrintSettingGroup('time', $extraData);
+        $prependData = "<div class='row'><div class='col-lg'><div>Current System Time</div></div><div id='currentTime' class='col-xl labelValue disabled'></div></div>";
+        PrintSettingGroup('time', $extraData, $prependData);
         ?>
-    </div>
-
-
 </div>
 
 <script>


### PR DESCRIPTION
To begin with Grid transition, only the Settings pages were updated.  I'm hoping with a successful review, I can move on to other pages to make consistent.

**Added**
* bootstrap `container`s and `row`s to the setting pages.

**Changed**
* `span` to `div` for settings descriptions so they respect `margin-top`
* halved padding for buttons globally.  buttons are ~20% smaller across interface.
* made ClockDate and ClockTime input widths consistent (that was bothering me)
* Current Time is now in the Time Config table to benefit from styling.

**Removed**
* `table`s
* colons after description

![image](https://user-images.githubusercontent.com/387006/108012785-45d2e400-6fd8-11eb-870f-53b37261622c.png)
