### PR TITLE
Updated JSON Backup to gather extra JSON config files & network inter…

### DIFF
--- a/www/backup_locations.json
+++ b/www/backup_locations.json
@@ -1,7 +1,0 @@
-{
-  "plugins": {
-    "fpp-arcade": {
-      "joysticks.json": "/home/fpp/media/config/joysticks.json"
-    }
-  }
-}


### PR DESCRIPTION
Updated the JSON settings backup system to gather and pull in any extra JSON config files found in the /config folder, some filtering is done so that we don't pull in any config files which are already mapped to know areas (eg say Command Presets).

This change should enable the system to be a little more capable and dynamic in handling config files we may not know about.
Extra checks are also done to ensure the file contents is actually JSON just to be sure.

Updated backing up of network interfaces, a similar approach to pulling in extra JSON files is taken so that all configured interfaces are backed up, so users with extra USB Ethernet or WiFi interfaces will have configs backed up correctly now.

Users who are relying on the JSON backup system should be prompted (maybe via release notes) to generate/download a new backup after this change tested & goes out, just so they have a good backup source (without any missing settings).


fixes #1088 
fixes #1077 
fixes #1032 