### PR TITLE
Additional MQTT Commands

### DIFF
--- a/docs/MQTT.txt
+++ b/docs/MQTT.txt
@@ -100,3 +100,6 @@ There are also Playlist specific topics. Currently, ${PLAYLIST} is ignored for a
 * playlist/${PLAYLISTNAME}/stop/graceful - gracefully stop playlist
 * playlist/${PLAYLISTNAME}/stop/afterloop - Allow playlist to finish current loop then stop.
 
+These are system commands for specific
+* system/fppd/stop - Stops the fppd process (Will also kill the MQTT listener!)
+* system/fppd/restart - Executes a Fast restart on the fppd process. (Reloads all settings.) 

--- a/docs/MQTT.txt
+++ b/docs/MQTT.txt
@@ -103,3 +103,5 @@ There are also Playlist specific topics. Currently, ${PLAYLIST} is ignored for a
 These are system commands for specific
 * system/fppd/stop - Stops the fppd process (Will also kill the MQTT listener!)
 * system/fppd/restart - Executes a Fast restart on the fppd process. (Reloads all settings.) 
+* system/shutdown - Shuts down the OS
+* system/restart - Reboots the OS


### PR DESCRIPTION
Adds 4 more topics for controlling FPPD and system state.  The body of the message isn't important, just that the topic receives data. 

* system/fppd/stop - Stops the fppd process (Will also kill the MQTT listener!)
* system/fppd/restart - Executes a Fast restart on the fppd process. (Reloads all settings.) 
* system/shutdown - Shuts down the OS
* system/restart - Reboots the OS

Closes #1136
