### PR TITLE
API update for subdir support

### DIFF
--- a/www/api/controllers/files.php
+++ b/www/api/controllers/files.php
@@ -130,7 +130,7 @@ function GetFiles()
 function GetFile()
 {
     $dirName = params("DirName");
-    $fileName = params("Name");
+    $fileName = params(0);
     $lines = -1;
     $play = 0;
     $attach = 0;

--- a/www/api/endpoints.json
+++ b/www/api/endpoints.json
@@ -513,10 +513,10 @@
             }
         },
         {
-            "endpoint": "file/:DirName/:Filename",
+            "endpoint": "file/:DirName(/:SubDir)/:Filename",
             "methods": {
                 "GET": {
-                    "desc": "Downloads the specified File where :DirName is one of ('config', 'effects', 'images', 'logs', 'music', 'playlists', 'plugins', 'scripts', 'sequences', 'tmp', 'upload', 'videos'). If ?tail=# is supplied then only the specified number of lines from the end of the file are returned. ?play=1 then will set the content type to be played rather than downloaded.",
+                    "desc": "Downloads the specified File where :DirName is one of ('config', 'effects', 'images', 'logs', 'music', 'playlists', 'plugins', 'scripts', 'sequences', 'tmp', 'upload', 'videos'). Optionally can provide a :SubDir. If ?tail=# is supplied then only the specified number of lines from the end of the file are returned. ?play=1 then will set the content type to be played rather than downloaded.",
                     "output": "The File Contents"
                 },
                 "DELETE": {

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -58,7 +58,7 @@ dispatch_get('/file/move/:fileName', 'MoveFile'); // keep above file/:DirName
 dispatch_get('/files/zip/:DirNames', 'GetZipDir');
 dispatch_post('/file/:DirName/copy/:source/:dest', 'files_copy');
 dispatch_post('/file/:DirName/rename/:source/:dest', 'files_rename');
-dispatch_get('/file/:DirName/:Name', 'GetFile');
+dispatch_get('/file/:DirName/**', 'GetFile');
 dispatch_delete('/file/:DirName/:Name', 'DeleteFile');
 dispatch_post('/file/:DirName', 'PatchFile');
 dispatch_patch('/file/:DirName', 'PatchFile');

--- a/www/common.php
+++ b/www/common.php
@@ -1392,21 +1392,12 @@ function media_duration_cache($media, $duration_seconds = null, $filesize = null
  */
 function human_filesize($path)
 {
-    // cannot use filesize($path) as that returns a signed 32bit number so maxes out at 2GB
-    $kbytes = trim(shell_exec("du -k \"" . $path . "\" | cut -f1 "));
-    if (strlen($kbytes) < 3) {
-        $bytes = filesize($path);
-        $sz = 'BKMGTP';
-        $factor = floor((strlen($bytes) - 1) / 3);
-        if ($factor) {
-            return sprintf("%.2f", $bytes / pow(1024, $factor)) . @$sz[$factor] . ($factor > 0 ? "B" : "");
-        }
-
-        return sprintf("%d", $bytes / pow(1024, $factor)) . @$sz[$factor] . ($factor > 0 ? "B" : "");
-    }
-    $sz = 'KMGTP';
-    $factor = floor((strlen($kbytes) - 1) / 3);
-    return sprintf("%.2f", $kbytes / pow(1024, $factor)) . @$sz[$factor] . "B";
+    // cannot use PHP's filesize($path) as that returns a signed 32bit number so maxes out at 2GB
+    // Using du -bs to return one human readable file size (or total directory size) even if subdirs are present
+    // Additional shell ternary is to keep prior number formatting
+    return trim(shell_exec("tsz=$(du -bs \"" . $path . "\" | cut -f1); [ \$tsz -ge 1024 ] && numfmt --to=iec --format=%.2f \$tsz || echo \$tsz")) . "B";
+    // Alternative for 1000 bytes to 1KB
+    //return trim(shell_exec("tsz=$(du -bs \"" . $path . "\" | cut -f1); [ \$tsz -ge 1000 ] && numfmt --to=si --format=%.2f \$tsz || echo \$tsz")) . "B";
 }
 
 /**


### PR DESCRIPTION
With a plugin installed that contains subdirectories (like fpp-ArtNetAdv)
There is an error opening /api/files/plugins
In /opt/fpp/www/common.php on line 1409 AND sizeHuman is shown as 0.00B

In common.php, function human_filesize used du -k which can return multiple lines of output when subdirectories are present
Switched to du -bs to return one human readable file size (or directory total size) in bytes
Added some additional logic to keep the size formatting the same

Attempting to use /api/file/:DirName/:FileName GET for a file in a subdirectory failed
Updated to /api/file/:DirName/** to support subdirectories
Modified GetFile to use the ** value as the fileName
Did a grep for usage in FPP and it appears everything still works as expected
Updated endpoints.js