### PR TITLE
Change internet/Github availability checks due to ICMP being blocked …

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -46,7 +46,7 @@ all: gitsubmodules $(TARGETS)
 .PHONY: gitsubmodules
 ifneq '$(SUBMODULES)' ''
 gitsubmodules:
-	@! ping -q -c 1 github.com > /dev/null 2>&1 || (cd ..; \
+	@! curl -S -s -o /dev/null -m 2 https://github.com/FalconChristmas/fpp/blob/master/README.md 2>&1 || (cd ..; \
 		for submodule in $(SUBMODULES); do \
 			git submodule sync $$submodule; \
 		done; \

--- a/www/api/controllers/stats.php
+++ b/www/api/controllers/stats.php
@@ -73,7 +73,7 @@ function stats_network()
     $rc = array();
     $output = array();
 
-    exec("ping -c 1 -q -W 2 github.com", $output, $exitCode);
+    exec("curl -s -m 2 https://github.com/FalconChristmas/fpp/blob/master/README.md", $output, $exitCode);
     $rc['github_access'] = ($exitCode == 0 ? true : false);
 
     $rc['wifi'] = json_decode(file_get_contents("http://localhost/api/network/wifi/strength"), true);

--- a/www/troubleshootingCommands.php
+++ b/www/troubleshootingCommands.php
@@ -24,7 +24,7 @@ $commands = array(
     'Wireless' => '(iwconfig ; echo ; echo ; cat /proc/net/wireless)',
     'Routing' => 'netstat -rn',
     'Default Gateway' => 'ping -c 1 $(netstat -rn | grep \'^0.0.0.0\' | awk \'{print $2}\')',
-    'Internet Access' => 'ping -c 1 github.com',
+    'Internet Access' => 'curl -S -s -o /dev/null -m 2 https://github.com/FalconChristmas/fpp/blob/master/README.md 2>&1 ; if [ "$?" -eq "0" ]; then echo "GitHub reachable: **YES**" ; else echo "GitHub Reachable: ** NO **"; fi',
 
     // Disk
     'Block Devices' => $SUDO . ' lsblk -l',


### PR DESCRIPTION
…by GitHub

This now uses cURL to test for the README.md at the root of the GitHub repo. 
Note that due to the way GitHub does redirects on a 404 not found to a valid URL, there is no dependency on this file exiting in the repository, cURL will still exit with a zero exit code showing Github is accessible.