### PR TITLE
Hostname change on initial setup

### DIFF
--- a/www/initialSetup.php
+++ b/www/initialSetup.php
@@ -23,6 +23,11 @@ function finishSetup() {
             return;
     }
 
+    if (settings['HostName'] == 'FPP') {
+        alert('Please change the default host name (FPP) to a unique name. ie FPPMain, MainPlayer, Player etc...');
+        return;
+    }
+
 <? if ($showOSSecurity) { ?>
     if ($('#osPasswordEnable').val() == '') {
         alert('You must choose to either use the default OS password or choose a custom password.');


### PR DESCRIPTION
New SOP is to use hostnames in setting up ctrls/players and proxies, so this helps to keep them unique if they have more than one and one less change when we help them configure it (the right way).