### PR TITLE
add multi arch support to docker for both amd64 and arm64

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        
       # setup Docker buld action
       - name: Set up Docker Buildx
         id: buildx
@@ -62,6 +65,7 @@ jobs:
           context: .
           file: ./Docker/Dockerfile
           # Note: tags has to be all lower-case
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.IMAGE_REPOSITORY }}/fpp:${{ steps.extract_branch.outputs.branch }},${{ env.IMAGE_REPOSITORY }}/fpp:latest
           push: true
           cache-from: type=registry,ref=${{ env.IMAGE_REPOSITORY }}/fpp:master


### PR DESCRIPTION
Fixes #898 

Github workflow for Docker setup to build with qemu on arm64.   People should be able to do ```docker pull falconchristmas/fpp``` and it will automatically get the right image for their arch.

The first build of arm64 will take a couple hours because of the VLC compilation and that the apt upgrades for buster.  

Note: I had to duplicate the repo in order to test this because forks can't work with github secrets.  An official maintainer should verify the push to Dockerhub works after the build.  

Multi-arch test build that I verified runs on a Raspberry Pi.

here: https://hub.docker.com/layers/183007577/akutruff/fpp/test-latest/images/sha256-9561b84f59f3b54f761fc2f1d9a1e04f65b7792896b3138290bffa00dea8a40c?context=repo
