### PR TITLE
Pixel Strings: show details, more error info, import models from xLights

### DIFF
--- a/src/CapeUtils.cpp
+++ b/src/CapeUtils.cpp
@@ -341,7 +341,7 @@ static void copyFile(const std::string& src, const std::string& target) {
     while (true) {
         int l = read(s, buf, 256);
         if (l == -1) {
-            printf("Error copying file %s\n", strerror(errno));
+            printf("Error copying file %s - %s\n", src.c_str(), strerror(errno));
             close(s);
             close(t);
             return;
@@ -456,6 +456,7 @@ bool fpp_detectCape() {
         printf("Did not find eeprom on i2c.\n");
     }
     if (!file_exists(EEPROM)) {
+        printf("EEPROM file doesn't exist %s.\n", EEPROM.c_str());
         EEPROM = "/opt/fpp-vendor/cape-eeprom.bin";
     }
     if (!file_exists(EEPROM)) {
@@ -726,7 +727,7 @@ bool fpp_detectCape() {
             std::string resultStr = Json::writeString(wbuilder, result);
             put_file_contents("/home/fpp/media/tmp/cape-info.json", (const uint8_t*)resultStr.c_str(), resultStr.size());
         } else {
-            printf("Failed to parse cape-info.json\n");
+            printf("Failed to parse cape-info.json: %s\n", errors.c_str());
         }
     }
 

--- a/src/CapeUtils.cpp
+++ b/src/CapeUtils.cpp
@@ -331,9 +331,16 @@ static void copyFile(const std::string& src, const std::string& target) {
         printf("Failed to open src %s - %s\n", src.c_str(), strerror(errno));
         return;
     }
-    t = open(target.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
+
+    size_t fsep = target.find_last_of("/");
+    std::string target_fname = (fsep != std::string::npos)? target.substr(fsep + 1): target;
+    if (fsep != std::string::npos) mkdir(target.substr(0, fsep).c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH); //ensure target folder exists
+//        if (mkdir(path, mode) != 0 && errno != EEXIST)
+//    else if (!S_ISDIR(st.st_mode)) errno = ENOTDIR;
+
+    t = open(target_fname.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
     if (t == -1) {
-        printf("Failed to open target %s - %s\n", src.c_str(), strerror(errno));
+        printf("Failed to open target %s - %s\n", target.c_str(), strerror(errno));
         close(s);
         return;
     }

--- a/src/channeloutput/DPIPixels.cpp
+++ b/src/channeloutput/DPIPixels.cpp
@@ -416,12 +416,12 @@ bool DPIPixelsOutput::FrameBufferIsConfigured(void) {
                 if (longestString <= 800)
                     return true;
                 else
-                    errStr = m_outputType + " Framebuffer configured for 40fps but pixel count is to high.  Reboot is required.";
+                    errStr = m_outputType + " Framebuffer configured for 40fps but pixel count " + std::to_string(longestString) + " is too high.  Reboot is required.";
             } else if (vinfo.yres == 324) {
                 if (longestString <= 1600)
                     return true;
                 else
-                    errStr = m_outputType + " Framebuffer configured for 20fps but pixel count is to high.";
+                    errStr = m_outputType + " Framebuffer configured for 20fps but pixel count " + std::to_string(longestString) + " is too high.";
             }
         } else {
             return false;

--- a/www/co-pixelStrings.php
+++ b/www/co-pixelStrings.php
@@ -1749,7 +1749,13 @@ $(document).ready(function(){
                     
                         <input type='button' class="buttons" onClick='loadBBBOutputs();' value='Revert'>
                         <input type='button' class="buttons" onClick='cloneSelectedString();' value='Clone String'>
-                        <input type='button' class="buttons" onClick='importStrings();' value='Import Strings'>
+<? if ($uiLevel >= 3) { ?>
+<!--                            <input type='button' class="buttons" onClick='importStrings();' value='Import Strings'> -->
+			<span class="buttons" onClick='importStrings();'>
+                            <i class='fas fa-fw fa-code ui-level-3'></i>
+                            Import Strings
+                        </span>
+<? } ?>
                         <input type='button' class="buttons btn-success ml-1" onClick='saveBBBOutputs();' value='Save'>
                 </div>
             </div>
@@ -1883,4 +1889,3 @@ style="display: none;"
 <a name='capeNotes'></a>
 <span class='capeNotes' style='display: none;'><b>Cape Configuration Notes:</b><br></span>
 <span class='capeNotes' id='capeNotes' style='display: none;'></span>
-<style>

--- a/www/co-pixelStrings.php
+++ b/www/co-pixelStrings.php
@@ -572,23 +572,24 @@ function cloneSelectedString()
     
     var clones = prompt('How many strings to clone from selected string?', maxClone);
     
-    if (clones == null || clones == "")
+    if (clones == null || clones == "" || clones == 0)
         return;
     
     clones = parseInt(clones);
+    const dir = (clones < 0)? "prev": "next";
     
     var sDescription = row.find('.vsDescription').val();
     var sStartChannel = parseInt(row.find('.vsStartChannel').val()) || 1;
     var sPixelCount = parseInt(row.find('.vsPixelCount').val()) || 0;
-    var nextRow = row.closest('tr').next('tr');
+    var nextRow = row.closest('tr')[dir]('tr');
 
     if (nextRow.find('td.vsPortLabel').length == 0)
-        nextRow = nextRow.closest('tr').next('tr');
+        nextRow = nextRow.closest('tr')[dir]('tr');
     
 //    row.find('.vsDescription').val(sDescription + '0');
     const suffix = (sDescription.match(/(\d+)$/) || [])[1] || "0";
 
-    for (i = 0; i < clones; i++)
+    for (i = 0; i < Math.abs(clones); i++)
     {
         const oldname = nextRow.find(".vsDescription").val();
         setRowData(nextRow,
@@ -606,10 +607,10 @@ function cloneSelectedString()
                    row.find('.vsBrightness').val(),
                    row.find('.vsGamma').val());
         
-        nextRow = nextRow.closest('tr').next('tr');
+        nextRow = nextRow.closest('tr')[dir]('tr');
 
         if (nextRow.find('td.vsPortLabel').length == 0)
-            nextRow = nextRow.closest('tr').next('tr');
+            nextRow = nextRow.closest('tr')[dir]('tr');
     }
 }
 

--- a/www/uploadfile.php
+++ b/www/uploadfile.php
@@ -473,6 +473,8 @@ include 'menu.inc'; ?>
               <div class='form-actions'>
                 <input onclick="ClearSelections('Uploads');" class="buttons" type="button" value="Clear" />
                 <input onclick="ButtonHandler('Uploads', 'download');" class="disableButtons singleUploadsButton multiUploadsButton" type="button"  value="Download" />
+                <input onclick="ButtonHandler('Uploads', 'copyFile');" class="disableButtons singleUploadsButton" type="button"  value="Copy" />
+                <input onclick="ButtonHandler('Uploads', 'rename');" class="disableButtons singleUploadsButton" type="button"  value="Rename" />
                 <input onclick="ButtonHandler('Uploads', 'delete');" class="disableButtons singleUploadsButton multiUploadsButton" type="button"  value="Delete" />
               </div>
               <div class="note"><strong>CTRL+Click to select multiple items</strong></div>


### PR DESCRIPTION
- display file name, parse error details (helpful for diagnosing cape files)
- show virtual string details when click on a row (include estimated current drawn for real + null/off px)
- don't scroll table header
- default color order to "RGB"
- import xLights models (convert uploaded models to Pixel Strings), only show in Dev ui mode
- also changed string rename logic for Clone to not change suffix# if there is already one there, and allow reverse direction
- also add Copy, Rename buttons to Uploaded Files tab (very handy when dealing with multiple sets of xLights models)
- also show #pixels in log/error message when too high (helpful for debug)
- also create target copy-to folder if !exists, and show correct target file name if copyFile fails