### PR TITLE
Use FalconPlayer NTP Pool

### DIFF
--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -462,7 +462,7 @@ case "${OSVER}" in
         ACTUAL_PHPVER="7.4"
         if [ "${OSVER}" == "ubuntu_22.04" -o "${OSVER}" == "linuxmint_21" ]; then
             PHPVER="7.4"
-            echo "FPP - Forceing PHP 7.4"
+            echo "FPP - Forcing PHP 7.4"
             apt install software-properties-common apt-transport-https -y
             add-apt-repository ppa:ondrej/php -y
             apt-get -y update
@@ -1268,6 +1268,15 @@ case "${OSVER}" in
 		systemctl enable apache2.service
 		;;
 esac
+
+
+#######################################
+echo "FPP - Configuring NTP Daemon"
+
+# Clear all existing servers and pools and set default pool to be falconplayer NTP Pool
+sed -i '/^server.*/d' /etc/ntp.conf 
+sed -i '/^pool.*/d' /etc/ntp.conf 
+sed -i '\$s/\$/\\npool falconplayer.pool.ntp.org iburst minpoll 8 maxpoll 12 prefer/' /etc/ntp.conf
 
 
 if [ "x${FPPPLATFORM}" = "xBeagleBone Black" ]; then

--- a/www/common/settings.php
+++ b/www/common/settings.php
@@ -62,7 +62,8 @@ function SetNTPServer($value)
     if ($value != '') {
         exec("sudo sed -i '/^server.*/d' /etc/ntp.conf ; sudo sed -i '/^pool.*/d' /etc/ntp.conf ; sudo sed -i '\$s/\$/\\nserver $value iburst/' /etc/ntp.conf");
     } else {
-        exec("sudo sed -i '/^server.*/d' /etc/ntp.conf ; sudo sed -i '/^pool.*/d' /etc/ntp.conf ; sudo sed -i '\$s/\$/\\npool 0.debian.pool.ntp.org iburst\\npool 1.debian.pool.ntp.org iburst\\npool 2.debian.pool.ntp.org iburst\\npool 3.debian.pool.ntp.org iburst\\n/' /etc/ntp.conf");
+		// Updated as we should be using our own zone falconplayer.pool.ntp.org
+        exec("sudo sed -i '/^server.*/d' /etc/ntp.conf ; sudo sed -i '/^pool.*/d' /etc/ntp.conf ; sudo sed -i '\$s/\$/\\npool falconplayer.pool.ntp.org iburst minpoll 8 maxpoll 12 prefer/' /etc/ntp.conf");
     }
 
     // Note: Assume NTP is always enabled now.


### PR DESCRIPTION
Remove default Debian pool and use the custom one assigned to the project. Sets this when NTP server is cleared and on initial installation.