### PR TITLE
Modify output buffering of file copy script to get output faster

### DIFF
--- a/www/backup.php
+++ b/www/backup.php
@@ -2630,6 +2630,12 @@ function PerformCopy() {
         url += '&delete=no';
     }
 
+    if (document.getElementById("backup.sendCompressed").checked) {
+        url += '&compress=yes';
+    } else {
+        url += '&compress=no';
+    }
+
     if (direction.substring(0,4) == 'FROM')
     {
         if (!confirm(warningMsg)) {
@@ -3200,6 +3206,7 @@ function BackupDirectionChanged() {
             $('.copyHost').show();
             $('.copyHostDevice').show();
             $('.copyBackups').hide();
+            $('.sendCompressed').show();
             //Check if remote has rsynd enabled
             CheckRemoteHasRsyncdEnabled(host);
             //USB Device on remote
@@ -3212,6 +3219,7 @@ function BackupDirectionChanged() {
             $('.copyHost').show();
             $('.copyHostDevice').show();
             $('.copyBackups').hide();
+            $('.sendCompressed').show();
             GetBackupHostBackupDirs();
             //Check if remote has rsynd enabled
             CheckRemoteHasRsyncdEnabled(host);
@@ -3390,6 +3398,9 @@ if (isset($_GET['tab']) and is_numeric($_GET['tab'])) {
             display: none;
         }
         .copyHostDevice {
+            display: none;
+        }
+        .sendCompressed{
             display: none;
         }
     </style>
@@ -3737,7 +3748,15 @@ foreach ($settings_restored as $area_restored => $success) {
         <tr class='copyHostDevice'><td>Remote Storage:</td><td><select id="backup.RemoteStorage" onchange="backupRemoteStorageChanged();"><option value="none" selected="">Default FPP Storage</option></select></td></tr>
         <tr class='copyPath'><td>Backup Path:</td><td><?php PrintSettingTextSaved('backup.Path', 0, 0, 128, 64, '', $settings["HostName"]);?></td></tr>
         <tr class='copyPathSelect'><td>Backup Path:</td><td><select name='backup.PathSelect' id='backup.PathSelect'></select></td></tr>
-        <tr><td>What to copy:</td><td>
+        <tr class='sendCompressed'>
+            <td>Send Compressed Data: </td>
+            <td>
+				<?php PrintSettingCheckbox('Send Compressed Data:', 'backup.sendCompressed', 0, 0, 1, 0, "", "", 0, ' (Compress files during copy to speed up the copy process. NOTE: Newer xLights versions already used a compressed FSEQ format, so this option may only slow down the transfer as FPP tries to recompress already-compressed data. Some data like Music and Videos are not compressed.)'); ?>
+                <br>
+            </td>
+        </tr>
+
+       <tr><td>What to copy:</td><td>
         <table id="CopyFlagsTable">
         <tr><td>
 				<?php PrintSettingCheckbox('Backup Configuration', 'backup.Configuration', 0, 0, 1, 0, "", "", 1, 'Configuration');?><br>

--- a/www/copystorage.php
+++ b/www/copystorage.php
@@ -1,4 +1,6 @@
 <?php
+// Ignore user aborts and allow the script
+ignore_user_abort(true);
 header( "Access-Control-Allow-Origin: *");
 
 $wrapped = 0;
@@ -30,10 +32,13 @@ Copy Settings
 }
     $date = date("Ymd-Hi");
     $path = preg_replace('/{DATE}/', $date, $_GET['path']);
+    $compress = isset($_GET['compress']) ? escapeshellcmd($_GET['compress']) : "no";
+    $delete = isset($_GET['delete']) ? escapeshellcmd($_GET['delete']) : "no";
+    $remote_storage = isset($_GET['remoteStorage']) ? escapeshellcmd($_GET['remoteStorage']) : 'none';
 
 		echo "==================================================================================\n";
 
-    $command = "sudo " . __DIR__ . "/../scripts/copy_settings_to_storage.sh " . escapeshellcmd($_GET['storageLocation']) . " " . $path . " " . escapeshellcmd($_GET['direction']) . " " . escapeshellcmd(isset($_GET['remoteStorage']) ? $_GET['remoteStorage'] : 'none') . " " . escapeshellcmd($_GET['delete']) . " " . escapeshellcmd($_GET['flags']);
+    $command = "sudo stdbuf --output=L  " . __DIR__ . "/../scripts/copy_settings_to_storage.sh " . escapeshellcmd($_GET['storageLocation']) . " " . $path . " " . escapeshellcmd($_GET['direction']) . " " . $remote_storage . " " .  $compress . " " . $delete . " " . escapeshellcmd($_GET['flags']);
 
 		echo "Command: ".htmlspecialchars($command)."\n";
 		echo "----------------------------------------------------------------------------------\n";


### PR DESCRIPTION
Changed output buffering while executing the copy_settings_to_storage.sh script to Line Buffered (instead of Fully Buffered) so that it returns output quicker (give sense of progress rather than output at the end of the rsync process)

Added option to compress data that's sent in case users want that option, added same description as what's on the Multisync Copy files option.
