### PR TITLE
[MQTT] Add option to publish output port information  including current draw

### DIFF
--- a/docs/MQTT.txt
+++ b/docs/MQTT.txt
@@ -182,7 +182,7 @@ entries in a Playlist are allowed, only one will be displayed in real life.
    ]
 }
 
-Message Example for fppd_status
+Message Example for port_status 
 ---------------------------------------------
 When output sensors are present, this will report the status of each port and how many milliamps were
 being pulled when the port was sampled. 

--- a/docs/MQTT.txt
+++ b/docs/MQTT.txt
@@ -32,6 +32,7 @@ FPP will published the following sub_topics (using the full topic format) if MQT
 */playlist/media/artist - The artist listing in the audio / video file being played
 */playlist_details - If the MQTT Playlist Publish Frequency option (Advanced settings) is > 0 then a JSON file is published based on the duration (seconds) specified. 
 */fppd_status - If the MQTT Status Publish Frequency option (Advanced settings) is > 0 then a JSON file is published based on the duration (seconds) specified. 
+*/port_status - If the MQTT Port Status Publish Frequency option (Advanced settings) is > 0 then a JSON file is published based on the duration (seconds) specified. 
 
 Message Example for fppd_status
 ---------------------------------------------
@@ -180,6 +181,45 @@ entries in a Playlist are allowed, only one will be displayed in real life.
       }
    ]
 }
+
+Message Example for fppd_status
+---------------------------------------------
+When output sensors are present, this will report the status of each port and how many milliamps were
+being pulled when the port was sampled. 
+[
+  {
+    "col": 1,
+    "enabled": true,
+    "ma": 435,
+    "name": "Port #1",
+    "row": 1,
+    "status": true
+  },
+  {
+    "col": 2,
+    "enabled": false,
+    "ma": 0,
+    "name": "Port #2",
+    "row": 1,
+    "status": true
+  },
+  {
+    "col": 3,
+    "enabled": false,
+    "ma": 0,
+    "name": "Port #3",
+    "row": 1,
+    "status": true
+  },
+  {
+    "col": 4,
+    "enabled": false,
+    "ma": 0,
+    "name": "Port #4",
+    "row": 1,
+    "status": true
+  }
+]
 
 
 

--- a/src/OutputMonitor.h
+++ b/src/OutputMonitor.h
@@ -36,10 +36,12 @@ public:
     void EnableOutputs();
     void DisableOutputs();
 
-    void SetOutput(const std::string &port, bool on);
+    void SetOutput(const std::string& port, bool on);
 
     void AutoEnableOutputs();
     void AutoDisableOutputs();
+
+    void GetCurrentPortStatusJson(Json::Value& result);
 
     virtual HTTP_RESPONSE_CONST std::shared_ptr<httpserver::http_response> render_GET(const httpserver::http_request& req) override;
 

--- a/www/settings.json
+++ b/www/settings.json
@@ -128,6 +128,7 @@
                 "MQTTPassword",
                 "MQTTCaFile",
                 "MQTTFrequency",
+                "MQTTPortStatusFrequency",
                 "MQTTStatusFrequency",
                 "MQTTSubscribe"
             ]
@@ -1560,6 +1561,18 @@
             "max": 65535,
             "step": 1
         },
+        "MQTTPortStatusFrequency": {
+            "name": "MQTTPortStatusFrequency",
+            "description": "Publish Port Status Frequency",
+            "gatherStats": true,
+            "tip": "Optional frequency to publish Port Monitoring status Json to MQTT Broker.  Zero indicates that the status will not be published",
+            "restart": 2,
+            "default": 0,
+            "type": "number",
+            "min": 0,
+            "max": 3600,
+            "step": 1
+        },
         "MQTTPrefix": {
             "name": "MQTTPrefix",
             "description": "Topic Prefix",
@@ -1580,7 +1593,7 @@
         },
         "MQTTStatusFrequency": {
             "name": "MQTTStatusFrequency",
-            "description": "Publish Status Frequency",
+            "description": "Publish FPPD Status Frequency",
             "gatherStats": true,
             "tip": "Optional frequency to publish FPP status Json to MQTT Broker.  Zero indicates that the status will not be published",
             "restart": 2,


### PR DESCRIPTION
This PR adds a new configuration option on MQTT screen.  When greater than zero, the status of each port (including point in time current draw) is published via MQTT.  

Closes #1661