### PR TITLE
Add support for PCF8574 (non-A) to fix #1269

### DIFF
--- a/src/oled/I2C1602_2004_DisplayDriver.cpp
+++ b/src/oled/I2C1602_2004_DisplayDriver.cpp
@@ -8,6 +8,8 @@
 static constexpr int LED_TYPE_0x20_1602 = 11;
 static constexpr int LED_TYPE_0x3f_1602 = 12;
 static constexpr int LED_TYPE_0x3f_2004 = 13;
+static constexpr int LED_TYPE_0x27_PCF_1602 = 14;
+static constexpr int LED_TYPE_0x27_PCF_2004 = 15;
 
 static constexpr int RS_PIN = 0;
 static constexpr int RW_PIN = 1;
@@ -40,13 +42,13 @@ I2C1602_2004_DisplayDriver::I2C1602_2004_DisplayDriver(int lt) :
 I2C1602_2004_DisplayDriver::~I2C1602_2004_DisplayDriver() {
 }
 int I2C1602_2004_DisplayDriver::getWidth() {
-    if (ledType == LED_TYPE_0x20_1602 || ledType == LED_TYPE_0x3f_1602) {
+    if (ledType == LED_TYPE_0x20_1602 || ledType == LED_TYPE_0x3f_1602 || ledType == LED_TYPE_0x27_PCF_1602) {
         return 16 * 6;
     }
     return 20 * 6;
 }
 int I2C1602_2004_DisplayDriver::getHeight() {
-    if (ledType == LED_TYPE_0x20_1602 || ledType == LED_TYPE_0x3f_1602) {
+    if (ledType == LED_TYPE_0x20_1602 || ledType == LED_TYPE_0x3f_1602 || ledType == LED_TYPE_0x27_PCF_1602) {
         return 16;
     }
     return 32;
@@ -135,6 +137,10 @@ bool I2C1602_2004_DisplayDriver::initialize(int& i2cBus) {
         lineOffsets = lineOffsets0x20;
         blOffset = lineOffset0x20Backlight;
         BACKLIGHTONVALUE = 0;
+    }
+    if (ledType == LED_TYPE_0x27_PCF_1602 || ledType == LED_TYPE_0x27_PCF_2004) {
+        device = 0x27;
+        deviceType = "pcf8574";
     }
     i2cBus = findI2CDeviceBus(device);
     if (i2cBus == -1) {

--- a/www/settings.json
+++ b/www/settings.json
@@ -1060,9 +1060,11 @@
                 "128x64 Flipped I2C (SH1106)": 6,
                 "128x128 I2C (SSD1327)": 9,
                 "128x128 Flipped I2C (SSD1327)": 10,
-                "Adafruit 16x2 LCD": 11,
-                "PCF8574 16x2 LCD": 12,
-                "PCF8574 20x4 LCD": 13
+                "Adafruit 16x2 LCD (I2C 0x20)": 11,
+                "PCF8574A 16x2 LCD (I2C 0x3F)": 12,
+                "PCF8574A 20x4 LCD (I2C 0x3F)": 13,
+                "PCF8574 16x2 LCD (I2C 0x27)": 14,
+                "PCF8574 20x4 LCD (I2C 0x27)": 15
             }
         },
         "Locale": {


### PR DESCRIPTION
Also adds the i2c addresses to the existing 16x2 and 20x4 display drivers in the UI to differentiate between them.
Tested with both 20x4 and 16x2 displays as per photo below.

![image](https://user-images.githubusercontent.com/55641392/213599071-07abf36a-9e7a-4da6-a27d-83f78552270e.png)
