### PR TITLE
Misc fixes to Backups Page

### DIFF
--- a/www/api/controllers/backups.php
+++ b/www/api/controllers/backups.php
@@ -305,9 +305,9 @@ function MakeJSONBackup()
 		   $mediaDirectory, $eventDirectory, $playlistDirectory, $scriptDirectory, $settingsFile,
 		   $skipHTMLCodeOutput,
 		   $system_config_areas, $known_json_config_files, $known_ini_config_files,
-		   $backup_errors, $backup_error_string,
+		   $backup_errors, $backup_error_string, $backups_verbose_logging,
 		   $sensitive_data, $protectSensitiveData,
-		   $fpp_backup_version, $fpp_backup_prompt_download,
+		   $fpp_backup_version, $fpp_major_version, $fpp_backup_prompt_download,
 		   $fpp_backup_max_age, $fpp_backup_min_number_kept,
 		   $fpp_backup_location, $fpp_backup_location_alternate_drive;
 
@@ -371,11 +371,11 @@ function RestoreJsonBackup(){
 		   $mediaDirectory,$eventDirectory, $playlistDirectory, $scriptDirectory, $settingsFile, $scheduleFile, $fppDir,
 		   $skipHTMLCodeOutput,
 		   $system_config_areas, $known_json_config_files, $known_ini_config_files,
-		   $backup_errors,$backup_error_string,
+		   $backup_errors,$backup_error_string, $backups_verbose_logging,
 		   $keepMasterSlaveSettings, $keepNetworkSettings, $uploadData_IsProtected, $settings_restored,
 		   $network_settings_restored, $network_settings_restored_post_apply, $network_settings_restored_applied_ips,
 		   $sensitive_data, $protectSensitiveData,
-		   $fpp_backup_version, $fpp_backup_prompt_download,
+		   $fpp_backup_version, $fpp_major_version, $fpp_backup_prompt_download,
 		   $fpp_backup_max_age, $fpp_backup_min_number_kept,
 		   $fpp_backup_location, $fpp_backup_location_alternate_drive,
 		   $args;

--- a/www/api/endpoints.json
+++ b/www/api/endpoints.json
@@ -42,7 +42,7 @@
             "endpoint": "backups/configuration/list",
             "methods": {
                 "GET": {
-                    "desc": "Gets a list of JSON Configuration backups stored locally or if set Alternate Backup Device is set, a list of backups on local and USB",
+                    "desc": "Gets a list of JSON Configuration backups stored locally or if an Alternate Backup Device is set, a list of backups on local and USB",
                     "output": [
                         {
                             "backup_alternative_location": false,
@@ -99,88 +99,102 @@
             "endpoint": "backups/configuration/restore/:Directory/:BackupFilename",
             "methods": {
                 "POST": {
-                    "desc": "Restored the specified JSON Backup, Directory is either JsonBackups (local) or JsonAlternateBackup (configured alternate device). API backups/configuration/list can be used to get valid directories and files.",
+                    "desc": "Restored the specified JSON Backup, Directory is either JsonBackups (local) or JsonAlternateBackup (configured alternate device). API backups/configuration/list can be used to get valid directory and file combinations.",
                     "output": {
                         "success": true,
                         "message": {
-                            "channelInputs": {
-                                "ATTEMPT": true,
-                                "SUCCESS": true
-                            },
-                            "channelOutputs": {
-                                "universes": {
+                            "success": true,
+                            "message": {
+                                "channelInputs": {
+                                    "VALID_DATA": true,
                                     "ATTEMPT": true,
                                     "SUCCESS": true
                                 },
-                                "falcon_pixelnet_DMX": {
+                                "channelOutputs": {
+                                    "universes": {
+                                        "VALID_DATA": true,
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    },
+                                    "falcon_pixelnet_DMX": {
+                                        "VALID_DATA": true,
+                                        "ATTEMPT": true,
+                                        "SUCCESS": {
+                                            "Falcon.FPDV1": true
+                                        }
+                                    },
+                                    "pixel_strings": {
+                                        "VALID_DATA": true,
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    },
+                                    "led_panels": {
+                                        "VALID_DATA": true,
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    },
+                                    "other": {
+                                        "VALID_DATA": true,
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    }
+                                },
+                                "misc_configs": {
+                                    "configs": {
+                                        "VALID_DATA": false,
+                                        "SUCCESS": false
+                                    }
+                                },
+                                "outputProcessors": {
+                                    "VALID_DATA": true,
                                     "ATTEMPT": true,
                                     "SUCCESS": true
                                 },
-                                "pixel_strings": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": true
+                                "show_setup": {
+                                    "playlist": {
+                                        "VALID_DATA": true,
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    },
+                                    "schedule": {
+                                        "VALID_DATA": true,
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    },
+                                    "scripts": {
+                                        "VALID_DATA": true,
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    }
                                 },
-                                "led_panels": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": true
+                                "settings": {
+                                    "VALID_DATA": true,
+                                    "system_settings": {
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    },
+                                    "commandPresets": {
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    },
+                                    "proxies": {
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    },
+                                    "email": {
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    },
+                                    "timezone": {
+                                        "ATTEMPT": true,
+                                        "SUCCESS": true
+                                    }
                                 },
-                                "other": {
+                                "virtualEEPROM": {
+                                    "VALID_DATA": true,
                                     "ATTEMPT": true,
                                     "SUCCESS": true
                                 }
-                            },
-                            "misc_configs": {
-                                "configs": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": false
-                                }
-                            },
-                            "outputProcessors": {
-                                "ATTEMPT": true,
-                                "SUCCESS": true
-                            },
-                            "show_setup": {
-                                "events": {
-                                    "SUCCESS": false
-                                },
-                                "playlist": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": true
-                                },
-                                "schedule": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": true
-                                },
-                                "scripts": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": true
-                                }
-                            },
-                            "settings": {
-                                "system_settings": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": true
-                                },
-                                "commandPresets": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": true
-                                },
-                                "proxies": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": true
-                                },
-                                "email": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": true
-                                },
-                                "timezone": {
-                                    "ATTEMPT": true,
-                                    "SUCCESS": true
-                                }
-                            },
-                            "virtualEEPROM": {
-                                "ATTEMPT": true,
-                                "SUCCESS": true
                             }
                         }
                     }

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -2497,6 +2497,15 @@ input[type=search].tablesorter-filter:disabled {
 	transition-delay: 0.5s;
 }
 
+.host_rsyncd_warning {
+	font-size: 0.8em;
+	padding-left: 10px;
+}
+
+.host_rsyncd_warning b {
+	color: #F63939 !important;
+}
+
 #CopyFlagsTable input {
 	margin: 0.4em;
 }


### PR DESCRIPTION
All to do with the Backups or Backup Page:

- Added a warning next to the selected host if remote rsync service disabled on the File Copy Backup Page (To and From Remote FPP instances). The warning prompts the user to enable it under FPP Settings -> System -> OS Services on the affected host.
![image](https://user-images.githubusercontent.com/799998/215327518-8b76daa9-7a18-4b55-99f1-869e40d68706.png)

- Added an additional key 'VALID_DATA' to describe whether an area had valid data when restoring
- Changed how FPD/Falcon Pixlenet DMX data is stored in the backup, it's now keyed under the file it came from (Falcon.FPDV1, Falcon.F16V2) to try add initial support for future versions.
- Increased the number of JSON settings kept from 14 to 45 (automatic settings backups are generating more backups now)
- Removed dangling SUCCESS key where areas had no VALID_DATA or ATTEMPT was made, mostly around restoring show_setup
- Updated endpoints.json JSON Settings Restore API Endpoint with new JSON output describing what was restored
- Updated pruneOrRemoveAgedBackupFiles() housekeeping function to use API now as backups can exist over multiple media
