### PR TITLE
Change Command Editor colour picker to use jQuery colpick instead of the browsers implementation 

### DIFF
--- a/www/commandPresets.php
+++ b/www/commandPresets.php
@@ -148,6 +148,10 @@ $(document).ready(function() {
 <?php
 $activeParentMenuItem = 'status';
 include 'menu.inc';?>
+<!--jQuery Colpicker to get the fancy color picker-->
+<link rel="stylesheet" type="text/css" href="jquery/colpick/css/colpick.css">
+<link rel="stylesheet" type="text/css" href="css/jquery.colpick.css">
+<script type="text/javascript" src="jquery/colpick/js/colpick.js"></script>
   <div class="mainContainer">
 	  <h2 class="title">Command Presets</h2>
 	  <div class="pageContent">

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -2606,6 +2606,29 @@ input[type=search].tablesorter-filter:disabled {
 	display: none !important;
 }
 
+/* Remove borders around the browsers default color swatch,*/
+input[type="color"] {
+	-webkit-appearance: none;
+	border: none;
+	width: 46px;
+	height: 33px;
+	padding-left: 0 !important;
+}
+
+/*Chrome, Safari Opera */
+input[type="color"]::-webkit-color-swatch-wrapper {
+	padding: 0;
+}
+
+input[type="color"]::-webkit-color-swatch {
+	border: none;
+}
+
+/*Firefox */
+input[type="color"]::-moz-color-swatch {
+	border: none;
+}
+
 @media (min-width: 991px) {
 	.divIPAddress {
 		display: inline-block;

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -2610,9 +2610,9 @@ input[type=search].tablesorter-filter:disabled {
 input[type="color"] {
 	-webkit-appearance: none;
 	border: none;
-	width: 46px;
-	height: 33px;
-	padding-left: 0 !important;
+	width: 5em;
+	height: 2em;
+	/*padding-left: 0 !important;*/
 }
 
 /*Chrome, Safari Opera */

--- a/www/jquery/colpick/js/colpick.js
+++ b/www/jquery/colpick/js/colpick.js
@@ -262,12 +262,20 @@
                 var left = pos.left;
                 var viewPort = getViewport();
                 var calW = cal.width();
-                if (left + calW > viewPort.l + viewPort.w) {
-                    left -= calW;
+                var calH = cal.height();
+                var bottom = top + calH;
+                var right = left + calW;
+                if (right > viewPort.w) {
+                    left = (viewPort.w-calW) / 2;
+                }
+                if (bottom > viewPort.l) {
+                    top -= (calH + this.offsetHeight);
                 }
                 cal.css({left: left + 'px', top: top + 'px'});
                 if (cal.data('colpick').onShow.apply(this, [cal.get(0)]) != false) {
                     cal.show();
+                    // Hide the keyboard on mobile devices be deselecting the text box
+                    $(document.activeElement).filter(':input:focus').blur();
                 }
                 //Hide when user clicks outside
                 $('html').mousedown({cal: cal}, hide);
@@ -288,7 +296,7 @@
             getViewport = function () {
                 var m = document.compatMode == 'CSS1Compat';
                 return {
-                    l: window.pageXOffset || (m ? document.documentElement.scrollLeft : document.body.scrollLeft),
+                    l: window.innerHeight || (m ? document.documentElement.scrollLeft : document.body.scrollLeft),
                     w: window.innerWidth || (m ? document.documentElement.clientWidth : document.body.clientWidth)
                 };
             },

--- a/www/jquery/colpick/js/colpick.js
+++ b/www/jquery/colpick/js/colpick.js
@@ -83,6 +83,9 @@
         //Called when the new color is changed
             change = function () {
                 var cal = $(this).parent().parent(), col;
+
+                if (!cal.data('colpick')) { return; }
+
                 if (this.parentNode.className.indexOf('_hex') > 0) {
                     cal.data('colpick').color = col = hexToHsb(fixHex(this.value));
                     fillRGBFields(col, cal.get(0));
@@ -153,6 +156,7 @@
                     cal: $(this).parent(),
                     y: $(this).offset().top
                 };
+                if (!current.cal.data('colpick')) { return false; }
                 $(document).on('mouseup touchend', current, upHue);
                 $(document).on('mousemove touchmove', current, moveHue);
 
@@ -166,6 +170,8 @@
                 return false;
             },
             moveHue = function (ev) {
+                if (!ev.data.cal.data('colpick')) { return false; }
+
                 var pageY = ((ev.type == 'touchmove') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
                     ev.data.cal.data('colpick')
@@ -176,6 +182,8 @@
                 return false;
             },
             upHue = function (ev) {
+                if (!ev.data.cal.data('colpick')) { return false; }
+
                 fillRGBFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 fillHexFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 $(document).off('mouseup touchend', upHue);
@@ -189,6 +197,7 @@
                     cal: $(this).parent(),
                     pos: $(this).offset()
                 };
+                if (!current.cal.data('colpick')) { return false; }
                 current.preview = current.cal.data('colpick').livePreview;
 
                 $(document).on('mouseup touchend', current, upSelector);
@@ -213,6 +222,8 @@
                 return false;
             },
             moveSelector = function (ev) {
+                if (!ev.data.cal.data('colpick')) { return false; }
+
                 var pageX, pageY;
                 if (ev.type == 'touchmove') {
                     pageX = ev.originalEvent.changedTouches[0].pageX;
@@ -232,6 +243,8 @@
                 return false;
             },
             upSelector = function (ev) {
+                if (!ev.data.cal.data('colpick')) { return false; }
+
                 fillRGBFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 fillHexFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 $(document).off('mouseup touchend', upSelector);
@@ -497,7 +510,21 @@
                 });
             },
             destroy: function () {
-                $('#' + $(this).data('colpickId')).remove();
+                var el = $(this);
+
+                $('#' + el.data('colpickId')).remove();
+
+                el.removeData('colpickId');
+
+                // unbind all events
+                var doc = $(document);
+                doc.off('mouseup touchend', upHue);
+                doc.off('mousemove touchmove', moveHue);
+                doc.off('mouseup touchend', upSelector);
+                doc.off('mousemove touchmove', moveSelector);
+                doc.off('mouseup', upIncrement);
+                doc.off('mousemove', moveIncrement);
+                $('html').off('mousedown', hide);
             }
         };
     }();

--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -27,6 +27,13 @@ var lastStatusJSON = null;
 var statusChangeFuncs = [];
 var zebraPinSubContentTop = 0;
 
+/* jQuery Colpick activation */
+var fppCommandColorPicker_fppDialogIntervalTimer = null
+var fppCommandColorPicker_fppDialogIsOpen = false;
+var fppCommandColorPicker_loopMaxRetries = 10;
+var fppCommandColorPicker_loopCount = 0;
+var fppCommandColorPicker_intervalMs = 250;
+
 if (('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)) {
     hasTouch = true;
 }
@@ -5183,6 +5190,9 @@ function UpdateChildVisibility() {
             $('.arg_row_' + a.name).show();
         }
     }
+
+    //Try activte the colpick colour picker
+    fppCommandColorPicker();
 }
 
 function CommandArgChanged() {
@@ -5593,7 +5603,7 @@ function PrintArgInputs(tblCommand, configAdjustable, args, startCount = 1) {
             }
             line += "></input>";
         } else if (val['type'] == "color") {
-            line += "<input type='color' class='fppCommandColor arg_" + val['name'] + "' id='" + ID + "' value='" + dv + "'></input>";
+            line += "<input type='color' class='color-box fppCommandColor arg_" + val['name'] + "' id='" + ID + "' value='" + dv + "' style='background-color: " + dv + ";'></input>";
         } else if (val['type'] == "time") {
             haveTime = 1;
             line += "<input class='time center arg_" + val['name'] + "' id='" + ID + "' type='text' size='8' value='00:00:00'/>";
@@ -5800,7 +5810,14 @@ function PopulateExistingCommand(json, commandSelect, tblCommand, configAdjustab
                         return ~$.inArray(this.text, split);
                     });
                 } else {
-                    inp.val(v).change();
+                    //Update the colour fields differently
+                    if (inp.attr('type') === 'color') {
+                        //v is already the hex colour value from the playlist entry
+                        inp.attr('value', v)
+                        inp.css('background-color', v)
+                    } else {
+                        inp.val(v).change();
+                    }
                 }
 
                 if (inp.data('url') != null) {
@@ -5816,6 +5833,77 @@ function PopulateExistingCommand(json, commandSelect, tblCommand, configAdjustab
         }
     }
 }
+
+/**
+ * Tries to activate the jQuery Colpicker for any colour input fields on the Command Editor form
+ * because the modal is not immediately visible, the colpciker doesn't seem to work, so we create a small loop that waits for the modal to show and then we active the colpicker
+ */
+function fppCommandColorPicker() {
+
+    if (typeof (fppCommandColorPicker_fppDialogIntervalTimer) === 'undefined' || fppCommandColorPicker_fppDialogIntervalTimer === null) {
+        //Use a interval timer to keep waiting for a open modal to then apply the colpicker
+        fppCommandColorPicker_fppDialogIntervalTimer = setInterval(function () {
+            // do your thing
+
+            if ($('.modal-body').is(":visible") === false) {
+                fppCommandColorPicker_fppDialogIsOpen = false;
+
+                //When the modal content is hidden, Unbind events from the colour input element so they aren't pointing to invalid colour pickers next time
+                $('.fppCommandColor').off();
+
+                // Destroy existing colour pickers
+                $('[id*="collorpicker_"]').remove();
+            } else {
+                fppCommandColorPicker_fppDialogIsOpen = true;
+
+                //try to calculate margins around the modal dialog so we can try correct the color pickers location
+                //the colour picker is using the viewport dimensions but the page we're on is in a modal with a top and left pixel offset
+                var modalDialog_topOffset = Math.round($('.modal-dialog').css('margin-top').replace('px', ''));
+                var modalDialog_headerHeight = Math.round($('.modal-header').outerHeight());
+                var modalDialogFooterHeight = Math.round($('.modal-footer').outerHeight());
+                var modalDialog_bottomOffset = Math.round($('.modal-dialog').css('margin-bottom').replace('px', ''));
+                var modalDialog_leftOffset = $('.modal-dialog').css('margin-left');
+                var colpickNewBottomPad = Math.abs(modalDialogFooterHeight + modalDialog_bottomOffset);
+                var colpickNewTopMargin = -Math.abs(modalDialog_topOffset + modalDialog_headerHeight + colpickNewBottomPad) + 'px';
+
+
+                //Add the colour picker to any color elements
+                if (($('[id*="collorpicker_"]').length !== $('.fppCommandColor').length)) {
+                    $('.fppCommandColor').colpick({
+                        layout: 'rgbhex',
+                        color: 'auto',
+                        submit: false,
+                        appendTo: '.modal-body',
+                        style: {marginTop: colpickNewTopMargin},
+                        onChange: function (hsb, hex, rgb, el, bySetColor) {
+                            $(el).css('background-color', '#' + hex);
+                            $(el).attr('value', '#' + hex);
+                            // if (!bySetColor) {
+                            //
+                            // }
+                        },
+                        onBeforeShow: function () {
+                            if (typeof (this.value !== 'undefined')) {
+                                $(this).colpickSetColor(this.value);
+                            }
+                        }
+                    });
+                }
+            }
+
+            fppCommandColorPicker_loopCount++;
+            if (fppCommandColorPicker_loopCount === fppCommandColorPicker_loopMaxRetries || fppCommandColorPicker_fppDialogIsOpen === true) {
+                clearInterval(fppCommandColorPicker_fppDialogIntervalTimer);
+                //Reset the interval reference so it can started again
+                fppCommandColorPicker_fppDialogIntervalTimer = null;
+                //reset the loop count so we're ready again
+                fppCommandColorPicker_loopCount = 0;
+            }
+        }, fppCommandColorPicker_intervalMs);
+    }
+
+}
+
 
 function FileChooser(dir, target) {
     if ($('#fileChooser').length == 0) {
@@ -6063,6 +6151,10 @@ function ShowCommandEditor(target, data, callback, cancelCallback = '', args = '
     $('#commandEditorPopup').fppDialog("moveToTop");
     $('#commandEditorDiv').load('commandEditor.php', function () {
         CommandEditorSetup(target, data, callback, cancelCallback, args);
+
+        //
+        // Add the colour picker to any color elements
+        fppCommandColorPicker();
     });
 }
 

--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -32,7 +32,7 @@ var fppCommandColorPicker_fppDialogIntervalTimer = null
 var fppCommandColorPicker_fppDialogIsOpen = false;
 var fppCommandColorPicker_loopMaxRetries = 10;
 var fppCommandColorPicker_loopCount = 0;
-var fppCommandColorPicker_intervalMs = 250;
+var fppCommandColorPicker_intervalMs = 150;
 
 if (('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0)) {
     hasTouch = true;
@@ -5859,13 +5859,9 @@ function fppCommandColorPicker() {
                 //try to calculate margins around the modal dialog so we can try correct the color pickers location
                 //the colour picker is using the viewport dimensions but the page we're on is in a modal with a top and left pixel offset
                 var modalDialog_topOffset = Math.round($('.modal-dialog').css('margin-top').replace('px', ''));
-                var modalDialog_headerHeight = Math.round($('.modal-header').outerHeight());
-                var modalDialogFooterHeight = Math.round($('.modal-footer').outerHeight());
-                var modalDialog_bottomOffset = Math.round($('.modal-dialog').css('margin-bottom').replace('px', ''));
-                var modalDialog_leftOffset = $('.modal-dialog').css('margin-left');
-                var colpickNewBottomPad = Math.abs(modalDialogFooterHeight + modalDialog_bottomOffset);
-                var colpickNewTopMargin = -Math.abs(modalDialog_topOffset + modalDialog_headerHeight + colpickNewBottomPad) + 'px';
-
+                var modalDialog_headerHeight = Math.round($('.modal-header').innerHeight());
+                var modalDialog_bodyPaddingHeight = Math.round($('.modal-body').css('padding-top').replace('px', ''));
+                var colpickNewTopMargin = -Math.abs((modalDialog_topOffset + modalDialog_headerHeight)) + modalDialog_bodyPaddingHeight;
 
                 //Add the colour picker to any color elements
                 if (($('[id*="collorpicker_"]').length !== $('.fppCommandColor').length)) {
@@ -5873,8 +5869,8 @@ function fppCommandColorPicker() {
                         layout: 'rgbhex',
                         color: 'auto',
                         submit: false,
-                        appendTo: '.modal-body',
-                        style: {marginTop: colpickNewTopMargin},
+                        appendTo: '.modal-header',
+                        styles: {marginTop: colpickNewTopMargin + "px"},
                         onChange: function (hsb, hex, rgb, el, bySetColor) {
                             $(el).css('background-color', '#' + hex);
                             $(el).attr('value', '#' + hex);
@@ -5900,6 +5896,15 @@ function fppCommandColorPicker() {
                 fppCommandColorPicker_loopCount = 0;
             }
         }, fppCommandColorPicker_intervalMs);
+    }else{
+        //interval loop is defined and most probably running as something might be in the process of changing
+        //cancel it, then start it again
+        clearInterval(fppCommandColorPicker_fppDialogIntervalTimer);
+        fppCommandColorPicker_fppDialogIntervalTimer = null;
+        //reset the loop count so we're ready again
+        fppCommandColorPicker_loopCount = 0;
+        //Start loop again
+        fppCommandColorPicker();
     }
 
 }

--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -5843,34 +5843,44 @@ function fppCommandColorPicker() {
     if (typeof (fppCommandColorPicker_fppDialogIntervalTimer) === 'undefined' || fppCommandColorPicker_fppDialogIntervalTimer === null) {
         //Use a interval timer to keep waiting for a open modal to then apply the colpicker
         fppCommandColorPicker_fppDialogIntervalTimer = setInterval(function () {
-            // do your thing
 
-            if ($('.modal-body').is(":visible") === false) {
-                fppCommandColorPicker_fppDialogIsOpen = false;
+            //Detect if the modal is visible now
+            if ($('.modal-body').is(":visible") === true) {
+                fppCommandColorPicker_fppDialogIsOpen = true;
 
-                //When the modal content is hidden, Unbind events from the colour input element so they aren't pointing to invalid colour pickers next time
+                //Do some cleanup of the old pickers
+                //When the modal content is hidden, Destroy the colorpicker using it's built in function
+                $('.fppCommandColor').colpickDestroy();
+                //Unbind events from our picker inputs
                 $('.fppCommandColor').off();
 
                 // Destroy existing colour pickers
-                $('[id*="collorpicker_"]').remove();
-            } else {
-                fppCommandColorPicker_fppDialogIsOpen = true;
+                $('div[id*="collorpicker_"]').remove();
 
                 //try to calculate margins around the modal dialog so we can try correct the color pickers location
                 //the colour picker is using the viewport dimensions but the page we're on is in a modal with a top and left pixel offset
                 var modalDialog_topOffset = Math.round($('.modal-dialog').css('margin-top').replace('px', ''));
+                var modalDialog_LeftOffset = Math.round($('.modal-dialog').css('margin-left').replace('px', ''));
                 var modalDialog_headerHeight = Math.round($('.modal-header').innerHeight());
                 var modalDialog_bodyPaddingHeight = Math.round($('.modal-body').css('padding-top').replace('px', ''));
                 var colpickNewTopMargin = -Math.abs((modalDialog_topOffset + modalDialog_headerHeight)) + modalDialog_bodyPaddingHeight;
 
-                //Add the colour picker to any color elements
-                if (($('[id*="collorpicker_"]').length !== $('.fppCommandColor').length)) {
+                //Add the colour picker to any color elements if we don't have as many as there are colour inputs
+                if (($('div[id*="collorpicker_"]').length !== $('.fppCommandColor').length)) {
+                    //Ideally we want to append to the modals footer element, but this doesn't exist on the commandPresets page
+                    var appendToElement = ".modal-footer"
+                    //If the footer doesn't exist, append to the header (sounds weird but it works and allows the colour picker to float over the footer and not get obscured begin it)
+                    if ($('.modal-footer').length === 0) {
+                        appendToElement = ".modal-header"
+                    }
+
+                    //Add the pickers again
                     $('.fppCommandColor').colpick({
                         layout: 'rgbhex',
                         color: 'auto',
                         submit: false,
-                        appendTo: '.modal-header',
-                        styles: {marginTop: colpickNewTopMargin + "px"},
+                        appendTo: appendToElement,
+                        styles: {marginLeft: modalDialog_LeftOffset, marginTop: colpickNewTopMargin + "px"},
                         onChange: function (hsb, hex, rgb, el, bySetColor) {
                             $(el).css('background-color', '#' + hex);
                             $(el).attr('value', '#' + hex);
@@ -5885,6 +5895,9 @@ function fppCommandColorPicker() {
                         }
                     });
                 }
+            }else{
+                //Not found yet so keep looping
+                fppCommandColorPicker_fppDialogIsOpen = false;
             }
 
             fppCommandColorPicker_loopCount++;
@@ -5896,15 +5909,10 @@ function fppCommandColorPicker() {
                 fppCommandColorPicker_loopCount = 0;
             }
         }, fppCommandColorPicker_intervalMs);
-    }else{
+    } else {
         //interval loop is defined and most probably running as something might be in the process of changing
-        //cancel it, then start it again
-        clearInterval(fppCommandColorPicker_fppDialogIntervalTimer);
-        fppCommandColorPicker_fppDialogIntervalTimer = null;
-        //reset the loop count so we're ready again
+        //reset the loop count to give it more time
         fppCommandColorPicker_loopCount = 0;
-        //Start loop again
-        fppCommandColorPicker();
     }
 
 }

--- a/www/playlists.php
+++ b/www/playlists.php
@@ -21,6 +21,10 @@ if (isset($_GET['playlist'])) {
 <?
 }
 ?>
+<!--jQuery Colpicker to get the fancy color picker-->
+<link rel="stylesheet" type="text/css" href="jquery/colpick/css/colpick.css">
+<link rel="stylesheet" type="text/css" href="css/jquery.colpick.css">
+<script type="text/javascript" src="jquery/colpick/js/colpick.js"></script>
 <script>
     function LoadInitialPlaylist() {
         $('#playlistSelect').val(initialPlaylist).trigger('change');


### PR DESCRIPTION
The command editor on the Command Presets and Playlist page used the browsers implementation of a colour picker which the user could use to input colours. It works well but doesn't provide consistency between browsers as they all implement a colour picker differently.

This change uses jQuery colpick which is used on the Display Testing, I haven't changed the elements in the Command Editor, the original input fields with type=color are still there, but the colpick plugin is overriding the default behaviour and providing a nicer colour picker.
What's also nice about this if the plugin fails for some reason, the colour picker falls back to the browsers implementation.

![image](https://user-images.githubusercontent.com/799998/220346586-c5f32d17-5481-442e-8f2f-f4db5ded2543.png)

Closes #1483