### PR TITLE
Add a check to compare fpp system time against the browser time

### DIFF
--- a/scripts/healthCheck
+++ b/scripts/healthCheck
@@ -21,6 +21,12 @@ then
     PHPOUT="y"
 fi
 
+
+if [ ${#2} -gt 1 ]
+then
+    BROWSER_TIME="$2"
+fi
+
 ID=0
 
 #############################################################################
@@ -226,7 +232,7 @@ HC_DNS() {
 }
 
 HC_NTPOffset() {
-    PrintItemHead "Time Offset"
+    PrintItemHead "Network Time Protocol Offset"
 
     # ntpq is not fully reliable, additional verification may be required
     offsets=$(ntpq -nc peers | tail -n +3 | cut -c 62-66 | tr -d '\.-')
@@ -240,6 +246,38 @@ HC_NTPOffset() {
             STATUSSTR="Your time may be incorrect, please verify"
         fi
     done
+
+    PrintItemFoot
+}
+
+HC_DateTime() {
+    PrintItemHead "FPP Date/Time Alignment to Browser"
+
+    # Compare FPP system time against the browser setting (passed as 2nd arg to script)
+    fppsystem_timestamp=$(date +%s)
+    WARN_THRESHOLD=600 #10 minutes (in seconds)
+    FAIL_THRESHOLD=14400 #4 hours (in seconds)
+    WARN_MIN=$(($BROWSER_TIME - $WARN_THRESHOLD))
+    WARN_MAX=$(($BROWSER_TIME + $WARN_THRESHOLD))
+    FAIL_MIN=$(($BROWSER_TIME - $FAIL_THRESHOLD))
+    FAIL_MAX=$(($BROWSER_TIME + $FAIL_THRESHOLD))
+    #echo "FPP TIME: "$fppsystem_timestamp
+    #echo "BROWSER TIME: "$BROWSER_TIME
+    #echo "WARN_MIN: $WARN_MIN"
+    #echo "WARN_MAX: $WARN_MAX"
+    STATUS=1
+    STATUSSTR="Your FPP system date/time is aligned to the browser"
+
+
+    if [ "$fppsystem_timestamp" -ge "$FAIL_MAX" ] || [ "$fppsystem_timestamp" -le "$FAIL_MIN" ]; then
+        STATUS=0
+        STATUSSTR="Your FPP system date/time is significantly different to the browser, please verify"
+        if [ "$fppsystem_timestamp" -le "$WARN_MAX" ] || [ "$fppsystem_timestamp" -ge "$WARN_MIN" ]; then
+        STATUS=2
+        STATUSSTR="Your FPP system date/time is more than 10 mins different to the browser, please verify"
+        fi
+    fi
+
 
     PrintItemFoot
 }
@@ -346,6 +384,9 @@ then
         fi
     fi
 fi
+############################
+# Date / Time
+HC_DateTime
 
 #############################
 # System Resources

--- a/www/healthCheck.php
+++ b/www/healthCheck.php
@@ -1,67 +1,76 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-<?php
-require_once('config.php');
-require_once('common.php');
-include 'common/menuHead.inc';
-?>
-<script>
-function HealthCheckDone() {
-    // fixme, maybe hide/enable a 're-run' button here
-    SetButtonState('#btnStartHealthCheck','enable');
-}
+    <?php
+    require_once ('config.php');
+    require_once ('common.php');
+    include 'common/menuHead.inc';
+    ?>
+    <script>
+        function HealthCheckDone() {
+            // fixme, maybe hide/enable a 're-run' button here
+            SetButtonState('#btnStartHealthCheck', 'enable');
+        }
 
-function StartHealthCheck() {
-    SetButtonState('#btnStartHealthCheck','disable');
-    $('#healthCheckOutput').html('');
-    //StreamURL('healthCheckHelper.php?output=php', 'healthCheckOutput', 'HealthCheckDone', '', 'GET', null, null, true, true);  //commented out by onlinedynamic as function giving broken results on Firefox browser
+        function StartHealthCheck() {
+            SetButtonState('#btnStartHealthCheck', 'disable');
+            $('#healthCheckOutput').html('');
+            //StreamURL('healthCheckHelper.php?output=php', 'healthCheckOutput', 'HealthCheckDone', '', 'GET', null, null, true, true);  //commented out by onlinedynamic as function giving broken results on Firefox browser
 
-    $.ajax({
-        url: "healthCheckHelper.php?output=php",
-        method: "GET",
-        dataType: "HTML"
-    }).done(function(html) {
-        $("#healthCheckOutput").append(html);
-        HealthCheckDone();
-        }); 
-    
-}
+            $.ajax({
+                url: "healthCheckHelper.php?output=php&timestamp=" + (Date.parse(Date()) / 1000),
+                method: "GET",
+                dataType: "HTML"
+            }).done(function (html) {
+                $("#healthCheckOutput").append(html);
+                HealthCheckDone();
+            });
 
-</script>
+        }
 
-<title><? echo $pageTitle; ?></title>
+    </script>
+
+    <title><? echo $pageTitle; ?></title>
 </head>
+
 <body class="is-loading" onLoad="StartHealthCheck();">
-<div id="bodyWrapper">
-<?php
-$activeParentMenuItem = 'help'; 
-include 'menu.inc'; ?>
-  <div class="mainContainer">
-    <h2 class="title d-none d-sm-block ">FPP Health Check</h2>
-    <div class="pageContent">
-        <div id="healthCheck" class="">
+    <div id="bodyWrapper">
+        <?php
+        $activeParentMenuItem = 'help';
+        include 'menu.inc'; ?>
+        <div class="mainContainer">
+            <h2 class="title d-none d-sm-block ">FPP Health Check</h2>
+            <div class="pageContent">
+                <div id="healthCheck" class="">
 
-<?php
-if (isset($settings["UnpartitionedSpace"]) && $settings["UnpartitionedSpace"] > 0) {
-?>
-<div id='upgradeFlag' class="alert alert-danger" role="alert">
-     SD card has unused space.  Go to
-     <a href="settings.php?tab=Storage">Storage Settings</a> to expand the
-     file system or create a new storage partition.
-</div>
+                    <?php
+                    if (isset($settings["UnpartitionedSpace"]) && $settings["UnpartitionedSpace"] > 0) {
+                        ?>
+                        <div id='upgradeFlag' class="alert alert-danger" role="alert">
+                            SD card has unused space. Go to
+                            <a href="settings.php?tab=Storage">Storage Settings</a> to expand the
+                            file system or create a new storage partition.
+                        </div>
 
-<?php
-}
-?>
-        <div id="warningsRow" class="alert alert-danger"><div id="warningsTd"><div id="warningsDiv"></div></div></div>
+                        <?php
+                    }
+                    ?>
+                    <div id="warningsRow" class="alert alert-danger">
+                        <div id="warningsTd">
+                            <div id="warningsDiv"></div>
+                        </div>
+                    </div>
 
-        <button id='btnStartHealthCheck' class='buttons wideButton disabled' onClick='StartHealthCheck();'>Restart Health Check</button>
+                    <button id='btnStartHealthCheck' class='buttons wideButton disabled'
+                        onClick='StartHealthCheck();'>Restart Health Check</button>
 
-        <div name='shouldUseCSSInstead' class='container-fluid' style='width: 90%; height: 90%;' disabled id='healthCheckOutput'></div>
-    </div>
-</div>
-<?php	include 'common/footer.inc'; ?>
-</div>
+                    <div name='shouldUseCSSInstead' class='container-fluid' style='width: 90%; height: 90%;' disabled
+                        id='healthCheckOutput'></div>
+                </div>
+            </div>
+            <?php include 'common/footer.inc'; ?>
+        </div>
 </body>
+
 </html>

--- a/www/healthCheckHelper.php
+++ b/www/healthCheckHelper.php
@@ -1,10 +1,10 @@
 <?
-header( "Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: *");
 
 $skipJSsettings = 1;
-require_once("common.php");
+require_once ("common.php");
 
 DisableOutputBuffering();
 
-system($settings["fppDir"] . "/scripts/healthCheck --php");
+system($settings["fppDir"] . "/scripts/healthCheck --php " . $_GET['timestamp']);
 ?>


### PR DESCRIPTION
In response to #1834 this PR creates a new Health check which compares the system time against the browser time.

If they are more than 10 mins apart it displays a warning 'amber alert' and if more than 4 hours different a red warning.

It also renames the existing time offset check to make it clear that relates to NTP offset