### PR TITLE
Made remap output processor more intuitive when reversing to source

### DIFF
--- a/src/channeloutput/processors/RemapOutputProcessor.cpp
+++ b/src/channeloutput/processors/RemapOutputProcessor.cpp
@@ -57,10 +57,9 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
         for (int l = 0; l < loops; l++) {
             if (count > 1) {
                 memcpy(channelData + destChannel + (l * count),
-                    channelData + sourceChannel,
-                    count);
-            }
-            else {
+                       channelData + sourceChannel,
+                       count);
+            } else {
                 channelData[destChannel + l] = channelData[sourceChannel];
             }
         }
@@ -76,14 +75,14 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
                     for (int c = 0; c < count; c++) {
                         channelData[destChannel + c] = tempBuffer[count - 1 - c];
                     }
-                }
-                else { // Subsequent loops, just copy first reversed block for speed
+                    // Delete the temporary buffer
+                    delete[] tempBuffer;
+                } else { // Subsequent loops, just copy first reversed block for speed
                     memcpy(channelData + destChannel + (l * count),
-                        channelData + destChannel,
-                        count);
+                           channelData + destChannel,
+                           count);
                 }
-            }
-            else { // Can't reverse 1 channel so just copy
+            } else { // Can't reverse 1 channel so just copy
                 channelData[destChannel + l] = channelData[sourceChannel];
             }
         }
@@ -96,20 +95,20 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
                     // Copy the required section of channel data to a temporary buffer
                     unsigned char* tempBuffer = new unsigned char[count];
                     memcpy(tempBuffer, channelData + sourceChannel, count);
-                    for (int c = 0; c < count - 2;) {
+                    for (int c = 0; c < count;) {
                         channelData[destChannel + c + 0] = tempBuffer[count - 1 - c - 2];
                         channelData[destChannel + c + 1] = tempBuffer[count - 1 - c - 1];
                         channelData[destChannel + c + 2] = tempBuffer[count - 1 - c - 0];
                         c += 3;
                     }
-                }
-                else { // Subsequent loops, just copy first reversed block for speed
+                    // Delete the temporary buffer
+                    delete[] tempBuffer;
+                } else { // Subsequent loops, just copy first reversed block for speed
                     memcpy(channelData + destChannel + (l * count),
-                        channelData + destChannel,
-                        count);
+                            channelData + destChannel,
+                            count);
                 }
-            }
-            else {
+            } else {
                 // Shouldn't ever get here, can't reverse pixels if only 1 channel
                 channelData[destChannel + l] = channelData[sourceChannel];
             }
@@ -130,14 +129,14 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
                         channelData[destChannel + c + 3] = tempBuffer[count - 1 - c - 0];
                         c += 4;
                     }
-                }
-                else { // Subsequent loops, just copy first reversed block for speed
+                    // Delete the temporary buffer
+                    delete[] tempBuffer;
+                } else { // Subsequent loops, just copy first reversed block for speed
                     memcpy(channelData + destChannel + (l * count),
-                        channelData + destChannel,
-                        count);
+                            channelData + destChannel,
+                            count);
                 }
-            }
-            else {
+            } else {
                 // Shouldn't ever get here, can't reverse pixels if only 1 channel
                 channelData[destChannel + l] = channelData[sourceChannel];
             }

--- a/src/channeloutput/processors/RemapOutputProcessor.cpp
+++ b/src/channeloutput/processors/RemapOutputProcessor.cpp
@@ -57,9 +57,10 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
         for (int l = 0; l < loops; l++) {
             if (count > 1) {
                 memcpy(channelData + destChannel + (l * count),
-                       channelData + sourceChannel,
-                       count);
-            } else {
+                    channelData + sourceChannel,
+                    count);
+            }
+            else {
                 channelData[destChannel + l] = channelData[sourceChannel];
             }
         }
@@ -69,15 +70,20 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
         for (int l = 0; l < loops; l++) {
             if (count > 1) {
                 if (!l) { // First loop, reverse while copying
+                    // Copy the required section of channel data to a temporary buffer
+                    unsigned char* tempBuffer = new unsigned char[count];
+                    memcpy(tempBuffer, channelData + sourceChannel, count);
                     for (int c = 0; c < count; c++) {
-                        channelData[destChannel + c] = channelData[sourceChannel + count - 1 - c];
+                        channelData[destChannel + c] = tempBuffer[count - 1 - c];
                     }
-                } else { // Subsequent loops, just copy first reversed block for speed
-                    memcpy(channelData + destChannel + (l * count),
-                           channelData + destChannel,
-                           count);
                 }
-            } else { // Can't reverse 1 channel so just copy
+                else { // Subsequent loops, just copy first reversed block for speed
+                    memcpy(channelData + destChannel + (l * count),
+                        channelData + destChannel,
+                        count);
+                }
+            }
+            else { // Can't reverse 1 channel so just copy
                 channelData[destChannel + l] = channelData[sourceChannel];
             }
         }
@@ -87,18 +93,23 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
         for (int l = 0; l < loops; l++) {
             if (count > 1) {
                 if (!l) { // First loop, reverse pixels while copying
-                    for (int c = 0; c < count;) {
-                        channelData[destChannel + c + 0] = channelData[sourceChannel + count - 1 - c - 2];
-                        channelData[destChannel + c + 1] = channelData[sourceChannel + count - 1 - c - 1];
-                        channelData[destChannel + c + 2] = channelData[sourceChannel + count - 1 - c - 0];
+                    // Copy the required section of channel data to a temporary buffer
+                    unsigned char* tempBuffer = new unsigned char[count];
+                    memcpy(tempBuffer, channelData + sourceChannel, count);
+                    for (int c = 0; c < count - 2;) {
+                        channelData[destChannel + c + 0] = tempBuffer[count - 1 - c - 2];
+                        channelData[destChannel + c + 1] = tempBuffer[count - 1 - c - 1];
+                        channelData[destChannel + c + 2] = tempBuffer[count - 1 - c - 0];
                         c += 3;
                     }
-                } else { // Subsequent loops, just copy first reversed block for speed
-                    memcpy(channelData + destChannel + (l * count),
-                           channelData + destChannel,
-                           count);
                 }
-            } else {
+                else { // Subsequent loops, just copy first reversed block for speed
+                    memcpy(channelData + destChannel + (l * count),
+                        channelData + destChannel,
+                        count);
+                }
+            }
+            else {
                 // Shouldn't ever get here, can't reverse pixels if only 1 channel
                 channelData[destChannel + l] = channelData[sourceChannel];
             }
@@ -109,19 +120,24 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
         for (int l = 0; l < loops; l++) {
             if (count > 1) {
                 if (!l) { // First loop, reverse pixels while copying
-                    for (int c = 0; c < count;) {
-                        channelData[destChannel + c + 0] = channelData[sourceChannel + count - 1 - c - 3];
-                        channelData[destChannel + c + 1] = channelData[sourceChannel + count - 1 - c - 2];
-                        channelData[destChannel + c + 2] = channelData[sourceChannel + count - 1 - c - 1];
-                        channelData[destChannel + c + 3] = channelData[sourceChannel + count - 1 - c - 0];
+                    // Copy the required section of channel data to a temporary buffer
+                    unsigned char* tempBuffer = new unsigned char[count];
+                    memcpy(tempBuffer, channelData + sourceChannel, count);
+                    for (int c = 0; c < count - 3;) {
+                        channelData[destChannel + c + 0] = tempBuffer[count - 1 - c - 3];
+                        channelData[destChannel + c + 1] = tempBuffer[count - 1 - c - 2];
+                        channelData[destChannel + c + 2] = tempBuffer[count - 1 - c - 1];
+                        channelData[destChannel + c + 3] = tempBuffer[count - 1 - c - 0];
                         c += 4;
                     }
-                } else { // Subsequent loops, just copy first reversed block for speed
-                    memcpy(channelData + destChannel + (l * count),
-                           channelData + destChannel,
-                           count);
                 }
-            } else {
+                else { // Subsequent loops, just copy first reversed block for speed
+                    memcpy(channelData + destChannel + (l * count),
+                        channelData + destChannel,
+                        count);
+                }
+            }
+            else {
                 // Shouldn't ever get here, can't reverse pixels if only 1 channel
                 channelData[destChannel + l] = channelData[sourceChannel];
             }

--- a/src/channeloutput/processors/RemapOutputProcessor.cpp
+++ b/src/channeloutput/processors/RemapOutputProcessor.cpp
@@ -95,7 +95,7 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
                     // Copy the required section of channel data to a temporary buffer
                     unsigned char* tempBuffer = new unsigned char[count];
                     memcpy(tempBuffer, channelData + sourceChannel, count);
-                    for (int c = 0; c < count;) {
+                    for (int c = 0; c < count - 2;) {
                         channelData[destChannel + c + 0] = tempBuffer[count - 1 - c - 2];
                         channelData[destChannel + c + 1] = tempBuffer[count - 1 - c - 1];
                         channelData[destChannel + c + 2] = tempBuffer[count - 1 - c - 0];

--- a/src/channeloutput/processors/RemapOutputProcessor.cpp
+++ b/src/channeloutput/processors/RemapOutputProcessor.cpp
@@ -105,8 +105,8 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
                     delete[] tempBuffer;
                 } else { // Subsequent loops, just copy first reversed block for speed
                     memcpy(channelData + destChannel + (l * count),
-                            channelData + destChannel,
-                            count);
+                           channelData + destChannel,
+                           count);
                 }
             } else {
                 // Shouldn't ever get here, can't reverse pixels if only 1 channel
@@ -133,8 +133,8 @@ void RemapOutputProcessor::ProcessData(unsigned char* channelData) const {
                     delete[] tempBuffer;
                 } else { // Subsequent loops, just copy first reversed block for speed
                     memcpy(channelData + destChannel + (l * count),
-                            channelData + destChannel,
-                            count);
+                           channelData + destChannel,
+                           count);
                 }
             } else {
                 // Shouldn't ever get here, can't reverse pixels if only 1 channel


### PR DESCRIPTION
Closes #1572.
Previously, the remap output processor reversed the channels into the input; this caused the strand to be mirrored because halfway through, it started using the already-reversed data from the other side. We fix this by copying the data we will reverse into a temporary buffer and using that instead.

Thanks!