### PR TITLE
Replaced a strcpy call by strncpy in src/command.c

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -128,7 +128,9 @@ char *ProcessCommand(char *command, char *response)
     char CommandStr[64];
     LogExcess(VB_COMMAND, "CMD: %s\n", command);
     s = strtok(command,",");
-    strcpy(CommandStr, s);
+    strncpy(CommandStr, s, sizeof(CommandStr)); //s can be 256 bytes long
+    CommandStr[sizeof(CommandStr)-1] = '\0';
+	
     if (!strcmp(CommandStr, "s")) {
         NextPlaylist = scheduler->GetNextPlaylistName();
         NextPlaylistStart = scheduler->GetNextPlaylistStartStr();


### PR DESCRIPTION
In line 131, a potentially 256 bytes buffer was copied into a 64 bytes buffer. This would have led to a buffer overflow.
For further explanations please refer to https://huntr.dev/bounties/25-other-FalconChristmas/fpp/