### PR TITLE
Add new feature to Extend Schedule API. 

### DIFF
--- a/src/ScheduleEntry.cpp
+++ b/src/ScheduleEntry.cpp
@@ -296,7 +296,7 @@ void ScheduleEntry::pushStartEndTimes(int dow, int &delta, int deltaThreshold) {
     if (delta != 0) {
         // Only adjust if the threshold time is in the future
 	if (deltaThreshold > time(NULL)) {
-            if (deltaThreshold > startTime) {
+            if (deltaThreshold > startTime && startTime > time(NULL() {
                 startTime += delta;
             }
 

--- a/src/ScheduleEntry.cpp
+++ b/src/ScheduleEntry.cpp
@@ -269,7 +269,7 @@ static void mapTimeString(const std::string& tm, int& h, int& m, int& s) {
     s = atoi(sparts[2].c_str());
 }
 
-void ScheduleEntry::pushStartEndTimes(int dow) {
+void ScheduleEntry::pushStartEndTimes(int dow, int delta, int deltaThreshold) {
     time_t startTime = GetTimeOnDOW(dow, startHour, startMinute, startSecond);
     time_t endTime = GetTimeOnDOW(dow, endHour, endMinute, endSecond);
 
@@ -291,6 +291,20 @@ void ScheduleEntry::pushStartEndTimes(int dow) {
 
     if (!DateInRange(startTime, startDate, endDate)) {
         return;
+    }
+
+    if (delta != 0) {
+        // Only adjust if the threshold time is in the future
+	if (deltaThreshold > startTime && deltaThreshold > time(NULL)) {
+            startTime += delta;
+        }
+
+	if (deltaThreshold > endTime && deltaThreshold > time(NULL)) {
+            endTime += delta;
+        } else {
+            // if threshold time has passed, set delta back to 0
+          delta = 0;
+        }
     }
 
     if ((repeatInterval) && (startTime != endTime)) {

--- a/src/ScheduleEntry.cpp
+++ b/src/ScheduleEntry.cpp
@@ -295,7 +295,7 @@ void ScheduleEntry::pushStartEndTimes(int dow, int delta, int deltaThreshold) {
 
     if (delta != 0) {
         // Only adjust if the threshold time is in the future
-	if (deltaThreshold > startTime && deltaThreshold > time(NULL)) {
+	if (deltaThreshold > startTime && startTime > time(NULL) && deltaThreshold > time(NULL)) {
             startTime += delta;
         }
 

--- a/src/ScheduleEntry.cpp
+++ b/src/ScheduleEntry.cpp
@@ -295,7 +295,7 @@ void ScheduleEntry::pushStartEndTimes(int dow, int delta, int deltaThreshold) {
 
     if (delta != 0) {
         // Only adjust if the threshold time is in the future
-	if (deltaThreshold > startTime && startTime > time(NULL) && deltaThreshold > time(NULL)) {
+	if (deltaThreshold > startTime && deltaThreshold > time(NULL)) {
             startTime += delta;
         }
 

--- a/src/ScheduleEntry.h
+++ b/src/ScheduleEntry.h
@@ -46,7 +46,7 @@ public:
     int LoadFromString(std::string entryStr);
     int LoadFromJson(Json::Value& entry);
 
-    void pushStartEndTimes(int day);
+    void pushStartEndTimes(int day, int delta, int deltaThreshold);
 
     void GetTimeFromSun(time_t& when, bool setStart);
 

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -297,11 +297,11 @@ void Scheduler::AddScheduledItems(ScheduleEntry* entry, int index) {
 
         // Schedule yesterday if needed to handle midnight crossovers
         if (dayOffset)
-            entry->pushStartEndTimes(now.tm_wday - 1);
+            entry->pushStartEndTimes(now.tm_wday - 1,timeDelta,timeDeltaThreshold);
 
         // Schedule out 5 weeks
         for (int i = now.tm_wday + dayOffset; i <= 35 ; i += 2) {
-            entry->pushStartEndTimes(i);
+            entry->pushStartEndTimes(i,timeDelta,timeDeltaThreshold);
         }
 
         break;
@@ -309,30 +309,30 @@ void Scheduler::AddScheduledItems(ScheduleEntry* entry, int index) {
 
     // Special case if today is Sunday, handle any Saturday night crossovers
     if (now.tm_wday == 0)
-        entry->pushStartEndTimes(-1);
+        entry->pushStartEndTimes(-1,timeDelta,timeDeltaThreshold);
 
     if ((entry->dayIndex != INX_ODD_DAY) && (entry->dayIndex != INX_EVEN_DAY)) {
         for (int weekOffset = 0; weekOffset <= 28; weekOffset += 7) {
             if (dayIndex & INX_DAY_MASK_SUNDAY)
-                entry->pushStartEndTimes(INX_SUN + weekOffset);
+                entry->pushStartEndTimes(INX_SUN + weekOffset,timeDelta,timeDeltaThreshold);
 
             if (dayIndex & INX_DAY_MASK_MONDAY)
-                entry->pushStartEndTimes(INX_MON + weekOffset);
+                entry->pushStartEndTimes(INX_MON + weekOffset,timeDelta,timeDeltaThreshold);
 
             if (dayIndex & INX_DAY_MASK_TUESDAY)
-                entry->pushStartEndTimes(INX_TUE + weekOffset);
+                entry->pushStartEndTimes(INX_TUE + weekOffset,timeDelta,timeDeltaThreshold);
 
             if (dayIndex & INX_DAY_MASK_WEDNESDAY)
-                entry->pushStartEndTimes(INX_WED + weekOffset);
+                entry->pushStartEndTimes(INX_WED + weekOffset,timeDelta,timeDeltaThreshold);
 
             if (dayIndex & INX_DAY_MASK_THURSDAY)
-                entry->pushStartEndTimes(INX_THU + weekOffset);
+                entry->pushStartEndTimes(INX_THU + weekOffset,timeDelta,timeDeltaThreshold);
 
             if (dayIndex & INX_DAY_MASK_FRIDAY)
-                entry->pushStartEndTimes(INX_FRI + weekOffset);
+                entry->pushStartEndTimes(INX_FRI + weekOffset,timeDelta,timeDeltaThreshold);
 
             if (dayIndex & INX_DAY_MASK_SATURDAY)
-                entry->pushStartEndTimes(INX_SAT + weekOffset);
+                entry->pushStartEndTimes(INX_SAT + weekOffset,timeDelta,timeDeltaThreshold);
         }
     }
 
@@ -1018,6 +1018,14 @@ Json::Value Scheduler::GetSchedule() {
     return result;
 }
 
+void Scheduler::SetTimeDelta(int delta, int timeLimit) {
+    timeDelta = timeDelta + delta;
+    timeDeltaThreshold = time(NULL) + timeLimit;
+
+    // Trigger a reload the next time Scheduler::ScheduleProc() is called
+    m_loadSchedule = true;
+}
+
 class ScheduleCommand : public Command {
 public:
     ScheduleCommand(const std::string& str, Scheduler* s) :
@@ -1032,16 +1040,24 @@ class ExtendScheduleCommand : public ScheduleCommand {
 public:
     ExtendScheduleCommand(Scheduler* s) :
         ScheduleCommand("Extend Schedule", s) {
-        args.push_back(CommandArg("Seconds", "int", "Seconds").setRange(-12 * 60 * 60, 12 * 60 * 60).setDefaultValue("300").setAdjustable());
+        args.push_back(CommandArg("Seconds","int", "Extend for Seconds").setRange(-12 * 60 * 60, 12 * 60 * 60).setDefaultValue("300").setAdjustable());
+        args.push_back(CommandArg("Limit","int", "For schedule events occurring in the next x Seconds").setRange(-12 * 60 * 60, 12 * 60 * 60).setDefaultValue("0").setAdjustable());
     }
 
     virtual std::unique_ptr<Command::Result> run(const std::vector<std::string>& args) override {
-        if (args.size() != 1) {
-            return std::make_unique<Command::ErrorResult>("Command needs 1 argument, found " + std::to_string(args.size()));
+        if (args.size() < 1) {
+            return std::make_unique<Command::ErrorResult>("Command needs at least 1 argument, found " + std::to_string(args.size()));
         }
 
-        if (Player::INSTANCE.AdjustPlaylistStopTime(std::stoi(args[0])))
+        if (Player::INSTANCE.AdjustPlaylistStopTime(std::stoi(args[0]))) {
+            if (args.size() > 1) {
+                if (std::stoi(args[1]) != 0) {
+                    scheduler->SetTimeDelta(std::stoi(args[0]),std::stoi(args[1]));
+                }
+            }
+
             return std::make_unique<Command::Result>("Schedule Updated");
+	}
 
         return std::make_unique<Command::Result>("Error extending Schedule");
     }

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -97,6 +97,10 @@ public:
     void CheckIfShouldBePlayingNow(int ignoreRepeat = 0, int forceStopped = -1);
     void ReloadScheduleFile(void);
 
+    void SetTimeDelta(int delta, int timeLimit);
+    int timeDelta = 0;;
+    time_t timeDeltaThreshold = 0;
+
     std::string GetNextPlaylistName();
     std::string GetNextPlaylistStartStr();
 


### PR DESCRIPTION
You can now specify an optional 2nd parameter Limit - a number of seconds that will cause FPP to extend start/end times for all future schedules that fall within the next Limit seconds.

api/command/Extend Schedule/SECONDS[/LIMIT]

eg api/command/Extend Schedule/600/3600 will extend all start/end times due to occur within the next 1 hour by 10 minutes

Thanks to Captain Murdoch for his assistance with this feature.