### PR TITLE
Initalise deDuplicate to be sure that it's default is the same as the…

### DIFF
--- a/src/channeloutput/UDPOutput.h
+++ b/src/channeloutput/UDPOutput.h
@@ -101,7 +101,7 @@ public:
 protected:
     void SaveFrame(unsigned char* channelData, int len);
     bool NeedToOutputFrame(unsigned char* channelData, int startChannel, int savedIdx, int count);
-    bool deDuplicate = 0;
+    bool deDuplicate = false;
     int skippedFrames;
     unsigned char* lastData;
 };

--- a/src/channeloutput/UDPOutput.h
+++ b/src/channeloutput/UDPOutput.h
@@ -101,7 +101,7 @@ public:
 protected:
     void SaveFrame(unsigned char* channelData, int len);
     bool NeedToOutputFrame(unsigned char* channelData, int startChannel, int savedIdx, int count);
-    bool deDuplicate;
+    bool deDuplicate = 0;
     int skippedFrames;
     unsigned char* lastData;
 };


### PR DESCRIPTION
… UI rather than whatever is in memory.