### PR TITLE
Update to new url and correct error in retrieving time from USNO

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -1163,7 +1163,9 @@ checkTimeAgainstUSNO() {
 
 		# allow clocks to differ by 24 hours to handle time zone differences
 		THRESHOLD=86400
-		USNOSECS=$(curl -m 10 -s -k https://www.usno.navy.mil/cgi-bin/time.pl | sed -e "s/.*\">//" -e "s/<\/t.*//" -e "s/...$//" -e "s/[^0-9]//g")
+        USNODATE=$(curl -v --silent https://nist.time.gov/ 2>&1 \ | grep '< Date' | sed -e 's/< Date: //')
+        USNOSECS=$(date -d "${USNODATE}" +%s)
+		
 
 		if [ "x${USNOSECS}" != "x" ]
 		then


### PR DESCRIPTION
Corrects this startup error:

./startup

FPP - Setting up for the Falcon Player on the Raspberry Pi platform
FPP: Checking local time against U.S. Naval Observatory
expr: syntax error: unexpected argument ‘13011’
expr: syntax error: unexpected argument ‘13011’
date: extra operand ‘13011’
Try 'date --help' for more information.
FPP: USNO Time  : 
FPP: Local Time : Sat 04 Feb 2023 09:51:26 PM GMT
/opt/fpp/scripts/functions: line 1182: [: -o: integer expression expected
FPP: Local Time is OK