### PR TITLE
Improve serial port detection for "other" channel outputs

### DIFF
--- a/www/co-other-modules.php
+++ b/www/co-other-modules.php
@@ -128,10 +128,9 @@ foreach (scandir("/dev/") as $fileName) {
 var SerialDevices = new Array();
 <?
 foreach (scandir("/dev/") as $fileName) {
-    if ((preg_match("/^ttyS[0-9]+/", $fileName)) ||
+    if ((preg_match("/^ttySC?[0-9]+/", $fileName)) ||
         (preg_match("/^ttyACM[0-9]+/", $fileName)) ||
         (preg_match("/^ttyO[0-9]/", $fileName)) ||
-        (preg_match("/^ttyS[0-9]/", $fileName)) ||
         (preg_match("/^ttyAMA[0-9]+/", $fileName)) ||
         (preg_match("/^ttyUSB[0-9]+/", $fileName))) {
         echo "SerialDevices['$fileName'] = '$fileName';\n";


### PR DESCRIPTION
This change aims to improve the filtration of serial ports as follows:

* Coalesce /^ttyS[0-9]/ and /^ttyS[0-9]+/ into /^ttyS[0-9]+/ as the latter will match everything that the former will.
* Match ttyS and ttySC prefixes for compatibility with the NXP SC16IS752 UART expander (such is used on the Waveshare 2ch RS485 HAT) by adjusting the above to /^ttySC?[0-9]+/ 

Screenshot of changes (on a Pi3B+ with a [Waveshare 2ch RS485 HAT ](https://www.amazon.com/2-Channel-RS485-HAT-Pi-Protection/dp/B081DL4D34/)attached) 
<img width="1536" alt="Screen Shot 2022-06-16 at 7 27 55 PM" src="https://user-images.githubusercontent.com/2483681/174199333-8af46995-06cb-49eb-85c7-0995da1ca456.png">
