### PR TITLE
Docker tweaks for FPP 8.x and Windows

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,7 +5,8 @@ FROM debian:bookworm
 # so building docker containers will be faster
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -yq upgrade
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"  alsa-utils arping avahi-daemon avahi-utils locales nano net-tools \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -o Acquire::Retries=32 \
+alsa-utils arping avahi-daemon avahi-utils locales nano net-tools \
     apache2 apache2-bin apache2-data apache2-utils \
     bc bash-completion btrfs-progs exfat-fuse lsof ethtool curl zip unzip bzip2 wireless-tools dos2unix \
     fbi fbset file flite ca-certificates lshw ffmpeg mp3gain \
@@ -18,10 +19,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq -o Dpkg::Options::="--for
     vorbis-tools libgraphicsmagick++1-dev graphicsmagick-libmagick-dev-compat libmicrohttpd-dev \
     libmosquitto-dev mosquitto-clients mosquitto libzstd-dev lzma zstd gpiod libgpiod-dev libjsoncpp-dev libcurl4-openssl-dev \
     gettext apt-utils x265 libtheora-dev libvorbis-dev libx265-dev iputils-ping libssl-dev libusb-1.0-0-dev \
-    wget flex bison pkg-config libasound2-dev mesa-common-dev python3-distutils libssl-dev libtool bsdextrautils iw ; apt-get clean
+    wget flex bison pkg-config libasound2-dev mesa-common-dev python3-distutils libssl-dev libtool bsdextrautils iw && apt-get clean
 
 # similar to above, do this once and Docker can cache the intermediary
-ADD SD/buildVLC.sh /root/buildVLC.sh
+COPY SD/buildVLC.sh /root/buildVLC.sh
 RUN ( yes | /root/buildVLC.sh ) || true
 
 
@@ -33,8 +34,8 @@ ARG EXTRA_INSTALL_FLAG=
 # branch being build
 ARG FPPBRANCH
 
-ADD ./ /opt/fpp/
-ADD SD/FPP_Install.sh /root/FPP_Install.sh
+COPY ./ /opt/fpp/
+COPY SD/FPP_Install.sh /root/FPP_Install.sh
 RUN ( yes | bash /root/FPP_Install.sh $EXTRA_INSTALL_FLAG --branch ${FPPBRANCH:-master} --skip-apt-install --skip-vlc )
 RUN rm -rf /tmp/*
 RUN cp /opt/fpp/etc/asoundrc.plain /root/.asoundrc

--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -382,8 +382,9 @@ case "${OSVER}" in
 				;;
 			*)
 				echo "FPP - Enabling non-free repo"
-				sed -i -e "s/^deb \(.*\)/deb \1 non-free/" /etc/apt/sources.list
-				sed -i -e "s/non-free\(.*\)non-free/non-free\1/" /etc/apt/sources.list
+				sed -i -e "s/Components: main/Components: main contrib non-free non-free-firmware/" /etc/apt/sources.list.d/debian.sources
+                #sed -i -e "s/^deb \(.*\)/deb \1 non-free/" /etc/apt/sources.list
+				#sed -i -e "s/non-free\(.*\)non-free/non-free\1/" /etc/apt/sources.list
 				;;
 		esac
 
@@ -964,7 +965,7 @@ fi
 
 #######################################
 # Upgrade the config if needed
-sh scripts/upgrade_config -notee
+bash scripts/upgrade_config -notee
 
 
 #######################################
@@ -1299,9 +1300,9 @@ esac
 echo "FPP - Configuring NTP Daemon"
 
 # Clear all existing servers and pools and set default pool to be falconplayer NTP Pool
-sed -i '/^server.*/d' /etc/ntp.conf 
-sed -i '/^pool.*/d' /etc/ntp.conf 
-sed -i '$s/$/\npool falconplayer.pool.ntp.org iburst minpoll 8 maxpoll 12 prefer/' /etc/ntp.conf
+sed -i '/^server.*/d' /etc/ntpsec/ntp.conf 
+sed -i '/^pool.*/d' /etc/ntpsec/ntp.conf 
+sed -i '$s/$/\npool falconplayer.pool.ntp.org iburst minpoll 8 maxpoll 12 prefer/' /etc/ntpsec/ntp.conf
 
 
 if [ "x${FPPPLATFORM}" = "xBeagleBone Black" ]; then

--- a/dockerBuildWin.ps1
+++ b/dockerBuildWin.ps1
@@ -1,0 +1,30 @@
+# Steps for building FPP Docker on Windows
+# Install latest PowerShell https://github.com/PowerShell/PowerShell/releases
+# Install WSL https://learn.microsoft.com/en-us/windows/wsl/install
+#   Open PowerShell
+#   wsl --install
+# Install Docker Desktop https://docs.docker.com/desktop/install/windows-install/
+#   Use 4.25.2 as of 2/15/2024, since a bug in 4.26.0 causes "ERROR: failed to solve: Canceled: context canceled"
+#   Tracking issue is https://github.com/docker/for-win/issues/13812
+# Set git to handle line endings so that scripts will work
+#   git config --global core.autocrlf input
+# Pull down FPP repo for git
+# Run this powershell script from your local repo directory
+
+# If you already have the FPP repo pulled down, follow these steps to fix the line endings
+# Fix line endings - https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+#  git config --global core.autocrlf input
+#  git rm -rf --cached .
+#  git reset --hard HEAD
+
+$env:FPPBRANCH = $env:FPPBRANCH ?? "master"
+
+# build the docker image
+docker build -t falconchristmas/fpp:latest -f Docker/Dockerfile --build-arg FPPBRANCH=$env:FPPBRANCH .
+#or
+#docker build -t falconchristmas/fpp:latest  --build-arg EXTRA_INSTALL_FLAG=--skip-clone -f Docker/Dockerfile .
+
+# docker run --name fpp --hostname fppDocker -t -i -p 80:80 -p 4048:4048/udp -p 5568:5568/udp -p 32320:32320/udp -v ${PWD}:/opt/fpp${DOCKER_MOUNT_FLAG} falconchristmas/fpp:latest
+
+# A sample docker-compose.yml file to use the docker image is also
+# included in the Docker directory.


### PR DESCRIPTION
Updates and tweaks to docker for 8.x
-   Increased number of retries for apt to reduce likelihood of download failures from Debian server
-   Changed ; to && to have docker stop if there was a failure
-   Switched ADD to COPY based on current docker recommendations
-   A few tweaks in the FPP_Install.sh related to path changes in Debian bookworm
-   Using bash instead of sh with upgrade_config to fix an error

Added a PowerShell script with instructions for building the image on Windows