### PR TITLE
Fix Website URL Markdown Formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ can also be a controller on P5 and P10 Matrixes, or strings of ws2811 pixels.
 Useful Links:
 
 - [Documentation in Github](./docs/README.md)
-- [Falcon Player website] (https://www.falconplayer.com)
+- [Falcon Player website](https://www.falconplayer.com)
 - [Falcon Christmas forums](http://falconchristmas.com/forum/)
 - [Falcon Player sub-forum](http://falconchristmas.com/forum/index.php/board,8.0.html)
 - [Wiki](http://falconchristmas.com/wiki/index.php/Main_Page)


### PR DESCRIPTION
There is currently a space within the markdown formatting for the URL which points to the Falcon Player website in the README, therefore, causing it not to render correctly. This fixes it to align with the other links in the README.