### PR TITLE
Update regex in ReadSettingFromFile to parse setting values with spaces.

### DIFF
--- a/www/common.php
+++ b/www/common.php
@@ -102,7 +102,7 @@ function ReadSettingFromFile($settingName, $plugin = "")
     }
     if (!empty($settingsStr)) {
         if (preg_match("/^" . $settingName . "/m", $settingsStr)) {
-            $result = preg_match("/^" . $settingName . "\s*=(\s*\S*\w*)/m", $settingsStr, $output_array);
+            $result = preg_match("/^" . $settingName . "\s*=(.+)/m", $settingsStr, $output_array);
             if ($result == 0) {
 //        error_log("The setting " . $settingName . " could not be found in " . $filename);
                 return false;


### PR DESCRIPTION
Updated the regex for parsing the setting value in common.php `ReadSettingFromFile`. Previous regex was unable to parse setting values that contained spaces and only returned the value up to the first whitespace. For example, a setting value of "Some Playlist" would return only "Some". Current regex allows all characters within the setting value to be returned.