### PR TITLE
Forces MAC address instead of DUID as DHCP client identifier - Fixes #1371

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -396,8 +396,16 @@ SetupFPPNetworkConfigViaSystemdNetworkd() {
             fi
         fi
         echo "" >> $TMPFILE
-        if [ "$ROUTEMETRIC" != "0" ]; then
+
+        if [ "$PROTO" == "dhcp" ]; then
             echo "[DHCPv4]" >> $TMPFILE
+            echo "ClientIdentifier=mac" >> $TMPFILE
+            echo "" >> $TMPFILE
+        fi
+        if [ "$ROUTEMETRIC" != "0" && "$PROTO" != "dhcp" ]; then
+            echo "[DHCPv4]" >> $TMPFILE
+        fi
+        if [ "$ROUTEMETRIC" != "0" ]; then
             echo "RouteMetric=${ROUTEMETRIC}" >> $TMPFILE
             echo "" >> $TMPFILE
             echo "[IPv6AcceptRA]" >> $TMPFILE


### PR DESCRIPTION
If an interface is configured using DHCP, this change will send the MAC Address as the DHCP client identifier, rather than a random DUID generated by Systemd. Issue was introduced with the Bullseye update, and breaks anyone who is using DHCP reservations based on MAC address.
