### PR TITLE
Remove "," breaking json syntax so API endpoints work correctly again…

### DIFF
--- a/www/api/endpoints.json
+++ b/www/api/endpoints.json
@@ -509,7 +509,7 @@
                         "file": "block_driveways.xbkp",
                         "dir": "uploads"
                     }
-                },
+                }
             }
         },
         {


### PR DESCRIPTION
The API help is not currently displaying the API end points due to syntax error in the endpoints.json file

This corrects that and gets help page working again
