### PR TITLE
Add Setting name in callback

### DIFF
--- a/www/common.php
+++ b/www/common.php
@@ -791,7 +791,7 @@ function PrintSettingSelectInternal($title, $setting, $restart, $reboot, $defaul
     }
 
     if ($callbackName != "" && ($callbackName[strlen($callbackName) - 1] != ")")) {
-        $callbackName = $callbackName . "();";
+        $callbackName = $callbackName . "('$setting');";
     }
 
     if ($changedFunction == "") {
@@ -958,7 +958,7 @@ function PrintSettingTextSaved($setting, $restart = 1, $reboot = 0, $maxlength =
     }
 
     if ($callbackName != "" && ($callbackName[strlen($callbackName) - 1] != ")")) {
-        $callbackName = $callbackName . "();";
+        $callbackName = $callbackName . "('$setting');";
     }
 
     if ($changedFunction == "") {
@@ -1129,7 +1129,7 @@ function PrintSettingSave($title, $setting, $restart = 1, $reboot = 0, $pluginNa
     }
 
     if ($callbackName != "" && ($callbackName[strlen($callbackName) - 1] != ")")) {
-        $callbackName = $callbackName . "();";
+        $callbackName = $callbackName . "('$setting');";
     }
 
     $saveFunction = preg_replace('/\./', '', $setting . "Changed");


### PR DESCRIPTION
Added the setting name to the call back function call for the other PrintSetting* functions that use it.

This was implemented for PrintSettingCheckbox back in https://github.com/FalconChristmas/fpp/commit/19ae97bdb6046d4734ac18f7858846bdf5befbe8 
In that commit, it appears the intent was to add this to all the PrintSetting* callback functions, but was only implemented for Checkbox.