### PR TITLE
Attempted fix on downloading settings backup as JSON

### DIFF
--- a/www/backup.php
+++ b/www/backup.php
@@ -1,4 +1,7 @@
 <?php
+//Stop config.php spitting out any JS used in the UI, not needed on the backup page, if unset the JSON download will have the <script> tag in it due to
+//that data already being in the buffer
+$skipJSsettings = 1;
 //error_reporting(E_ALL);
 //ini_set('display_errors', 1);
 


### PR DESCRIPTION
Try to fix issue where when trying to download a settings backup just shows the JSON data in the browser instead of triggering it to be downloaded as a file

