### PR TITLE
File Copy Backup To Remote Host's USB Device

### DIFF
--- a/etc/rsyncd.conf
+++ b/etc/rsyncd.conf
@@ -10,3 +10,10 @@ uid = FPPUSER
 gid = FPPUSER
 hosts allow = 127.0.0.0/8 172.16.0.0/12 192.168.0.0/16 10.0.0.0/8
 
+[remote_filecopy]
+path = /mnt/remote_filecopy
+read only = no
+list = no
+uid = FPPUSER
+gid = FPPUSER
+hosts allow = 127.0.0.0/8 172.16.0.0/12 192.168.0.0/16 10.0.0.0/8

--- a/upgrade/76/upgrade.sh
+++ b/upgrade/76/upgrade.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#####################################
+## Add new rsync module into the rsync config that represents the mount location where USB device is mounted so that a remote host can put files here
+
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/../../scripts/common
+
+echo "
+[remote_filecopy]
+path = /mnt/remote_filecopy
+read only = no
+list = no
+uid = fpp
+gid = fpp
+hosts allow = 127.0.0.0/8 172.16.0.0/12 192.168.0.0/16 10.0.0.0/8
+
+" >> /etc/rsyncd.conf
+
+rsyncEnabled=$(getSetting Service_rsync)
+
+if [ "$rsyncEnabled" == 1 ]; then
+   service rsync restart
+fi
+

--- a/www/api/controllers/backups.php
+++ b/www/api/controllers/backups.php
@@ -163,15 +163,30 @@ function GetAvailableBackupsOnDevice()
  * @param $deviceName string The device to be mounted
  * @param $usercallback_function string The function we should call once mounting is completed so we can do something in the directory
  * @param $functionArgs array Order AND Number arguments MUST!! match the arguments required by the supplied user function
+ * @param $mountPath string Path/Folder where the device will be mounted, DEFAULT: /mnt/tmp
+ * @param $unmountWhenDone string Whether to automatically unmount the device when done
+ * @param $globalNameSpace string Whether to use 'nsenter' to mount the device under the root mount namespace
+ * @param $returnResultCodes string Whether to return output and result codes of the commands that were run
  * @return mixed|string
  */
-function DriveMountHelper($deviceName, $usercallback_function, $functionArgs = array())
+function DriveMountHelper($deviceName, $usercallback_function, $functionArgs = array(), $mountPath = '/mnt/tmp', $unmountWhenDone = true, $globalNameSpace = false, $returnResultCodes = false)
 {
 	global $SUDO;
 	$dirs = array();
+	$nsEnter = '';
+	$fsTypeOutput = $mountCmdOutput = $unmountCmdOutput = array();
+	$unmountCmdResultCode = null;
+
+	//Run commands so mount is available to entire system
+	if ($globalNameSpace === true) {
+		//Since Apache sandboxes all mount interactions and makes them private to the apache process(s)
+		//https://manpages.ubuntu.com/manpages/bionic/man1/nsenter.1.html
+		//Run commands under the root (process 1) mount namespace so the mounted device is available to the entire system
+		$nsEnter = ' nsenter -m -t 1 ';
+	}
 
 	// unmount just in case
-	exec($SUDO . ' umount /mnt/tmp');
+	exec($SUDO . $nsEnter . ' umount ' . $mountPath);
 
 	$unusable = CheckIfDeviceIsUsable($deviceName);
 	if ($unusable != '') {
@@ -179,30 +194,145 @@ function DriveMountHelper($deviceName, $usercallback_function, $functionArgs = a
 		return json($dirs);
 	}
 
-	exec($SUDO . ' mkdir -p /mnt/tmp');
+	exec($SUDO . $nsEnter . ' mkdir -p ' . $mountPath);
 
-	$fsType = exec($SUDO . ' file -sL /dev/' . $deviceName, $output);
+	$fsType = exec($SUDO . $nsEnter . ' file -sL /dev/' . $deviceName, $fsTypeOutput, $fsTypeResultCode);
 
 	$mountCmd = '';
 	// Same mount options used in scripts/copy_settings_to_storage.sh
 	if (preg_match('/BTRFS/', $fsType)) {
-		$mountCmd = "mount -t btrfs -o noatime,nodiratime,compress=zstd,nofail /dev/$deviceName /mnt/tmp";
+		$mountCmd = "mount -t btrfs -o noatime,nodiratime,compress=zstd,nofail /dev/$deviceName $mountPath";
 	} else if ((preg_match('/FAT/', $fsType)) ||
 		(preg_match('/DOS/', $fsType))) {
-		$mountCmd = "mount -t auto -o noatime,nodiratime,exec,nofail,uid=500,gid=500 /dev/$deviceName /mnt/tmp";
+		$mountCmd = "mount -t auto -o noatime,nodiratime,exec,nofail,uid=500,gid=500 /dev/$deviceName $mountPath";
 	} else {
 		// Default to ext4
-		$mountCmd = "mount -t ext4 -o noatime,nodiratime,nofail /dev/$deviceName /mnt/tmp";
+		$mountCmd = "mount -t ext4 -o noatime,nodiratime,nofail /dev/$deviceName $mountPath";
 	}
 
-	exec($SUDO . ' ' . $mountCmd);
+	exec($SUDO . $nsEnter . ' ' . $mountCmd, $mountCmdOutput, $mountCmdResultCode);
 
-	//Call the function that will do some work in the mounted directory
-	$dirs = call_user_func_array($usercallback_function, $functionArgs);
+	if (isset($usercallback_function) && !empty($functionArgs)) {
+		//Call the function that will do some work in the mounted directory
+		$dirs = call_user_func_array($usercallback_function, $functionArgs);
+	}
 
-	exec($SUDO . ' umount /mnt/tmp');
+	//Unmount by default before we finish
+	if ($unmountWhenDone === true) {
+		$umountCmd = exec($SUDO . $nsEnter . ' umount ' . $mountPath, $unmountCmdOutput, $unmountCmdResultCode);
+	}
+
+	//Return more detail about the what has happened with each command
+	if ($returnResultCodes === true) {
+		return (array('dirs' => $dirs,
+			'fsType' => array('fsTypeOutput' => $fsTypeOutput, 'fsTypeResultCode' => $fsTypeResultCode),
+			'mountCmd' => array('mountCmdOutput' => $mountCmdOutput, 'mountCmdResultCode' => $mountCmdResultCode, 'mountCmdResultCodeText' => MountReturnCodeMap($mountCmdResultCode), 'actualMountCmd' => $mountCmd),
+			'unmountCmd' => array('unmountCmdOutput' => $unmountCmdOutput, 'unmountCmdResultCode' => $unmountCmdResultCode),
+			'args' => array('mountPath' => '/mnt/tmp', 'unmountWhenDone' => $unmountWhenDone, 'globalNameSpace' => $globalNameSpace)
+		)
+		);
+	}
 
 	return ($dirs);
+}
+
+/**
+ * Mounts the specified device to the specified mount location /mnt/<MountLocation>, Defaults to /mnt/api_mount
+ * POST /backups/devices/mount/:DeviceName/:MountLocation
+ * @return string
+ */
+function MountDevice()
+{
+	$drive_mount_location = "/mnt/api_mount";
+	//get the device name
+	$deviceName = params('DeviceName');
+	$mountLocation = params('MountLocation');
+	//If a mount location was supplied, adjust the drive mount location to latch it
+	if (isset($mountLocation) && !empty($mountLocation)) {
+		$drive_mount_location = "/mnt/" . $mountLocation;
+	}
+
+	$mountResultCode = $mountResultCodeText = null;
+	$result = array();
+
+	//Make sure we have a valid device name supplied
+	if (isset($deviceName) && ($deviceName !== "no" || $deviceName !== "")) {
+		//Mount the device at the specified location
+		$mountResult = DriveMountHelper($deviceName, '', array(), $drive_mount_location, false, true, true);
+
+		//Check the relevant result code keys exist in the returned data
+		if (array_key_exists('mountCmd', $mountResult) && array_key_exists('mountCmdResultCode', $mountResult['mountCmd'])) {
+			$mountResultCode = $mountResult['mountCmd']['mountCmdResultCode'];
+			$mountResultCodeText = $mountResult['mountCmd']['mountCmdResultCodeText'];
+		}
+
+		//Success
+		if ($mountResultCode == 0) {
+			$result = array('Status' => 'OK', 'Message' => 'Device (' . $deviceName . ') mounted at (' . $drive_mount_location . ')', 'MountLocation' => $drive_mount_location);
+			//TODO REMOVE
+
+			error_log('MountDevice: ( ' . json($result) . ' )');
+		} else {
+			//Some kind of failure
+			$result = array('Status' => 'Error', 'Message' => 'Unable to mount device (' . $deviceName . ') under (' . $drive_mount_location . ')', 'MountLocation' => $drive_mount_location, 'Error' => $mountResultCodeText);
+			error_log('MountDevice: ( ' . json($result) . ' )');
+		}
+	} else {
+		$result = array('Status' => 'Error', 'Message' => 'Invalid Device Name Supplied');
+		error_log('MountDevice: ( ' . json($result) . ' )');
+	}
+
+	return json($result);
+}
+
+/**
+ * Unmounts the drive mounted to the supplied mount location e.g /mnt/<MountLocation>, Defaults to /mnt/api_mount
+ * POST /backups/devices/unmount/:DeviceName/:MountLocation
+ * @return string
+ */
+function UnmountDevice()
+{
+	global $SUDO;
+	$drive_mount_location = "/mnt/api_mount";
+	$nsEnter = ' nsenter -m -t 1 ';
+
+	//get the device name
+	$deviceName = params('DeviceName');
+	$mountLocation = params('MountLocation');
+	//If a mount location was supplied, adjust the drive mount location to latch it
+	if (isset($mountLocation) && !empty($mountLocation)) {
+		$drive_mount_location = "/mnt/" . $mountLocation;
+	}
+
+	$unmountCmdOutput = array();
+	$unmountCmdResultCode = null;
+
+	//Make sure we have a valid device name supplied
+	if (isset($deviceName) && ($deviceName !== "no" || $deviceName !== "")) {
+		//Unmount device from the root namespace (it will be mounted there)
+		$umountCmd = exec($SUDO . $nsEnter . ' umount ' . $drive_mount_location, $unmountCmdOutput, $unmountCmdResultCode);
+		//This could be incorrect as this result codes are for the mount command, but will give us an idea
+		$unmountCmdOutputText = MountReturnCodeMap($unmountCmdResultCode);
+
+		//Remove the folder that is created for the device to be mounted under
+		exec($SUDO . ' rmdir ' . $drive_mount_location);
+
+		//Success
+		if ($unmountCmdResultCode == 0) {
+			$result = array('Status' => 'OK', 'Message' => 'Device (' . $deviceName . ') unmounted from (' . $drive_mount_location . ')', 'MountLocation' => $drive_mount_location);
+			//TODO REMOVE
+			error_log('UnmountDevice: ( ' . json($result) . ' )');
+		} else {
+			//Some kind of failure
+			$result = array('Status' => 'Error', 'Message' => 'Unable to unmount device (' . $deviceName . ') from under (' . $drive_mount_location . ')', 'MountLocation' => $drive_mount_location, 'Error' => $unmountCmdOutputText);
+			error_log('UnmountDevice: ( ' . json($result) . ' )');
+		}
+	} else {
+		$result = array('Status' => 'Error', 'Message' => 'Invalid Device Name Supplied');
+		error_log('UnmountDevice: ( ' . json($result) . ' )');
+	}
+
+	return json($result);
 }
 
 ////
@@ -583,5 +713,32 @@ function DeleteJsonBackup(){
 function sort_backup_time_asc($a, $b)
 {
 	return $b['backup_time_unix'] - $a['backup_time_unix'];
+}
+
+/**
+ * Maps the mount commands return codes to text
+ * @param $returnCode
+ * @return string
+ */
+function MountReturnCodeMap($returnCode)
+{
+    if ($returnCode == 0) {
+        return 'success';
+    } else if ($returnCode == 1) {
+        return 'incorrect invocation or permissions';
+    } else if ($returnCode == 2) {
+        return 'system error (out of memory, cannot fork, no more loop devices)';
+    } else if ($returnCode == 4) {
+        return 'internal mount bug';
+    } else if ($returnCode == 8) {
+        return 'user interrupt';
+    } else if ($returnCode == 16) {
+        return 'problems writing or locking /etc/mtab';
+    } else if ($returnCode == 32) {
+        return 'mount failure';
+    } else if ($returnCode == 64) {
+        return 'some mount succeeded';
+    }
+    return 'unkown';
 }
 ?>

--- a/www/api/controllers/backups.php
+++ b/www/api/controllers/backups.php
@@ -523,7 +523,7 @@ function RestoreJsonBackup(){
 	$fullPath = "$dir/$restore_from_filename";
 
 	$file_contents_decoded = null;
-	$restore_status = array('success' => 'Failed', 'message' => '');
+	$restore_status = array('Success' => 'Failed', 'Message' => '');
 
 	//check that the area supplied is not empty, if so then assume we're restoring all araeas
 	if (empty($area_to_restore)) {
@@ -546,8 +546,8 @@ function RestoreJsonBackup(){
 				$file_contents_decoded = json_decode($file_contents, true);
 			} else {
 				//file_get_contents will return false if it couldn't read the file so
-				$restore_status['success'] = "Ok";
-				$restore_status['message'] = 'Backup File ' . $fullPath . ' could not be read.';
+				$restore_status['Success'] = "Ok";
+				$restore_status['Message'] = 'Backup File ' . $fullPath . ' could not be read.';
 			}
 		} else if ((strtolower($restore_from_directory) === 'jsonbackupsalternate')) {
 			if (isset($settings['jsonConfigBackupUSBLocation']) && !empty($settings['jsonConfigBackupUSBLocation'])) {
@@ -560,8 +560,8 @@ function RestoreJsonBackup(){
 					$file_contents_decoded = json_decode($file_contents, true);
 				} else {
 					//file_get_contents will return false if it couldn't read the file so
-					$restore_status['success'] = "Ok";
-					$restore_status['message'] = 'Backup File ' . $fullPath . ' could not be read.';
+					$restore_status['Success'] = "Ok";
+					$restore_status['Message'] = 'Backup File ' . $fullPath . ' could not be read.';
 				}
 			}
 		}
@@ -569,11 +569,11 @@ function RestoreJsonBackup(){
 		//Perform the restore
 		$restore_data = doRestore($area_to_restore, $file_contents_decoded, $restore_from_filename, true, true, 'api');
 
-		$restore_status['success'] = $restore_data['success'];
-		$restore_status['message'] = $restore_data['message'];
+		$restore_status['Success'] = $restore_data['success'];
+		$restore_status['Message'] = $restore_data['message'];
 	} else {
-		$restore_status['success'] = "Error";
-		$restore_status['message'] = 'Supplied Directory or Filename is invalid';
+		$restore_status['Success'] = "Error";
+		$restore_status['Message'] = 'Supplied Directory or Filename is invalid';
 	}
 
 	//Return the result which contains the success of the backup and the path which it was written to;
@@ -612,7 +612,7 @@ function DownloadJsonBackup(){
 			readfile($fullPath);
 		} else {
 			$status = "File Not Found";
-			return json(array("status" => $status, "file" => $fileName, "dir" => $dirName));
+			return json(array("Status" => $status, "file" => $fileName, "dir" => $dirName));
 		}
 	} elseif (strtolower($dirName) == "jsonbackupsalternate") {
 		//Use our DriveMountHelper to mount the specified USB drive and check if the file exists
@@ -630,7 +630,7 @@ function DownloadJsonBackup(){
 			DriveMountHelper($settings['jsonConfigBackupUSBLocation'], 'readfile', array($fullPath));
 		} else {
 			$status = "File Not Found";
-			return json(array("status" => $status, "file" => $fileName, "dir" => $dirName));
+			return json(array("Status" => $status, "file" => $fileName, "dir" => $dirName));
 		}
 	}
 }
@@ -701,7 +701,7 @@ function DeleteJsonBackup(){
 		}
 	}
 
-	return json(array("status" => $status, "file" => $fileName, "dir" => $dirName));
+	return json(array("Status" => $status, "file" => $fileName, "dir" => $dirName));
 }
 
 /**

--- a/www/api/endpoints.json
+++ b/www/api/endpoints.json
@@ -88,7 +88,7 @@
                 "DELETE": {
                     "desc": "Deletes a specific JSON Backup, Directory is are either JsonBackups (local) or JsonAlternateBackup (configured alternate device). API backups/configuration/list can be used to get valid directories and files.",
                     "output": {
-                        "status": "OK",
+                        "Status": "OK",
                         "file": "FPP_all-backup_v6_20230124210514.json",
                         "dir": "JsonBackupsAlternate"
                     }
@@ -101,8 +101,8 @@
                 "POST": {
                     "desc": "Restored the specified JSON Backup, Directory is either JsonBackups (local) or JsonAlternateBackup (configured alternate device). API backups/configuration/list can be used to get valid directory and file combinations.",
                     "output": {
-                        "success": true,
-                        "message": {
+                        "Success": true,
+                        "Message": {
                             "success": true,
                             "message": {
                                 "channelInputs": {

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -8,6 +8,8 @@ require_once '../common.php';
 dispatch_get('/backups/list', 'GetAvailableBackups');
 dispatch_get('/backups/list/:DeviceName', 'GetAvailableBackupsOnDevice');
 dispatch_get('/backups/devices', 'GetAvailableBackupsDevices');
+dispatch_post('/backups/devices/mount/:DeviceName/:MountLocation', 'MountDevice');
+dispatch_post('/backups/devices/unmount/:DeviceName/:MountLocation', 'UnmountDevice');
 dispatch_post('/backups/configuration', 'MakeJSONBackup');
 dispatch_get('/backups/configuration/list', 'GetAvailableJSONBackups');
 dispatch_get('/backups/configuration/list/:DeviceName', 'GetAvailableJSONBackupsOnDevice');

--- a/www/backup.php
+++ b/www/backup.php
@@ -3254,7 +3254,7 @@ function backupRemoteStorageChanged() {
     $('#backup\\.RemoteStorage').parent().closest('td').addClass('fpp-backup-action-loading');
 
     //do a ajax call to save the setting
-    $.get('fppjson.php?command=setSetting&plugin=&key=backup.RemoteStorage&value=' + value)
+    $.put('api/settings/backup.RemoteStorage/' + value)
         .done(function () {
             $('#backup\\.RemoteStorage').parent().closest('td').removeClass('fpp-backup-action-loading');
 

--- a/www/backup.php
+++ b/www/backup.php
@@ -2638,10 +2638,10 @@ function CopyDone() {
 function GetBackupDevices() {
     $('#backup\\.USBDevice').html('<option>Loading...</option>');
     //Add a loading spinner to show something is happening on the JSON Backup page dropdown list
-    $('#jsonConfigbackup\\.USBDevice').parent().closest('div').addClass('backup-file-configuration-actions-button-loading');
+    $('#jsonConfigbackup\\.USBDevice').parent().closest('div').addClass('fpp-backup-action-loading');
     //Also do the same for the file copy list these both use the same functions and deal with the same data
     //Add a loading spinner to show something is happening
-    $('#backup\\.USBDevice').parent().closest('td').addClass('backup-file-configuration-actions-button-loading');
+    $('#backup\\.USBDevice').parent().closest('td').addClass('fpp-backup-action-loading');
 
     $.get("api/backups/devices"
         ).done(function(data) {
@@ -2670,10 +2670,10 @@ function GetBackupDevices() {
             $('#jsonConfigbackup\\.USBDevice').html(default_none_selected_option + options);
 
             //Remove the loading spinner
-            $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('backup-file-configuration-actions-button-loading');
+            $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('fpp-backup-action-loading');
             //Also do the same for the file copy list these both use the same functions and deal with the same data
             //Add a loading spinner to show something is happening
-            $('#backup\\.USBDevice').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+            $('#backup\\.USBDevice').parent().closest('td').removeClass('fpp-backup-action-loading');
 
             if (options != "") {
                     if (document.getElementById("backup.Direction").value == 'FROMUSB')
@@ -2741,7 +2741,7 @@ function JSONConfigBackupUSBDeviceChanged() {
     var storage_location = document.getElementById("jsonConfigbackup.USBDevice").value;
 
     //Add a loading spinner to indicate the setting is being saved
-    $('#jsonConfigbackup\\.USBDevice').parent().closest('div').addClass('backup-file-configuration-actions-button-loading');
+    $('#jsonConfigbackup\\.USBDevice').parent().closest('div').addClass('fpp-backup-action-loading');
 
     //Write setting to system
     $.ajax({
@@ -2749,7 +2749,7 @@ function JSONConfigBackupUSBDeviceChanged() {
         type: 'PUT',
         data: storage_location,
         success: function(data){
-            $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('backup-file-configuration-actions-button-loading');
+            $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('fpp-backup-action-loading');
 
             if (storage_location !== "none"){
                 $.jGrowl('JSON Configuration Backups will now be copied to: ' + storage_location, {themeState: 'success'});
@@ -2780,7 +2780,7 @@ function JSONConfigBackupUSBDeviceChanged() {
             GetJSONConfigBackupList();
         },
         error: function(data) {
-            $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('backup-file-configuration-actions-button-loading');
+            $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('fpp-backup-action-loading');
 
             DialogError('JSON Configuration Backup Storage Location', 'Failed to set additional storage location.');
 
@@ -2811,7 +2811,7 @@ function CopyBackupsToUSBHelper(){
 
 function GetJSONConfigBackupDevice() {
     //Add a the loading spinner to show something is happening
-    $('#jsonConfigbackup\\.USBDevice').parent().closest('div').addClass('backup-file-configuration-actions-button-loading');
+    $('#jsonConfigbackup\\.USBDevice').parent().closest('div').addClass('fpp-backup-action-loading');
 
     $.ajax({
         url: 'api/settings/jsonConfigBackupUSBLocation',
@@ -2821,14 +2821,14 @@ function GetJSONConfigBackupDevice() {
                 //Change the JSON Config backup location to the one set by the user if a valid value is set
                 $('#jsonConfigbackup\\.USBDevice option[value="'+data.value+'"]').attr('selected', true);
                 //
-                $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('backup-file-configuration-actions-button-loading');
+                $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('fpp-backup-action-loading');
             }
         },
         error: function(data) {
             //do nothing
             DialogError('JSON Configuration Backup Storage Location', 'Failed to read additional storage location.');
 
-            $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('backup-file-configuration-actions-button-loading');
+            $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('fpp-backup-action-loading');
         }
     });
 }
@@ -2994,7 +2994,7 @@ function DeleteJsonBackupFile(dir, row, file, silent = false) {
     }
 
     //Add a loading  spinner to the delete button for the row we're deleting to add some feedback to the user something is happening
-    $( row + ' .deleteConfigButton > i').addClass('backup-file-configuration-actions-button-loading');
+    $( row + ' .deleteConfigButton > i').addClass('fpp-backup-action-loading');
 
     $.ajax({
         url: "api/backups/configuration/" + dir + "/" + encodeURIComponent(file),
@@ -3019,7 +3019,7 @@ function RestoreJsonBackup(directory, filename, row){
     //validate directory and filename are not emptry
     if (typeof (selected_restore_area) && (typeof (directory) !== 'undefined' && typeof (filename) !== 'undefined')) {
         //Add a loading  spinner to the delete button for the row we're deleting to add some feedback to the user something is happening
-        $( row + ' .restoreJsonConfigActionButton > i').addClass('backup-file-configuration-actions-button-loading');
+        $( row + ' .restoreJsonConfigActionButton > i').addClass('fpp-backup-action-loading');
 
         //all the API backend to do the restore
         $.ajax({
@@ -3029,7 +3029,7 @@ function RestoreJsonBackup(directory, filename, row){
             processData: false,
             success: function (data) {
                 //Remove the loading spinner
-                $( row + ' .restoreJsonConfigActionButton > i').removeClass('backup-file-configuration-actions-button-loading');
+                $( row + ' .restoreJsonConfigActionButton > i').removeClass('fpp-backup-action-loading');
 
                 if (data.success === true) {
                     $.jGrowl('Successfully restored selected backup: ', {themeState: 'success'});
@@ -3039,7 +3039,7 @@ function RestoreJsonBackup(directory, filename, row){
             },
             error: function (data) {
                 //Remove the loading spinner also if we fail
-                $( row + ' .restoreJsonConfigActionButton > i').removeClass('backup-file-configuration-actions-button-loading');
+                $( row + ' .restoreJsonConfigActionButton > i').removeClass('fpp-backup-action-loading');
 
                 DialogError('Error occurred attempting to restore data', data.message);
             }
@@ -3070,15 +3070,15 @@ function GetBackupDirsViaAPI(host, remoteStorageSelected = '') {
     }
 
     //Add a loading spinner to show the user something is happening
-    $('#backup\\.PathSelect').parent().closest('td').addClass('backup-file-configuration-actions-button-loading');
+    $('#backup\\.PathSelect').parent().closest('td').addClass('fpp-backup-action-loading');
 
     $.get(url
     ).done(function (data) {
         PopulateBackupDirs(data);
-        $('#backup\\.PathSelect').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+        $('#backup\\.PathSelect').parent().closest('td').removeClass('fpp-backup-action-loading');
     }).fail(function () {
         $('#backup\\.PathSelect').html('');
-        $('#backup\\.PathSelect').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+        $('#backup\\.PathSelect').parent().closest('td').removeClass('fpp-backup-action-loading');
     });
 }
 
@@ -3207,7 +3207,7 @@ function GetRemoteHostUSBStorage() {
 
     // $('#backup\\.USBDevice').html('<option>Loading...</option>');
     //Add a loading spinner to show something is happening
-    $('#backup\\.RemoteStorage').parent().closest('td').addClass('backup-file-configuration-actions-button-loading');
+    $('#backup\\.RemoteStorage').parent().closest('td').addClass('fpp-backup-action-loading');
 
     $.get(requestUrl
     ).done(function (data) {
@@ -3234,7 +3234,7 @@ function GetRemoteHostUSBStorage() {
         $('#backup\\.RemoteStorage').html(default_none_selected_option + options);
 
         //Remove the loading spinner
-        $('#backup\\.RemoteStorage').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+        $('#backup\\.RemoteStorage').parent().closest('td').removeClass('fpp-backup-action-loading');
 
         if (options !== "") {
             //After populating the list, Get the currently set remote host storage device
@@ -3251,12 +3251,12 @@ function backupRemoteStorageChanged() {
     var value = encodeURIComponent($('#backup\\.RemoteStorage').val());
 
     //Add the loading spinner
-    $('#backup\\.RemoteStorage').parent().closest('td').addClass('backup-file-configuration-actions-button-loading');
+    $('#backup\\.RemoteStorage').parent().closest('td').addClass('fpp-backup-action-loading');
 
     //do a ajax call to save the setting
     $.get('fppjson.php?command=setSetting&plugin=&key=backup.RemoteStorage&value=' + value)
         .done(function () {
-            $('#backup\\.RemoteStorage').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+            $('#backup\\.RemoteStorage').parent().closest('td').removeClass('fpp-backup-action-loading');
 
             $.jGrowl('Remote Backup Storage saved', {themeState: 'success'});
             settings['backup.RemoteStorage'] = value;
@@ -3266,14 +3266,14 @@ function backupRemoteStorageChanged() {
         }).fail(function () {
         DialogError('Remote Backup Storage', 'Failed to save Backup Storage');
         //remove the spinner
-        $('#backup\\.RemoteStorage').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+        $('#backup\\.RemoteStorage').parent().closest('td').removeClass('fpp-backup-action-loading');
     });
 }
 
 //Get the current setting for the remote hosts remote backup storage device (where the file copy will go to)
 function GetBackupRemoteStorageDevice() {
     //Add a the loading spinner to show something is happening
-    $('#backup\\.RemoteStorage').parent().closest('div').addClass('backup-file-configuration-actions-button-loading');
+    $('#backup\\.RemoteStorage').parent().closest('div').addClass('fpp-backup-action-loading');
 
     $.ajax({
         url: 'api/settings/backup.RemoteStorage',
@@ -3283,7 +3283,7 @@ function GetBackupRemoteStorageDevice() {
                 //Change the JSON Config backup location to the one set by the user if a valid value is set
                 $('#backup\\.RemoteStorage option[value="' + data.value + '"]').attr('selected', true);
                 //
-                $('#backup\\.RemoteStorage').parent().closest('div').removeClass('backup-file-configuration-actions-button-loading');
+                $('#backup\\.RemoteStorage').parent().closest('div').removeClass('fpp-backup-action-loading');
 
                 //Get the backup directories avaiable on the selected storage device if were restoring from remote,
                 if (document.getElementById("backup.Direction").value == 'FROMREMOTE') {
@@ -3299,7 +3299,7 @@ function GetBackupRemoteStorageDevice() {
             //do nothing
             DialogError('Remote Host Backup Storage Location', 'Failed to read remote storage location.');
 
-            $('#backup\\.RemoteStorage').parent().closest('div').removeClass('backup-file-configuration-actions-button-loading');
+            $('#backup\\.RemoteStorage').parent().closest('div').removeClass('fpp-backup-action-loading');
         }
     });
 }

--- a/www/backup.php
+++ b/www/backup.php
@@ -3000,11 +3000,11 @@ function DeleteJsonBackupFile(dir, row, file, silent = false) {
         url: "api/backups/configuration/" + dir + "/" + encodeURIComponent(file),
         type: 'DELETE'
     }).done(function (data) {
-        if (data.status == "OK") {
+        if (data.Status == "OK") {
             $(row).remove();
         } else {
             if (!silent)
-                DialogError("ERROR", "Error deleting file \"" + file + "\": " + data.status);
+                DialogError("ERROR", "Error deleting file \"" + file + "\": " + data.Status);
             }
     }).fail(function () {
         if (!silent)
@@ -3031,7 +3031,7 @@ function RestoreJsonBackup(directory, filename, row){
                 //Remove the loading spinner
                 $( row + ' .restoreJsonConfigActionButton > i').removeClass('fpp-backup-action-loading');
 
-                if (data.success === true) {
+                if (data.Success === true) {
                     $.jGrowl('Successfully restored selected backup: ', {themeState: 'success'});
                 } else {
                     $.jGrowl('Error occurred restoring selected backup: ', {themeState: 'danger'});
@@ -3041,7 +3041,7 @@ function RestoreJsonBackup(directory, filename, row){
                 //Remove the loading spinner also if we fail
                 $( row + ' .restoreJsonConfigActionButton > i').removeClass('fpp-backup-action-loading');
 
-                DialogError('Error occurred attempting to restore data', data.message);
+                DialogError('Error occurred attempting to restore data', data.Message);
             }
         });
     }

--- a/www/backup.php
+++ b/www/backup.php
@@ -2468,6 +2468,7 @@ $backupHosts = getKnownFPPSystems();
     <script type="text/javascript">
         var settings = new Array();
         var list_of_existing_backups;
+        var debug_mode = <? echo $backups_verbose_logging;?>
 		<?php
 ////Override restartFlag setting not reflecting actual value after restoring, just read what's in the settings file
     $settings['restartFlag'] = ReadSettingFromFile('restartFlag');
@@ -2550,6 +2551,7 @@ function PerformCopy() {
     var dev = document.getElementById("backup.USBDevice").value;
     var path = document.getElementById("backup.Path").value.replaceAll('\\', '/');
     var pathSelect = document.getElementById("backup.PathSelect").value;
+    var remoteStorage = document.getElementById("backup.RemoteStorage").value;
     var host = document.getElementById("backup.Host").value;
     var direction = document.getElementById("backup.Direction").value;
     var flags = GetCopyFlags();
@@ -2569,11 +2571,17 @@ function PerformCopy() {
             return;
         }
 
+        //Add the remote storage value is restoring to or from remote hosts
+        if (typeof (remoteStorage) !== 'undefined' || remoteStorage !== '') {
+            url += '&remoteStorage=' + remoteStorage;
+        }
+
         storageLocation = host;
     } else {
         storageLocation = settings['mediaDirectory'] + "/backups";
     }
 
+    //Add in the specified backup path
     if (direction.substring(0,4) == 'FROM') {
         if (pathSelect == '') {
             DialogError('Copy Failed', 'No path specified');
@@ -2718,9 +2726,11 @@ function GetRestoreDeviceDirectories() {
         });
 }
 
-function USBDeviceChanged() {
+function USBDeviceChanged(toFromRemote=false) {
     var direction = document.getElementById("backup.Direction").value;
-alert('direction: ' + direction);
+    if (debug_mode == true) {
+        alert('direction: ' + direction);
+    }
     if (direction == 'FROMUSB')
         GetBackupDeviceDirectories();
     else if (direction == 'TOUSB')
@@ -3050,18 +3060,41 @@ function PopulateBackupDirs(data) {
     $('#backup\\.PathSelect').html(options);
 }
 
-function GetBackupDirsViaAPI(host) {
+function GetBackupDirsViaAPI(host, remoteStorageSelected = '') {
     $('#backup\\.PathSelect').html('<option>Loading...</option>');
-    $.get("http://" + host + "/api/backups/list"
-        ).done(function(data) {
-            PopulateBackupDirs(data);
-        }).fail(function() {
-            $('#backup\\.PathSelect').html('');
-        });
+
+    //Build a different URL if a storage device has been specified
+    var url = "http://" + host + "/api/backups/list";
+    if (remoteStorageSelected !== '' || remoteStorageSelected !== false) {
+        url = "http://" + host + "/api/backups/list/" + remoteStorageSelected;
+    }
+
+    //Add a loading spinner to show the user something is happening
+    $('#backup\\.PathSelect').parent().closest('td').addClass('backup-file-configuration-actions-button-loading');
+
+    $.get(url
+    ).done(function (data) {
+        PopulateBackupDirs(data);
+        $('#backup\\.PathSelect').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+    }).fail(function () {
+        $('#backup\\.PathSelect').html('');
+        $('#backup\\.PathSelect').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+    });
 }
 
-function GetBackupHostBackupDirs() {
-    GetBackupDirsViaAPI($('#backup\\.Host').val());
+//Wrapper for GetBackupDirsViaAPI when quering folders on a remote hosts storage device
+function GetBackupHostBackupDirs(remoteStorageSelected = false) {
+    if (remoteStorageSelected !== false) {
+        //Get the value of the selected storage
+        var selectedStorage = remoteStorageSelected;
+        //ignore if the default of none is still selected
+        if (selectedStorage == 'none') {
+            selectedStorage = '';
+        }
+    }
+
+    //Get the backup directories on the specified storage device
+    GetBackupDirsViaAPI($('#backup\\.Host').val(), selectedStorage);
 }
 
 function BackupDirectionChanged() {
@@ -3074,6 +3107,7 @@ function BackupDirectionChanged() {
             $('.copyPath').show();
             $('.copyPathSelect').hide();
             $('.copyHost').hide();
+            $('.copyHostDevice').hide();
             $('.copyBackups').show();
             GetRestoreDeviceDirectories();
             break;
@@ -3082,6 +3116,7 @@ function BackupDirectionChanged() {
             $('.copyPath').hide();
             $('.copyPathSelect').show();
             $('.copyHost').hide();
+            $('.copyHostDevice').hide();
             $('.copyBackups').hide();
             GetBackupDeviceDirectories();
             break;
@@ -3090,6 +3125,7 @@ function BackupDirectionChanged() {
             $('.copyPath').show();
             $('.copyPathSelect').hide();
             $('.copyHost').hide();
+            $('.copyHostDevice').hide();
             $('.copyBackups').hide();
             break;
         case 'FROMLOCAL':
@@ -3097,6 +3133,7 @@ function BackupDirectionChanged() {
             $('.copyPath').hide();
             $('.copyPathSelect').show();
             $('.copyHost').hide();
+            $('.copyHostDevice').hide();
             $('.copyBackups').hide();
             GetBackupDirsViaAPI('<?php echo $_SERVER['HTTP_HOST'] ?>');
             break;
@@ -3105,24 +3142,30 @@ function BackupDirectionChanged() {
             $('.copyPath').show();
             $('.copyPathSelect').hide();
             $('.copyHost').show();
+            $('.copyHostDevice').show();
             $('.copyBackups').hide();
             //Check if remote has rsynd enabled
             CheckRemoteHasRsyncdEnabled(host);
+            //USB Device on remote
+            GetRemoteHostUSBStorage();
             break;
         case 'FROMREMOTE':
             $('.copyUSB').hide();
             $('.copyPath').hide();
             $('.copyPathSelect').show();
             $('.copyHost').show();
+            $('.copyHostDevice').show();
             $('.copyBackups').hide();
             GetBackupHostBackupDirs();
             //Check if remote has rsynd enabled
             CheckRemoteHasRsyncdEnabled(host);
+            //USB device on remote
+            GetRemoteHostUSBStorage();
             break;
     }
 }
 
-function CheckRemoteHasRsyncdEnabled(host) {
+ function CheckRemoteHasRsyncdEnabled(host) {
     //Read the the setting value for whether the Rsync Daemon is enabled on the host
     //if it isn't prompt the user that this needs to be enabled before copy TO or FROM the remote host can happen
     $.ajax({
@@ -3134,8 +3177,10 @@ function CheckRemoteHasRsyncdEnabled(host) {
                 if (rsyncd_setting_value === 0 || rsyncd_setting_value === '0') {
                     //remove the warning text in case it's hanging around from a previous host
                     $('.host_rsyncd_warning').remove();
+                    //Generate a URL by IP address to the affected host so the user can navigate easier
+                    var hostHref = "<a href='http://" + host + "/settings.php#settings-system' target='_blank'>" + host + "</a>";
                     //rsynd is disabled on host, add a warning next to the selected host
-                    $('#backup\\.Host').after('<span class="host_rsyncd_warning"><b>WARNING!</b> Rsync server is disabled on remote host, please enable rsync under FPP Settings -> System -> OS Services on ' + host + ' </span');
+                    $('#backup\\.Host').after('<span class="host_rsyncd_warning"><b>WARNING!</b> Rsync server is disabled on remote host, please enable rsync under FPP Settings -> System -> OS Services on ' + hostHref + ' </span');
                     //<span><b>WARNING!</b> Rsync server is disabled on this host, please enable under FPP Settings -> System -> OS Services on *host*</span
                 }else{
                     //remove the warning text in case it's hanging around from a previous host
@@ -3149,6 +3194,112 @@ function CheckRemoteHasRsyncdEnabled(host) {
         error: function (data) {
             //something went wrong
             $.jGrowl('Error occurred reading the Service_rsync value from host - ' + host, {themeState: 'danger'});
+        }
+    });
+}
+
+//Retrieves a list of available backup devices on the selected remote host
+function GetRemoteHostUSBStorage() {
+    //Very similar to GetBackupDevices() but adapted to collect storage info from a remote system
+    var host = document.getElementById("backup.Host").value;
+    var requestUrl = "http://" + host + "/" + "api/backups/devices";
+    var default_none_selected_option = "<option value='none' selected>Default FPP Storage</option>";
+
+    // $('#backup\\.USBDevice').html('<option>Loading...</option>');
+    //Add a loading spinner to show something is happening
+    $('#backup\\.RemoteStorage').parent().closest('td').addClass('backup-file-configuration-actions-button-loading');
+
+    $.get(requestUrl
+    ).done(function (data) {
+        var options = "";
+
+        for (var i = 0; i < data.length; i++) {
+            var desc = data[i].name;
+            if (data[i].vendor != '')
+                desc += ' - ' + data[i].vendor;
+
+            if (data[i].model != '') {
+                if (data[i].vendor != '')
+                    desc += ' ';
+                else
+                    desc += ' - ';
+
+                desc += data[i].model;
+            }
+
+            desc += ' - ' + data[i].size + 'GB';
+            options += "<option value='" + data[i].name + "'>" + desc + "</option>";
+        }
+        //Populate the dropdown with the detected storage devices
+        $('#backup\\.RemoteStorage').html(default_none_selected_option + options);
+
+        //Remove the loading spinner
+        $('#backup\\.RemoteStorage').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+
+        if (options !== "") {
+            //After populating the list, Get the currently set remote host storage device
+            GetBackupRemoteStorageDevice();
+        }
+    }).fail(function () {
+        $('#backup\\.RemoteStorage').html(default_none_selected_option);
+    });
+}
+
+//Save the selected remote backup storage device selection to settings
+function backupRemoteStorageChanged() {
+    //Get the value of the selected remove storage device
+    var value = encodeURIComponent($('#backup\\.RemoteStorage').val());
+
+    //Add the loading spinner
+    $('#backup\\.RemoteStorage').parent().closest('td').addClass('backup-file-configuration-actions-button-loading');
+
+    //do a ajax call to save the setting
+    $.get('fppjson.php?command=setSetting&plugin=&key=backup.RemoteStorage&value=' + value)
+        .done(function () {
+            $('#backup\\.RemoteStorage').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+
+            $.jGrowl('Remote Backup Storage saved', {themeState: 'success'});
+            settings['backup.RemoteStorage'] = value;
+
+            //Get the directories on the selected storage
+            GetBackupHostBackupDirs(encodeURIComponent(value));
+        }).fail(function () {
+        DialogError('Remote Backup Storage', 'Failed to save Backup Storage');
+        //remove the spinner
+        $('#backup\\.RemoteStorage').parent().closest('td').removeClass('backup-file-configuration-actions-button-loading');
+    });
+}
+
+//Get the current setting for the remote hosts remote backup storage device (where the file copy will go to)
+function GetBackupRemoteStorageDevice() {
+    //Add a the loading spinner to show something is happening
+    $('#backup\\.RemoteStorage').parent().closest('div').addClass('backup-file-configuration-actions-button-loading');
+
+    $.ajax({
+        url: 'api/settings/backup.RemoteStorage',
+        type: 'GET',
+        success: function (data) {
+            if (data.value !== "" || typeof (data.value) !== "undefined") {
+                //Change the JSON Config backup location to the one set by the user if a valid value is set
+                $('#backup\\.RemoteStorage option[value="' + data.value + '"]').attr('selected', true);
+                //
+                $('#backup\\.RemoteStorage').parent().closest('div').removeClass('backup-file-configuration-actions-button-loading');
+
+                //Get the backup directories avaiable on the selected storage device if were restoring from remote,
+                if (document.getElementById("backup.Direction").value == 'FROMREMOTE') {
+                    //If no Remote Storage device is selected don't pass anything to this function telling it to look at another device
+                    //so we just get what is on the default FPP storage device
+                    var selectedStorage = encodeURIComponent($('#backup\\.RemoteStorage').val());
+
+                    GetBackupHostBackupDirs(selectedStorage);
+                }
+            }
+        },
+        error: function (data) {
+            //do nothing
+            DialogError('Remote Host Backup Storage Location', 'Failed to read remote storage location.');
+
+            $('#backup\\.RemoteStorage').parent().closest('div').removeClass('backup-file-configuration-actions-button-loading');
         }
     });
 }
@@ -3175,6 +3326,9 @@ if (isset($_GET['tab']) and is_numeric($_GET['tab'])) {
             display: none;
         }
         .copyPathSelect {
+            display: none;
+        }
+        .copyHostDevice {
             display: none;
         }
     </style>
@@ -3519,6 +3673,7 @@ foreach ($settings_restored as $area_restored => $success) {
         </select></td></tr>
         <tr class='copyUSB'><td>USB Device:</td><td><select name='backup.USBDevice' id='backup.USBDevice' onChange='USBDeviceChanged();'></select> <input type='button' class='buttons' onClick='GetBackupDevices();' value='Refresh List'></td></tr>
         <tr class='copyHost'><td>Remote Host:</td><td><?php PrintSettingSelect('Backup Host', 'backup.Host', 0, 0, '', $backupHosts, '', 'GetBackupHostBackupDirs');?></td></tr>
+        <tr class='copyHostDevice'><td>Remote Storage:</td><td><select id="backup.RemoteStorage" onchange="backupRemoteStorageChanged();"><option value="none" selected="">Default FPP Storage</option></select></td></tr>
         <tr class='copyPath'><td>Backup Path:</td><td><?php PrintSettingTextSaved('backup.Path', 0, 0, 128, 64, '', $settings["HostName"]);?></td></tr>
         <tr class='copyPathSelect'><td>Backup Path:</td><td><select name='backup.PathSelect' id='backup.PathSelect'></select></td></tr>
         <tr><td>What to copy:</td><td>

--- a/www/copystorage.php
+++ b/www/copystorage.php
@@ -33,7 +33,7 @@ Copy Settings
 
 		echo "==================================================================================\n";
 
-    $command = "sudo " . __DIR__ . "/../scripts/copy_settings_to_storage.sh " . escapeshellcmd($_GET['storageLocation']) . " " . $path . " " . escapeshellcmd($_GET['direction'])  . " " . escapeshellcmd($_GET['delete']) . " " . escapeshellcmd($_GET['flags']);
+    $command = "sudo " . __DIR__ . "/../scripts/copy_settings_to_storage.sh " . escapeshellcmd($_GET['storageLocation']) . " " . $path . " " . escapeshellcmd($_GET['direction']) . " " . escapeshellcmd(isset($_GET['remoteStorage']) ? $_GET['remoteStorage'] : 'none') . " " . escapeshellcmd($_GET['delete']) . " " . escapeshellcmd($_GET['flags']);
 
 		echo "Command: ".htmlspecialchars($command)."\n";
 		echo "----------------------------------------------------------------------------------\n";

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -2479,7 +2479,7 @@ input[type=search].tablesorter-filter:disabled {
 	font-size: 0.9em;
 }
 
-.backup-file-configuration-actions-button-loading:before {
+.fpp-backup-action-loading:before {
 	content: '';
 	display: inline-block;
 	color: #F63939;


### PR DESCRIPTION
This was a tricky one and only really made possible by the [nsenter ](https://man7.org/linux/man-pages/man1/nsenter.1.html) command which allows us to run commands in a different process's namespace.
This enables us to mount a device (under the root process) and make it available to the entire system, since apache sandbox's or more specifically mounts created in the apache process are private to apache.

I believe this command is available by default in most linux installation so shouldn't pose any issues.
Works on Raspbian, just needs to be tested on BBB but I gather it should work  there also

The rSync Config is also updated (via upgrade script 76) with a new module [remote_filecopy] which points to a predetermined and expected mount point at /mnt/remote_filecopy (specified USB device is mounted here)

**Backups API**
Added 2 endpoints which could be called to mount a specific device to a specified directory, useful only if a service on the remote device is expecting that mount location.
And Unmount that same location
Updated DriveMountHelper with ability to specify mount location,
-whether mount location is unmounted once done,
-whether to perform the mount in the root mount namespace (uses nsenter)
-or to return result codes etc for all the commands run (useful for debugging)

**Backup to Remote Host**
The File Copy Backup page To Remote and From remote options receive a extra dropdown box which is the available USB devices on that host,
![image](https://user-images.githubusercontent.com/799998/217263902-3ab1d007-1a7f-4efc-9121-125ff378c104.png)

**Restore from Remote** Host, leverage existing code to get list folders on the specified/selected device
![image](https://user-images.githubusercontent.com/799998/217264192-69958ef2-0cd7-4e7d-91ed-72fbaf91178b.png)

**Copy Process**
The copystore.php page gets a slight change to allow passing of the &remoteStorage query string (if omitted, we substitute in 'none' to the script.
![image](https://user-images.githubusercontent.com/799998/217264823-e19fee6f-6ed8-464b-91bf-f3ee3645ed08.png)

**Copy Settings Shell Script** - copy_settings_to_storage.sh
The shell script received changes to the params passed to and the TOREMOTE and FROMREMOTE sections to call a API to mount the specified device on the remote host IF a device is specified, Rsync continues as normal as the new module is configured pointing to the expected mount point.
Device is unmounted at the end

Closes #778 