### PR TITLE
Preserve unicode characters in media tags for plugin JSON

### DIFF
--- a/src/mediadetails.cpp
+++ b/src/mediadetails.cpp
@@ -100,13 +100,13 @@ void MediaDetails::ParseMedia(const char* mediaFilename) {
 
     TagLib::Tag* tag = f.tag();
 
-    title = tag->title().toCString();
-    artist = tag->artist().toCString();
-    album = tag->album().toCString();
+    title = tag->title().toCString(true);
+    artist = tag->artist().toCString(true);
+    album = tag->album().toCString(true);
     year = tag->year();
-    comment = tag->comment().toCString();
+    comment = tag->comment().toCString(true);
     track = tag->track();
-    genre = tag->genre().toCString();
+    genre = tag->genre().toCString(true);
 
     if (f.audioProperties()) {
         TagLib::AudioProperties* properties = f.audioProperties();


### PR DESCRIPTION
Found that special characters (unicode) like in Michael Bublé or Måneskin were not included in the media JSON sent to plugins

Changed mediadetails.cpp to preserve unicode characters for title, artist, album, comment, and genre

Testing:
Created ogg, mp3, and mp4 files with the above tags having values like
```
ěščřžýáíéúůŠČŘŽĚÝÁÉÚŮňŇÄäÖöÜüËÈèêùñìçôśźå
1À 2Á 3Â 4Ã 5Ä 6Å 7Ā 8Ă 9Ą 10Ǎ 11Ǟ 12Ǡ 13Ȁ 14Ȃ
```

Based on a code search for MediaDetails, I tested the following
- LogDebug Plugin worked as expected in mediadetails.cpp
- LogDebug MediaOut worked as expected in Plugins.cpp
- JSON sent to plugins worked as expected in Plugins.cpp
- MQTT title and artist worked as expected in PlaylistEntryMedia.cpp (via mosquitto_sub -v -h localhost -t "falcon/#")
- (MP4) File Manager -> Video Info displays correctly