### PR TITLE
File Copy Backup Enhancements

### DIFF
--- a/etc/apache2.site
+++ b/etc/apache2.site
@@ -51,6 +51,10 @@
 #	CustomLog /home/fpp/media/logs/apache2-access.log combined
 #	CustomLog ${APACHE_LOG_DIR}/access.log combined
 	Include conf-available/serve-cgi-bin.conf
+
+	# Set the timeout for Proxy FCGI PHP FPM connections to 20 minutes to avoid Apache expiring connections for long running scripts
+	# Default value is value of Timeout (which is defaulted to 300 seconds or 5 minutes)
+	ProxyTimeout 1200
 </VirtualHost>
 
 <IfModule !mod_php7.c>

--- a/scripts/copy_settings_to_storage.sh
+++ b/scripts/copy_settings_to_storage.sh
@@ -190,6 +190,8 @@ fi
 if [ "$DIRECTION" == "TOREMOTE" -o "$DIRECTION" == "FROMREMOTE" ]; then
     if [ "$RSTORAGE" != "" ]  && [ "$RSTORAGE" != "none" ]
         then
+          #Wait 4 seconds before requesting a unmount
+          sleep 4
           #Unmount the specified device from the remote location if going to or from remote host and a device has been specified
           REMOTE_UNMOUNT=$(curl --location --request POST -H "Content-Type:application/json" "$DEVICE/api/backups/devices/unmount/$RSTORAGE/remote_filecopy")
           echo " "
@@ -202,4 +204,3 @@ fi
 if [ "$BASEDIRECTION" = "FROM" ]; then
     chown -R fpp:fpp /home/fpp/media
 fi
-

--- a/upgrade/78/upgrade.sh
+++ b/upgrade/78/upgrade.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#####################################
+
+# Copy new Apache site config into place
+echo "Copying updated Apache config into place"
+sed -e "s#FPPDIR#${FPPDIR}#g" -e "s#FPPHOME#${FPPHOME}#g" < ${FPPDIR}/etc/apache2.site > /etc/apache2/sites-enabled/000-default.conf
+
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/../../scripts/common
+setSetting rebootFlag 1
+echo "A reboot will be required for the Apache config to come into effect"

--- a/www/api/controllers/backups.php
+++ b/www/api/controllers/backups.php
@@ -54,58 +54,14 @@ function GetAvailableBackups()
 	return json(GetAvailableBackupsFromDir($settings['mediaDirectory'] . '/backups/'));
 }
 
-function CheckIfDeviceIsUsable($deviceName)
-{
-	global $SUDO;
-
-	// Check if in use / Mount / List / Unmount
-	$mountPoint = exec($SUDO . " lsblk /dev/$deviceName");
-	$mountPoint = preg_replace('/.*disk ?/', '', $mountPoint);
-	$mountPoint = preg_replace('/.*part ?/', '', $mountPoint);
-	if (preg_match('/[a-z0-9\/]/', $mountPoint))
-		return "ERROR: Partition is mounted on: $mountPoint";
-
-	$isSwap = exec("grep /dev/$deviceName /proc/swaps");
-	if ($isSwap != "")
-		return "ERROR: $deviceName is a swap partition";
-
-	return "";
-}
-
 /**
  * Returns a list of devices like USB's or SSD's attached to the system
  * GET api/backups/devices
  * @return string
  */
-function GetAvailableBackupsDevices()
+function RetrieveAvailableBackupsDevices()
 {
-	global $SUDO;
-	$devices = array();
-
-	foreach (scandir("/dev/") as $deviceName) {
-		if (preg_match("/^sd[a-z][0-9]/", $deviceName)) {
-			exec($SUDO . " sfdisk -s /dev/$deviceName", $output, $return_val);
-			$GB = round(intval($output[0]) / 1024.0 / 1024.0, 1);
-			unset($output);
-
-			if ($GB <= 0.1)
-				continue;
-
-			$unusable = CheckIfDeviceIsUsable($deviceName);
-			if ($unusable != '')
-				continue;
-
-			$baseDevice = preg_replace('/[0-9]*$/', '', $deviceName);
-
-			$device = array();
-			$device['name'] = $deviceName;
-			$device['size'] = $GB;
-			$device['model'] = exec("cat /sys/block/$baseDevice/device/model");
-			$device['vendor'] = exec("cat /sys/block/$baseDevice/device/vendor");
-
-			array_push($devices, $device);
-		}
-	}
+	$devices = GetAvailableBackupsDevices();
 
 	return json($devices);
 }
@@ -219,7 +175,7 @@ function DriveMountHelper($deviceName, $usercallback_function, $functionArgs = a
 
 	//Unmount by default before we finish
 	if ($unmountWhenDone === true) {
-		$umountCmd = exec($SUDO . $nsEnter . ' umount ' . $mountPath, $unmountCmdOutput, $unmountCmdResultCode);
+		$umountCmd = exec($SUDO . $nsEnter . ' umount -l ' . $mountPath, $unmountCmdOutput, $unmountCmdResultCode);
 	}
 
 	//Return more detail about the what has happened with each command
@@ -310,7 +266,7 @@ function UnmountDevice()
 	//Make sure we have a valid device name supplied
 	if (isset($deviceName) && ($deviceName !== "no" || $deviceName !== "")) {
 		//Unmount device from the root namespace (it will be mounted there)
-		$umountCmd = exec($SUDO . $nsEnter . ' umount ' . $drive_mount_location, $unmountCmdOutput, $unmountCmdResultCode);
+		$umountCmd = exec($SUDO . $nsEnter . ' umount -l ' . $drive_mount_location, $unmountCmdOutput, $unmountCmdResultCode);
 		//This could be incorrect as this result codes are for the mount command, but will give us an idea
 		$unmountCmdOutputText = MountReturnCodeMap($unmountCmdResultCode);
 

--- a/www/api/controllers/files.php
+++ b/www/api/controllers/files.php
@@ -164,6 +164,11 @@ function GetFileImpl($dir, $filename, $lines, $play, $attach)
         $filename = substr($filename, 9);
     }
 
+	if (!file_exists($dir . '/' . $filename)){
+		echo "File does not exist.";
+		return;
+	}
+
     if ($play) {
         if (preg_match('/mp3$/i', $filename)) {
             header('Content-type: audio/mp3');

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -7,7 +7,7 @@ require_once '../common.php';
 
 dispatch_get('/backups/list', 'GetAvailableBackups');
 dispatch_get('/backups/list/:DeviceName', 'GetAvailableBackupsOnDevice');
-dispatch_get('/backups/devices', 'GetAvailableBackupsDevices');
+dispatch_get('/backups/devices', 'RetrieveAvailableBackupsDevices');
 dispatch_post('/backups/devices/mount/:DeviceName/:MountLocation', 'MountDevice');
 dispatch_post('/backups/devices/unmount/:DeviceName/:MountLocation', 'UnmountDevice');
 dispatch_post('/backups/configuration', 'MakeJSONBackup');


### PR DESCRIPTION
Increased Apache2 ProxyTimeout for PHP-FPM so connections to long running scripts don't get terminated

Ability to view & un-mount mounted USB devices via FPP Settings -> Storage

Use Lazy unmounts when un-mounting devices via the API, this removes future file access to the mount and allows the un-mount to occur after any open files are closed. This results in more reliable un-mounting if files are still finishing up or file system access is occurring at the time.

Save output of copy process to file & ability to read that file in cases where the connection is terminated while streaming the output of the copy process

Change view log API endpoint to return a message if specified log file doesn't exist instead of sending a empty file to the user.

Moved some API functions (GetAvailableBackupsDevices & CheckIfDeviceIsUsable) into common.php to be with shared settings-storage.