### PR TITLE
Updated JSON Backup to support plugins with multi config files

### DIFF
--- a/www/backup_locations.json
+++ b/www/backup_locations.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "fpp-arcade": {
+      "joysticks.json": "/home/fpp/media/config/joysticks.json"
+    }
+  }
+}

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -215,6 +215,26 @@ body .ui-tabs .ui-tabs-nav li {
 
 }
 
+#backuparea, #restorearea {
+	width: 100%;
+}
+
+select#backup\.Direction {
+	width: 70%;
+}
+
+input#backup\.Path {
+	width: 70%;
+}
+
+input#MultiSyncExtraRemotes {
+	width: 100%;
+}
+
+input#MultiSyncHTTPSubnets {
+	width: 100%;
+}
+
 @media(max-width:990px){
 	.fppBrand .versionHead{
 		display: none;
@@ -483,7 +503,8 @@ body.has-touch .pageContent-tabs{
   background-repeat: no-repeat;
   background-attachment: local, scroll;
   background-size: 100% 100%, 0.75em 100%;
-  height: 100%;
+	min-height: 36px;
+  /*height: 100%;*/
 }
 body.has-touch .pageContent-tabs>.nav-item{
 	display: inline-block;


### PR DESCRIPTION
The JSON Settings backup system makes some assumptions about what the plugin config file will be (using a known naming convention) and it's not possible to know if they have additional configuration files if they have any.

For the time being a simple map of what additional files belong to a plugin. Hopefully this can be improved down the track, maybe plugins can list somewhere what configuration files they use and we can just read them in. 
Just so we don't have we don't have to maintain this map.

Bumped up backup version so we can differentiate different plugin config restore methods (v4 now captures the config filename, v3 generates through naming convention).

CSS: Made some teeny tiny tweaks to solve some small layout issues.

Fixes #1032 , #1030