### PR TITLE
add .d-value class for hiding elements on small screens

### DIFF
--- a/www/css/fpp-bootstrap/src/fpp-bootstrap.scss
+++ b/www/css/fpp-bootstrap/src/fpp-bootstrap.scss
@@ -17,6 +17,7 @@
 @import "../../../node_modules/bootstrap/scss/button-group";
 @import "../../../node_modules/bootstrap/scss/nav";
 @import "../../../node_modules/bootstrap/scss/utilities/text";
+@import "../../../node_modules/bootstrap/scss/utilities/display";
 @import "../../../node_modules/bootstrap/scss/navbar";
 @import "../../../node_modules/bootstrap/scss/card";
 @import "../../../node_modules/bootstrap/scss/badge";


### PR DESCRIPTION
Hide elements on smaller screens without changing structure.

https://getbootstrap.com/docs/4.6/utilities/display/