### PR TITLE
avoid SEGV if no eFuse pin

### DIFF
--- a/src/OutputMonitor.cpp
+++ b/src/OutputMonitor.cpp
@@ -219,7 +219,7 @@ void OutputMonitor::EnableOutputs() {
         }
     }
     for (auto p : portPins) {
-        if (p->eFusePin->getValue() == p->eFuseOKValue) {
+        if (p->eFusePin && p->eFusePin->getValue() == p->eFuseOKValue) {
             WarningHolder::RemoveWarning("eFUSE Triggered for " + p->name);
         }
     }


### PR DESCRIPTION
I'm getting a SEGV from src/OutputMonitor.cpp:222.  p->eFusePin appears to be null - likely due to other config problems, but this error crashes fppd so I can't get any further with config.

Adding a check for p->eFusePin non-null allows the code to continue.