### PR TITLE
Repair the remote command execution vulnerability in www/flash-pi-usb.php

### DIFF
--- a/www/flash-pi-usb.php
+++ b/www/flash-pi-usb.php
@@ -7,7 +7,7 @@ require_once("common.php");
 DisableOutputBuffering();
 
 
-$device = $_GET['dev'];
+$device = escapeshellarg($_GET['dev']);
 $clone = $_GET['clone'];
 $cloneFlag = "";
 if ($clone == 'true') {


### PR DESCRIPTION
Repair the remote command execution vulnerability in www/flash-pi-usb.php file and use escapeshellarg function to format the incoming parameters.

Issue: https://github.com/FalconChristmas/fpp/issues/1863