### PR TITLE
Seperation of Vendor Logo's and Cape Logo's

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -134,7 +134,8 @@
         "numbers": "cpp",
         "semaphore": "cpp",
         "charconv": "cpp",
-        "execution": "cpp"
+        "execution": "cpp",
+        "menu.inc": "php"
     },
     "editor.formatOnSave": true,
     "cmake.configureOnOpen": false,

--- a/www/cape-info.php
+++ b/www/cape-info.php
@@ -72,10 +72,12 @@ if (isset($settings["cape-info"])) {
                 if (substr($file, 0, 1) != '.') {
                     $json = file_get_contents($path . $file);
                     $data = json_decode($json, true);
-                    if ((isset($data['driver'])) &&
+                    if (
+                        (isset($data['driver'])) &&
                         (($data['driver'] == 'DPIPixels') ||
                             ($data['driver'] == 'BBB48String') ||
-                            ($data['driver'] == 'BBShiftString'))) {
+                            ($data['driver'] == 'BBShiftString'))
+                    ) {
                         $channelOutputDriver = $data['driver'];
                         break;
                     }
@@ -127,60 +129,82 @@ if (isset($settings["cape-info"])) {
 ?>
 
 <head>
-<?php
-include 'common/menuHead.inc';
-?>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<script language='Javascript' src='https://<?=$APIhost?>/js/internetTest.js?ref=<?php echo time(); ?>'></script>
-<script language="Javascript">
+    <?php
+    include 'common/menuHead.inc';
+    ?>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <script language='Javascript' src='https://<?= $APIhost ?>/js/internetTest.js?ref=<?php echo time(); ?>'></script>
+    <script language="Javascript">
 
-function CloseUpgradeDialog(reload = false) {
-    $('#upgradePopup').fppDialog('close');
-    if (reload)
-        location.reload();
-}
-
-
-
-function RestoreDone() {
-    EnableModalDialogCloseButton("RestoreEEPROM");
-    $("#RestoreEEPROMCloseButton").prop("disabled", false);
-}
-
-function RestoreFirmwareDone() {
-    var txt = $('#RestoreEEPROMText').val();
-    if (txt.includes("Cape does not match new firmware")) {
-        var arrayOfLines = txt.match(/[^\r\n]+/g);
-        var msg = "Are you sure you want to replace the firmware for cape:\n" + arrayOfLines[1] + "\n\nWith the firmware for: \n" + arrayOfLines[2] + "\n";
-        if (confirm(msg)) {
-            var filename = $('#backupFile').val();
-            $('#RestoreEEPROMText').html('');
-            StreamURL('upgradeCapeFirmware.php?force=true&filename=' + filename, 'RestoreEEPROMText', 'RestoreDone', 'RestoreDone', 'GET', null, false, false);
+        function CloseUpgradeDialog(reload = false) {
+            $('#upgradePopup').fppDialog('close');
+            if (reload)
+                location.reload();
         }
-    }
-    RestoreDone();
-}
 
-function RestoreFirmware() {
-    var filename = $('#backupFile').val();
 
-    DisplayProgressDialog("RestoreEEPROM", "Restore Cape Firmware");
-    StreamURL('upgradeCapeFirmware.php?filename=' + filename, 'RestoreEEPROMText', 'RestoreFirmwareDone', 'RestoreFirmwareDone', 'GET', null, false, false);
-}
 
-function UpgradeDone() {
-    EnableModalDialogCloseButton("UpgradeEEPROM");
-    $("#UpgradeEEPROMCloseButton").prop("disabled", false);
-}
+        function RestoreDone() {
+            EnableModalDialogCloseButton("RestoreEEPROM");
+            $("#RestoreEEPROMCloseButton").prop("disabled", false);
+        }
 
-function UpgradeFirmwareDone() {
-    var txt = $('#UpgradeEEPROMText').val();
-    if (txt.includes("Cape does not match new firmware")) {
-        var arrayOfLines = txt.match(/[^\r\n]+/g);
-        var msg = "Are you sure you want to replace the firmware for cape:\n" + arrayOfLines[2] + "\n\nWith the firmware for: \n" + arrayOfLines[3] + "\n";
-        if (confirm(msg)) {
+        function RestoreFirmwareDone() {
+            var txt = $('#RestoreEEPROMText').val();
+            if (txt.includes("Cape does not match new firmware")) {
+                var arrayOfLines = txt.match(/[^\r\n]+/g);
+                var msg = "Are you sure you want to replace the firmware for cape:\n" + arrayOfLines[1] + "\n\nWith the firmware for: \n" + arrayOfLines[2] + "\n";
+                if (confirm(msg)) {
+                    var filename = $('#backupFile').val();
+                    $('#RestoreEEPROMText').html('');
+                    StreamURL('upgradeCapeFirmware.php?force=true&filename=' + filename, 'RestoreEEPROMText', 'RestoreDone', 'RestoreDone', 'GET', null, false, false);
+                }
+            }
+            RestoreDone();
+        }
+
+        function RestoreFirmware() {
+            var filename = $('#backupFile').val();
+
+            DisplayProgressDialog("RestoreEEPROM", "Restore Cape Firmware");
+            StreamURL('upgradeCapeFirmware.php?filename=' + filename, 'RestoreEEPROMText', 'RestoreFirmwareDone', 'RestoreFirmwareDone', 'GET', null, false, false);
+        }
+
+        function UpgradeDone() {
+            EnableModalDialogCloseButton("UpgradeEEPROM");
+            $("#UpgradeEEPROMCloseButton").prop("disabled", false);
+        }
+
+        function UpgradeFirmwareDone() {
+            var txt = $('#UpgradeEEPROMText').val();
+            if (txt.includes("Cape does not match new firmware")) {
+                var arrayOfLines = txt.match(/[^\r\n]+/g);
+                var msg = "Are you sure you want to replace the firmware for cape:\n" + arrayOfLines[2] + "\n\nWith the firmware for: \n" + arrayOfLines[3] + "\n";
+                if (confirm(msg)) {
+                    var eepromFile = $('#eepromVendorCapeVersions').val();
+                    let firmware = document.getElementById("firmware").files[0];
+
+                    let formData = new FormData();
+
+                    if (eepromFile != '') {
+                        formData.append("filename", eepromFile);
+                    } else {
+                        formData.append("firmware", firmware);
+                    }
+
+                    $('#UpgradeEEPROMText').html('');
+                    StreamURL('upgradeCapeFirmware.php?force=true', 'UpgradeEEPROMText', 'UpgradeDone', 'UpgradeDone', 'POST', formData, false, false);
+                }
+            }
+            UpgradeDone();
+        }
+        function UpgradeFirmware(force = false) {
             var eepromFile = $('#eepromVendorCapeVersions').val();
             let firmware = document.getElementById("firmware").files[0];
+            if ((eepromFile == '') && (firmware == "" || firmware == null)) {
+                alert('You must choose a downloadable file from the list or pick a local file to upload.');
+                return;
+            }
 
             let formData = new FormData();
 
@@ -190,937 +214,1048 @@ function UpgradeFirmwareDone() {
                 formData.append("firmware", firmware);
             }
 
-            $('#UpgradeEEPROMText').html('');
-            StreamURL('upgradeCapeFirmware.php?force=true', 'UpgradeEEPROMText', 'UpgradeDone', 'UpgradeDone', 'POST', formData, false, false);
+            var forceOpt = '';
+            if (force)
+                forceOpt = '?force=true';
+
+            DisplayProgressDialog("UpgradeEEPROM", "Upgrade Cape Firmware");
+            StreamURL('upgradeCapeFirmware.php' + forceOpt, 'UpgradeEEPROMText', 'UpgradeFirmwareDone', 'UpgradeFirmwareDone', 'POST', formData, false, false);
         }
-    }
-    UpgradeDone();
-}
-function UpgradeFirmware(force = false) {
-    var eepromFile = $('#eepromVendorCapeVersions').val();
-    let firmware = document.getElementById("firmware").files[0];
-    if ((eepromFile == '') && (firmware == "" || firmware == null)) {
-        alert('You must choose a downloadable file from the list or pick a local file to upload.');
-        return;
-    }
 
-    let formData = new FormData();
+        var eepromList = [];
+        var hasPhysicalEEPROM = <? echo $eepromFile == '' ? "false" : "true" ?>;
 
-    if (eepromFile != '') {
-        formData.append("filename", eepromFile);
-    } else {
-        formData.append("firmware", firmware);
-    }
-
-    var forceOpt = '';
-    if (force)
-        forceOpt = '?force=true';
-
-    DisplayProgressDialog("UpgradeEEPROM", "Upgrade Cape Firmware");
-    StreamURL('upgradeCapeFirmware.php' + forceOpt, 'UpgradeEEPROMText', 'UpgradeFirmwareDone', 'UpgradeFirmwareDone', 'POST', formData, false, false);
-}
-
-var eepromList = [];
-var hasPhysicalEEPROM = <?echo $eepromFile == '' ? "false" : "true" ?>;
-
-function GetDownloadableEEPROMList() {
-    $.get('https://raw.githubusercontent.com/FalconChristmas/fpp-data/master/eepromVendors.json', function(eepromVendors) {
-        if (typeof eepromVendors === 'string') {
-            eepromVendors = JSON.parse(eepromVendors);
-        }
-        for (var vendor in eepromVendors["vendors"]) {
-            if (eepromVendors["vendors"][vendor].url != "") {
-                $.get(eepromVendors["vendors"][vendor].url, function(eepromjson) {
-                    if (typeof eepromjson === 'string') {
-                        eepromjson = JSON.parse(eepromjson);
-                    }
-                    var vendName = eepromjson.name;
-                    if ("url" in eepromjson) {
-                        vendName += " (" + eepromjson.url + ")";
-                    }
-                    eepromList[vendName] = eepromjson["capes"];
-                    var options = "<option value='" + vendName+ "'>" + vendName + '</option>';
-                    $('#eepromVendorList').append(options);
-                    $('#eepromVendorList').removeAttr('disabled');
-                    $('#eepromVendorList').show();
-                });
-            }
-        }
-    });
-}
-
-function eepromVendorListChanged() {
-    var vendor = $('#eepromVendorList').val();
-    if (vendor in  eepromList) {
-        var eepromVendorCape = $('#eepromVendorCapes');
-        eepromVendorCape.empty();
-        var capes = eepromList[vendor];
-        for (cape in capes) {
-            var capeObj = capes[cape];
-            var valid = true;
-            if ("location" in capeObj) {
-                if (hasPhysicalEEPROM && capeObj.location == "virtual") {
-                    valid = false;
+        function GetDownloadableEEPROMList() {
+            $.get('https://raw.githubusercontent.com/FalconChristmas/fpp-data/master/eepromVendors.json', function (eepromVendors) {
+                if (typeof eepromVendors === 'string') {
+                    eepromVendors = JSON.parse(eepromVendors);
                 }
-                if (!hasPhysicalEEPROM && capeObj.location == "eeprom") {
-                    valid = false;
+                for (var vendor in eepromVendors["vendors"]) {
+                    if (eepromVendors["vendors"][vendor].url != "") {
+                        $.get(eepromVendors["vendors"][vendor].url, function (eepromjson) {
+                            if (typeof eepromjson === 'string') {
+                                eepromjson = JSON.parse(eepromjson);
+                            }
+                            var vendName = eepromjson.name;
+                            if ("url" in eepromjson) {
+                                vendName += " (" + eepromjson.url + ")";
+                            }
+                            eepromList[vendName] = eepromjson["capes"];
+                            var options = "<option value='" + vendName + "'>" + vendName + '</option>';
+                            $('#eepromVendorList').append(options);
+                            $('#eepromVendorList').removeAttr('disabled');
+                            $('#eepromVendorList').show();
+                        });
+                    }
                 }
+            });
+        }
+
+        function eepromVendorListChanged() {
+            var vendor = $('#eepromVendorList').val();
+            if (vendor in eepromList) {
+                var eepromVendorCape = $('#eepromVendorCapes');
+                eepromVendorCape.empty();
+                var capes = eepromList[vendor];
+                for (cape in capes) {
+                    var capeObj = capes[cape];
+                    var valid = true;
+                    if ("location" in capeObj) {
+                        if (hasPhysicalEEPROM && capeObj.location == "virtual") {
+                            valid = false;
+                        }
+                        if (!hasPhysicalEEPROM && capeObj.location == "eeprom") {
+                            valid = false;
+                        }
+                    }
+                    if ("platforms" in capeObj) {
+                        var plat = capeObj.platforms;
+                        if (settings["Platform"] == "BeagleBone Black") {
+                            if (!plat.includes(settings["Variant"])) {
+                                valid = false;
+                            }
+                        } else {
+                            if (!plat.includes(settings["Platform"])
+                                && !plat.includes(settings["Variant"])) {
+                                valid = false;
+                            }
+                        }
+                    }
+                    if (valid) {
+                        var option = "<option value='" + cape + "'>" + cape + "</option>";
+                        eepromVendorCape.append(option);
+                        eepromVendorCape.removeAttr('disabled');
+                    }
+                }
+            } else {
+                $('#eepromVendorCapes').empty();
+                $('#eepromVendorCapes').append("<option>-- Select Vendor --</option>");
+                $('#eepromVendorCapes').prop('disabled', true);
             }
-            if ("platforms" in capeObj) {
-                var plat = capeObj.platforms;
-                if (settings["Platform"] == "BeagleBone Black") {
-                    if (!plat.includes(settings["Variant"])) {
-                        valid = false;
+            eepromVendorCapeChanged();
+        }
+        function eepromVendorCapeChanged() {
+            var vendor = $('#eepromVendorList').val();
+            if (vendor in eepromList) {
+                var capeName = $('#eepromVendorCapes').val();
+                var eepromVendorCapeVersions = $('#eepromVendorCapeVersions');
+                eepromVendorCapeVersions.empty();
+                if (capeName in eepromList[vendor]) {
+                    for (v in eepromList[vendor][capeName]["versions"]) {
+                        var option = "<option value='" + eepromList[vendor][capeName]["versions"][v].url + "'>" + v + "</option>";
+                        eepromVendorCapeVersions.append(option);
+                        eepromVendorCapeVersions.removeAttr('disabled');
                     }
                 } else {
-                    if (!plat.includes(settings["Platform"])
-                       && !plat.includes(settings["Variant"])) {
-                        valid = false;
-                    }
+                    $('#eepromVendorCapeVersions').append("<option value=''>-- Select Vendor/Cape --</option>");
+                    $('#eepromVendorCapeVersions').prop('disabled', true);
                 }
-            }
-            if (valid) {
-                var option = "<option value='" + cape + "'>" + cape + "</option>";
-                eepromVendorCape.append(option);
-                eepromVendorCape.removeAttr('disabled');
-            }
-        }
-    } else {
-        $('#eepromVendorCapes').empty();
-        $('#eepromVendorCapes').append("<option>-- Select Vendor --</option>");
-        $('#eepromVendorCapes').prop('disabled', true);
-    }
-    eepromVendorCapeChanged();
-}
-function eepromVendorCapeChanged() {
-    var vendor = $('#eepromVendorList').val();
-    if (vendor in  eepromList) {
-        var capeName = $('#eepromVendorCapes').val();
-        var eepromVendorCapeVersions = $('#eepromVendorCapeVersions');
-        eepromVendorCapeVersions.empty();
-        if (capeName in eepromList[vendor]) {
-            for (v in eepromList[vendor][capeName]["versions"]) {
-                var option = "<option value='" + eepromList[vendor][capeName]["versions"][v].url + "'>" + v + "</option>";
-                eepromVendorCapeVersions.append(option);
-                eepromVendorCapeVersions.removeAttr('disabled');
-            }
-        } else {
-            $('#eepromVendorCapeVersions').append("<option value=''>-- Select Vendor/Cape --</option>");
-            $('#eepromVendorCapeVersions').prop('disabled', true);
-        }
-    } else {
-        $('#eepromVendorCapeVersions').empty();
-        $('#eepromVendorCapeVersions').append("<option value=''>-- Select Vendor/Cape --</option>");
-        $('#eepromVendorCapeVersions').prop('disabled', true);
-    }
-    eepromVendorCapeVersionChanged();
-}
-function eepromVendorCapeVersionChanged() {
-    var url = $('#eepromVendorCapeVersions').val();
-    if (url == '') {
-        $('#UpdateFirmware').removeClass('btn-success');
-        $('#UpdateFirmware').attr('disabled', 'disabled');
-    } else {
-        $('#firmware').val('');
-        $('#UpdateFirmware').addClass('btn-success');
-        $('#UpdateFirmware').removeAttr('disabled');
-    }
-}
-
-function firmwareChanged() {
-    $('#eepromVendorList').val('').trigger("change");;
-
-    if ($('#filename').val() == '') {
-        $('#UpdateFirmware').removeClass('btn-success');
-        $('#UpdateFirmware').attr('disabled', 'disabled');
-    } else {
-        $('#UpdateFirmware').addClass('btn-success');
-        $('#UpdateFirmware').removeAttr('disabled');
-    }
-}
-
-function backupChanged() {
-    if ($('#backupFile').val() == '') {
-        $('#RestoreFirmware').removeClass('btn-success');
-        $('#RestoreFirmware').attr('disabled', 'disabled');
-    } else {
-        $('#RestoreFirmware').addClass('btn-success');
-        $('#RestoreFirmware').removeAttr('disabled');
-    }
-}
-
-function RedeemVoucher() {
-    var voucherNumber = $('#voucherNumber').val().toUpperCase();
-    var fname = $('#voucherFName').val();
-    var lname = $('#voucherLName').val();
-    var email = $('#voucherEmail').val();
-    var password = $('#voucherPassword').val();
-    var alphanumeric = /^[\p{L}\p{N}]+$/u;
-    var passwordAllowed = /^[-\p{L}\p{N}_#@!\$%^&*()]+$/u;
-
-    if (voucherNumber == 'SUDCAEPP') {
-        alert("Thank you for reading the FPP Manual, but voucher ID 'SUDCAEPP' is for documentation use only and is not valid.  Please enter a valid voucher ID.");
-        return;
-    }
-
-    if (!(/^[-A-Z0-9]+$/.test(voucherNumber))) {
-        alert('Invalid Voucher Number.  The Voucher Number field should contain only the letters, numbers, and hypens.');
-        return;
-    }
-
-    if (!fname.match(alphanumeric)) {
-        alert('Invalid characters in first name.');
-        return;
-    }
-
-    if (!lname.match(alphanumeric)) {
-        alert('Invalid characters in last name.');
-        return;
-    }
-
-    if (!validateEmail(email)) {
-        alert('Invalid Email address.');
-        return;
-    }
-
-    if ((!password.match(passwordAllowed)) || (password.length < 8)) {
-        alert('Invalid characters in password or length too short.  Passwords should be at least 8 characters long and may contain only letters, numbers, and any of the following characters         -_#@!\$%^&*()');
-        return;
-    }
-
-    $('#voucherNumber').val(voucherNumber); // Save the toUpperCase()-ed value
-    var url = 'api/cape/eeprom/voucher';
-
-    $('.dialogCloseButton').hide();
-    $('#upgradePopup').fppDialog({ height: 600, width: 900, title: "Redeem Voucher", dialogClass: 'no-close' });
-    $('#upgradePopup').fppDialog( "moveToTop" );
-    $('#upgradeText').html('Voucher Redemption Status:\n');
-
-    $('#upgradeText').append('- Contacting API to redeem voucher\n');
-
-    data = {};
-    data.voucher = voucherNumber;
-    data.first_name = fname;
-    data.last_name = lname;
-    data.email = email;
-    data.password = password;
-
-    dataStr = JSON.stringify(data);
-
-    $.ajax({
-        url: url,
-        type: 'POST',
-        data: dataStr,
-        contentType: 'application/json',
-        async: true,
-        dataType: 'json',
-        success: function (data) {
-            if (data.Status == 'OK') {
-                $('#upgradeText').append('- Voucher Redeemed Successfully\n');
-                $('#upgradeText').append('  - Order Number: ' + data.order + '\n');
-                $('#upgradeText').append('  - License Key: ' + data.key + '\n');
-                $('#upgradeText').append('\nProceeding to sign EEPROM with new order and key info.\n\n');
-
-                SetSetting('voucherRedeemed', '1', true);
-
-                SignEEPROMHelper(data.key, data.order, true);
             } else {
-                $('#upgradeText').append('\nERROR redeeming voucher:\n\n' + data.Message);
-                $('#errorDialogButton').show();
+                $('#eepromVendorCapeVersions').empty();
+                $('#eepromVendorCapeVersions').append("<option value=''>-- Select Vendor/Cape --</option>");
+                $('#eepromVendorCapeVersions').prop('disabled', true);
             }
-        },
-        error: function () {
-            $('#upgradeText').append('\nERROR calling signing API\n');
-            $('#errorDialogButton').show();
+            eepromVendorCapeVersionChanged();
         }
-    });
-}
+        function eepromVendorCapeVersionChanged() {
+            var url = $('#eepromVendorCapeVersions').val();
+            if (url == '') {
+                $('#UpdateFirmware').removeClass('btn-success');
+                $('#UpdateFirmware').attr('disabled', 'disabled');
+            } else {
+                $('#firmware').val('');
+                $('#UpdateFirmware').addClass('btn-success');
+                $('#UpdateFirmware').removeAttr('disabled');
+            }
+        }
 
-function DownloadOfflineSigningFile() {
-    var order = $('#offlineOrderNumber').val();
-    var orderRegex = /^[0-9]+$/;
-    var key = $('#offlineLicenseKey').val().toUpperCase();
-    var keyRegex = /^FPPAFK-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}$/;
+        function firmwareChanged() {
+            $('#eepromVendorList').val('').trigger("change");;
 
-    if (!orderRegex.test(order)) {
-        alert('Invalid Order Number.  The Order Number field should contain only the numbers 0-9.');
-        return;
-    }
+            if ($('#filename').val() == '') {
+                $('#UpdateFirmware').removeClass('btn-success');
+                $('#UpdateFirmware').attr('disabled', 'disabled');
+            } else {
+                $('#UpdateFirmware').addClass('btn-success');
+                $('#UpdateFirmware').removeAttr('disabled');
+            }
+        }
 
-    if (!keyRegex.test(key)) {
-        alert("Invalid License Key Format.  The License Key should match the format 'FPPAFK-XXXXXX-XXXXXX-XXXXXX-XXXXXX' where the X's may be any letter or number.");
-        return;
-    }
+        function backupChanged() {
+            if ($('#backupFile').val() == '') {
+                $('#RestoreFirmware').removeClass('btn-success');
+                $('#RestoreFirmware').attr('disabled', 'disabled');
+            } else {
+                $('#RestoreFirmware').addClass('btn-success');
+                $('#RestoreFirmware').removeAttr('disabled');
+            }
+        }
 
-    $('#offlineLicenseKey').val(key); // Save the toUpperCase()-ed value
+        function RedeemVoucher() {
+            var voucherNumber = $('#voucherNumber').val().toUpperCase();
+            var fname = $('#voucherFName').val();
+            var lname = $('#voucherLName').val();
+            var email = $('#voucherEmail').val();
+            var password = $('#voucherPassword').val();
+            var alphanumeric = /^[\p{L}\p{N}]+$/u;
+            var passwordAllowed = /^[-\p{L}\p{N}_#@!\$%^&*()]+$/u;
 
-    // Update values on the other tab
-    $('#licenseKey').val(key);
-    $('#orderNumber').val(order);
+            if (voucherNumber == 'SUDCAEPP') {
+                alert("Thank you for reading the FPP Manual, but voucher ID 'SUDCAEPP' is for documentation use only and is not valid.  Please enter a valid voucher ID.");
+                return;
+            }
 
-    location.href = 'api/cape/eeprom/signingFile/' + key + '/' + order;
-}
+            if (!(/^[-A-Z0-9]+$/.test(voucherNumber))) {
+                alert('Invalid Voucher Number.  The Voucher Number field should contain only the letters, numbers, and hypens.');
+                return;
+            }
 
-function SignEEPROMViaBrowser() {
-    var order = $('#orderNumber').val();
-    var orderRegex = /^[0-9]+$/;
-    var key = $('#licenseKey').val().toUpperCase();
-    var keyRegex = /^FPPAFK-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}$/;
+            if (!fname.match(alphanumeric)) {
+                alert('Invalid characters in first name.');
+                return;
+            }
 
-    if (!orderRegex.test(order)) {
-        alert('Invalid Order Number.  The Order Number field should contain only the numbers 0-9.');
-        return;
-    }
+            if (!lname.match(alphanumeric)) {
+                alert('Invalid characters in last name.');
+                return;
+            }
 
-    if (!keyRegex.test(key)) {
-        alert("Invalid License Key Format.  The License Key should match the format 'FPPAFK-XXXXXX-XXXXXX-XXXXXX-XXXXXX' where the X's may be any letter or number.");
-        return;
-    }
+            if (!validateEmail(email)) {
+                alert('Invalid Email address.');
+                return;
+            }
 
-    $('#licenseKey').val(key); // Save the toUpperCase()-ed value
-    var url = 'api/cape/eeprom/signingData/' + key + '/' + order;
+            if ((!password.match(passwordAllowed)) || (password.length < 8)) {
+                alert('Invalid characters in password or length too short.  Passwords should be at least 8 characters long and may contain only letters, numbers, and any of the following characters         -_#@!\$%^&*()');
+                return;
+            }
 
-    $('.dialogCloseButton').hide();
-    $('#upgradePopup').fppDialog({ height: 600, width: 900, title: "Sign Cape EEPROM", dialogClass: 'no-close' });
-    $('#upgradePopup').fppDialog( "moveToTop" );
-    $('#upgradeText').html('Signing Status:\n');
+            $('#voucherNumber').val(voucherNumber); // Save the toUpperCase()-ed value
+            var url = 'api/cape/eeprom/voucher';
 
-    $('#upgradeText').append('- Downloading signing packet from FPP\n');
+            $('.dialogCloseButton').hide();
+            $('#upgradePopup').fppDialog({ height: 600, width: 900, title: "Redeem Voucher", dialogClass: 'no-close' });
+            $('#upgradePopup').fppDialog("moveToTop");
+            $('#upgradeText').html('Voucher Redemption Status:\n');
 
-    $.ajax({
-        url: url,
-        type: 'GET',
-        data: '',
-        async: true,
-        dataType: 'json',
-        success: function (data) {
-            if (data.hasOwnProperty('key')) {
-                $('#upgradeText').append('- Uploading signing packet to signing API\n');
-                $.ajax({
-                    url: 'https://<?=$APIhost?>/api/fpp/eeprom/sign',
-                    type: 'POST',
-                    contentType: 'application/json',
-                    data: JSON.stringify(data),
-                    async: true,
-                    dataType: 'json',
-                    success: function (data) {
-                        if (data.Status == 'OK') {
-                            $('#upgradeText').append('- Received signed packet back from signing API\n');
-                            $('#upgradeText').append('- Uploading signed packet to FPP\n');
-                            $.ajax({
-                                url: 'api/cape/eeprom/signingData',
-                                type: 'POST',
-                                contentType: 'application/json',
-                                data: JSON.stringify(data),
-                                async: true,
-                                dataType: 'json',
-                                success: function (data) {
-                                    if (data.Status == 'OK') {
-                                        SetRebootFlag();
-                                        $('#upgradeText').append('- Signing Complete.  Please reboot.\n');
-                                        $('#closeDialogButton').show();
-                                    } else {
-                                        $('#upgradeText').append('\nERROR processing signed packet: ' + data.Message + '\n');
-                                        $('#errorDialogButton').show();
-                                    }
-                                },
-                                error: function () {
-                                    $('#upgradeText').append('\nERROR uploading signed packet\n');
-                                    $('#errorDialogButton').show();
-                                }
-                            });
-                        // END of second nested AJAX call
-                        } else {
-                            $('#upgradeText').append('\nERROR signing packet: ' + data.Message + '\n');
-                            $('#errorDialogButton').show();
-                        }
-                    },
-                    error: function () {
-                        $('#upgradeText').append('\nERROR uploading signing packet\n');
+            $('#upgradeText').append('- Contacting API to redeem voucher\n');
+
+            data = {};
+            data.voucher = voucherNumber;
+            data.first_name = fname;
+            data.last_name = lname;
+            data.email = email;
+            data.password = password;
+
+            dataStr = JSON.stringify(data);
+
+            $.ajax({
+                url: url,
+                type: 'POST',
+                data: dataStr,
+                contentType: 'application/json',
+                async: true,
+                dataType: 'json',
+                success: function (data) {
+                    if (data.Status == 'OK') {
+                        $('#upgradeText').append('- Voucher Redeemed Successfully\n');
+                        $('#upgradeText').append('  - Order Number: ' + data.order + '\n');
+                        $('#upgradeText').append('  - License Key: ' + data.key + '\n');
+                        $('#upgradeText').append('\nProceeding to sign EEPROM with new order and key info.\n\n');
+
+                        SetSetting('voucherRedeemed', '1', true);
+
+                        SignEEPROMHelper(data.key, data.order, true);
+                    } else {
+                        $('#upgradeText').append('\nERROR redeeming voucher:\n\n' + data.Message);
                         $('#errorDialogButton').show();
                     }
-                });
-               // END of first nested AJAX call
-            } else {
-                $('#upgradeText').append('\nERROR retrieving signing packet: ' + data.Message + '\n');
-                $('#errorDialogButton').show();
-            }
-        },
-        error: function () {
-            $('#upgradeText').append('\nERROR retrieving signing packet from FPP\n');
-            $('#errorDialogButton').show();
-        }
-    });
-}
-
-function SignEEPROMHelper(key, order, redirect=false) {
-    var url = 'api/cape/eeprom/sign/' + key + '/' + order;
-
-    $('#upgradeText').append('- Contacting API to sign EEPROM\n');
-
-    $.ajax({
-        url: url,
-        type: 'POST',
-        data: '',
-        async: true,
-        dataType: 'json',
-        success: function (data) {
-            if (data.Status == 'OK') {
-                SetRebootFlag();
-                $('#upgradeText').append('- Signing Complete.  Please reboot.\n\nYou may also check the <b>EEPROM Signature</b> tab prior to reboot to confirm the EEPROM was signed.');
-                $('#closeDialogButton').show();
-            } else {
-                $('#upgradeText').append('\nERROR signing EEPROM:\n\n' + data.Message);
-                $('#errorDialogButton').show();
-            }
-        },
-        error: function () {
-            $('#upgradeText').append('\nERROR calling signing API\n');
-            $('#errorDialogButton').show();
-        }
-    });
-}
-
-function SignEEPROM() {
-    var order = $('#orderNumber').val();
-    var orderRegex = /^[0-9]+$/;
-    var key = $('#licenseKey').val().toUpperCase();
-    var keyRegex = /^FPPAFK-[A-Z0-9]{6}-[A-Z0-9]{6}-[A-Z0-9]{6}-[A-Z0-9]{6}$/;
-
-    if (!orderRegex.test(order)) {
-        alert('Invalid Order Number.  The Order Number field should contain only the numbers 0-9.');
-        return;
-    }
-
-    if (!keyRegex.test(key)) {
-        alert("Invalid License Key Format.  The License Key should match the format 'FPPAFK-XXXXXX-XXXXXX-XXXXXX-XXXXXX' where the X's may be any letter or number.");
-        return;
-    }
-
-    $('#licenseKey').val(key); // Save the toUpperCase()-ed value
-
-    $('.dialogCloseButton').hide();
-    $('#upgradePopup').fppDialog({ height: 600, width: 900, title: "Sign Cape EEPROM", dialogClass: 'no-close' });
-    $('#upgradePopup').fppDialog( "moveToTop" );
-    $('#upgradeText').html('Signing Status:\n');
-
-    SignEEPROMHelper(key, order);
-}
-
-function UploadSignedPacket() {
-    let signingPacket = document.getElementById("signingPacket").files[0];
-    if (signingPacket == "" || signingPacket == null) {
-        return;
-    }
-    let formData = new FormData();
-    formData.append("signingPacket", signingPacket);
-
-    $.ajax({
-        url: 'api/cape/eeprom/signingData',
-        method: 'POST',
-        data: formData,
-        async: true,
-        contentType: false,
-        processData: false,
-        dataType: 'json',
-        success: function (data) {
-            if (data.Status == 'OK') {
-                location.href='cape-info.php#eeprom-signature';
-                reloadPage();
-            } else {
-                alert('ERROR getting EEPROM signing data: ' + data.Message);
-            }
-        },
-        error: function () {
-            $.jGrowl('Error getting EEPROM signing data', { themeState: 'danger' });
-        }
-    });
-}
-
-var keysVisible = 0;
-function ToggleKeyVisibility() {
-    if (keysVisible) {
-        keysVisible = 0;
-        $('#keyVisibilityIcon').removeClass('fa-eye-slash');
-        $('#keyVisibilityIcon').addClass('fa-eye');
-        $('.keyHidden').show();
-        $('.keyShow').hide();
-    } else {
-        keysVisible = 1;
-        $('#keyVisibilityIcon').addClass('fa-eye-slash');
-        $('#keyVisibilityIcon').removeClass('fa-eye');
-        $('.keyHidden').hide();
-        $('.keyShow').show();
-    }
-}
-
-function TestInternet() {
-    // This variable is defined in https://api.FalconPlayer.com/js/internetTest.js included above
-    if (typeof theInternetIsUp === 'undefined') {
-        // Do nothing here
-    } else {
-        // Show the online version of the signing UI
-        $('.internetOnly').show();
-    }
-}
-
-$(document).ready(function() {
-    GetDownloadableEEPROMList();
-    setTimeout(function() { TestInternet(); }, 100);
-});
-
-</script>
-<title><?echo $pageTitle; ?></title>
-<style>
-.no-close .ui-dialog-titlebar-close {display: none }
-</style>
-</head>
-<body>
-<div id="bodyWrapper">
-<?php
-$activeParentMenuItem = 'help';
-include 'menu.inc';
-?>
-    <div class="mainContainer">
-        <div class="title"><?=$capeHardwareType?> Info</div>
-        <div class="pageContent">
-<?
-if (isset($settings["cape-info"])) {
-    ?>
-            <div>
-                <div style="overflow: hidden; padding: 10px;">
-                    <div class='eepromTabs'>
-                        <div id='eepromManager'>
-                            <ul id='eepromManagerTabs' class="nav nav-pills pageContent-tabs" role="tablist">
-                                <li class='nav-item'>
-                                    <a class="nav-link active" id="eeprom-about-tab" data-bs-toggle="pill" href="#eeprom-about" role="tab" aria-controls="eeprom-about" aria-selected="true">
-                                        About
-                                    </a>
-                                </li>
-                                <li class='nav-item'>
-                                    <a class="nav-link" id="eeprom-signature-tab" data-bs-toggle="pill" href="#eeprom-signature" role="tab" aria-controls="eeprom-signature">
-                                        EEPROM Signature
-                                    </a>
-                                </li>
-<?php
-if ($printSigningUI) {
-        if ($offlineMode) {
-            ?>
-                                <li class='nav-item'>
-                                    <a class="nav-link" id="eeprom-offline-tab" data-bs-toggle="pill" href="#eeprom-offline" role="tab" aria-controls="eeprom-offline">
-                                        Offline Signing
-                                    </a>
-                                </li>
-<?php
-} else if (((!isset($settings['voucherRedeemed'])) || ($settings['voucherRedeemed'] != '1')) && ((!isset($currentCapeInfo['verifiedKeyId'])) || ($currentCapeInfo['verifiedKeyId'] != 'fp'))) {
-            ?>
-                                <li class='nav-item'>
-                                    <a class="nav-link" id="eeprom-voucher-tab" data-bs-toggle="pill" href="#eeprom-voucher" role="tab" aria-controls="eeprom-voucher">
-                                        Voucher Redemption
-                                    </a>
-                                </li>
-<?php
-}
-    }
-    ?>
-                                <li class='nav-item'>
-                                    <a class="nav-link" id="eeprom-upgrade-tab" data-bs-toggle="pill" href="#eeprom-upgrade" role="tab" aria-controls="eeprom-upgrade">
-                                        EEPROM Upgrade
-                                    </a>
-                                </li>
-                            </ul>
-
-                            <div class="tab-content" id="eepromTabsContent">
-
-                                <div class="tab-pane fade show active" id="eeprom-about" role="tabpanel" aria-labelledby="eeprom-about-tab">
-
-            <h2>About <?=$capeHardwareType?> </h2>
-            <div class="container-fluid">
-                <div class="row">
-                    <div class='<?if (isset($currentCapeInfo['vendor'])) {echo "aboutLeft col-md";} else {echo "aboutAll";}?> '>
-                        <table class='tblAbout'>
-                            <tr><td><b>Name:</b></td><td width="100%"><?echo $currentCapeInfo['name'] ?></td></tr>
-<?php
-if (isset($currentCapeInfo['version'])) {
-        echo "<tr><td><b>Version:</b></td><td>" . $currentCapeInfo['version'] . "</td></tr>";
-    }
-    if (isset($currentCapeInfo['serialNumber'])) {
-        echo "<tr><td><b>Serial&nbsp;Number:</b></td><td>" . $currentCapeInfo['serialNumber'] . "</td></tr>";
-    }
-    if (isset($currentCapeInfo['designer'])) {
-        echo "<tr><td><b>Designer:</b></td><td>" . $currentCapeInfo['designer'] . "</td></tr>";
-    }
-    if ((isset($currentCapeInfo['verifiedKeyId'])) && (($channelOutputDriver == 'BBB48String') || ($channelOutputDriver == 'DPIPixels') || ($channelOutputDriver == 'BBShiftString'))) {
-        $key = $currentCapeInfo['verifiedKeyId'];
-        if ($key == 'fp') {
-            if (isset($currentCapeInfo['signed']['licensePorts'])) {
-                echo "<tr><td><b>Licensed&nbsp;Outputs:</b></td><td>" . $currentCapeInfo['signed']['licensePorts'] . " ('fp' key)</td></tr>";
-            } else {
-                echo "<tr><td><b>Licensed&nbsp;Outputs:</b></td><td>Unknown, licensePorts setting does not exist ('fp' key)</td></tr>";
-            }
-        } else {
-            echo "<tr><td><b>Licensed&nbsp;Outputs:</b></td><td>Unlimited ('$key' key)</td></tr>";
-        }
-    } else if (($channelOutputDriver == 'BBB48String') || ($channelOutputDriver == 'DPIPixels') || ($channelOutputDriver == 'BBShiftString')) {
-        echo "<tr><td><b>Licensed&nbsp;Outputs:</b></td><td>None, cape EEPROM is not signed.</td></tr>";
-    }
-    if ($channelOutputDriver != '') {
-        echo "<tr><td><b>Output&nbsp;Driver:</b></td><td>" . $channelOutputDriver . "</td></tr>";
-    }
-    if (((!isset($currentCapeInfo['verifiedKeyId'])) || ($currentCapeInfo['verifiedKeyId'] == 'fp')) && isset($currentCapeInfo['eepromLocation'])) {
-        $locationMsg = '';
-        if (isset($currentCapeInfo['validEepromLocation']) && !$currentCapeInfo['validEepromLocation']) {
-            $locationMsg = ' - <b>Warning:</b> Location flag specified in EEPROM<br>does not match actual EEPROM location.';
-        }
-
-        $location = 'Physical';
-        if (preg_match('/cape-eeprom.bin/', $currentCapeInfo['eepromLocation'])) {
-            $location = 'File';
-        }
-        echo "<tr><td valign='top'><b>EEPROM&nbsp;Location:</b></td><td>$location$locationMsg</td></tr>";
-    }
-    if (isset($currentCapeInfo['description'])) {
-        echo "<tr><td colspan=\"2\">";
-        if (isset($currentCapeInfo['vendor']) || $currentCapeInfo['name'] == "Unknown") {
-            echo $currentCapeInfo['description'];
-        } else {
-            echo htmlspecialchars($currentCapeInfo['description']);
-        }
-        echo "</td></tr>";
-    }
-    ?>
-                        </table>
-                    </div>
-<?php
-if (isset($currentCapeInfo['vendor'])) {
-        ?>
-                   <div class='aboutRight col-md'>
-                       <table class='tblAbout'>
-                            <tr><td><b>Vendor&nbsp;Name:</b></td><td><?echo $currentCapeInfo['vendor']['name'] ?></td></tr>
-<?php
-if (isset($currentCapeInfo['vendor']['url'])) {
-            $url = $currentCapeInfo['vendor']['url'];
-            $landing = $url;
-            if (isset($currentCapeInfo['vendor']['landingPage'])) {
-                $landing = $currentCapeInfo['vendor']['landingPage'];
-            }
-            if ($settings['SendVendorSerial'] == 1) {
-                $landing = $landing . "?sn=" . $currentCapeInfo['serialNumber'] . "&id=" . $currentCapeInfo['id'];
-            }
-            if (isset($currentCapeInfo['cs']) && $currentCapeInfo['cs'] != "" && $settings['SendVendorSerial'] == 1) {
-                $landing = $landing . "&cs=" . $currentCapeInfo['cs'];
-            }
-            if ($settings['hideExternalURLs']) {
-                $landing = "";
-            }
-            echo "<tr><td><b>Vendor&nbsp;URL:</b></td><td><a href=\"" . $landing . "\">" . $url . "</a></td></tr>";
-        }
-        if (isset($currentCapeInfo['vendor']['phone'])) {
-            echo "<tr><td><b>Phone&nbsp;Number:</b></td><td>" . $currentCapeInfo['vendor']['phone'] . "</td></tr>";
-        }
-        if (isset($currentCapeInfo['vendor']['email']) && !$settings['hideExternalURLs']) {
-            echo "<tr><td><b>E-mail:</b></td><td><a href=\"mailto:" . $currentCapeInfo['vendor']['email'] . "\">" . $currentCapeInfo['vendor']['email'] . "</td></tr>";
-        }
-        if (isset($currentCapeInfo['vendor']['forum']) && !$settings['hideExternalURLs']) {
-            echo "<tr><td><b>Support Forum:</b></td><td><a href=\"" . $currentCapeInfo['vendor']['forum'] . "\">" . $currentCapeInfo['vendor']['forum'] . "</td></tr>";
-        }
-        if (isset($currentCapeInfo['vendor']['image']) && $settings['FetchVendorLogos']) {
-            if ($settings['SendVendorSerial'] == 1) {
-                $iurl = $currentCapeInfo['vendor']['image'] . "?sn=" . $currentCapeInfo['serialNumber'] . "&id=" . $currentCapeInfo['id'];
-            }
-            if (isset($currentCapeInfo['cs']) && $currentCapeInfo['cs'] != "" && $settings['SendVendorSerial'] == 1) {
-                $iurl = $iurl . "&cs=" . $currentCapeInfo['cs'];
-            }
-            echo "<tr><td colspan=\"2\"><a href=\"" . $landing . "\"><img style='max-height: 90px; max-width: 300px;' src=\"" . $iurl . "\" ></a></td></tr>";
-        }
-        ?>
-                       </table>
-                   </div>
-<?
-    }
-    ?>
-               </div>
-           </div>
-                                </div>
-                                <div class="tab-pane fade show" id="eeprom-signature" role="tabpanel" aria-labelledby="eeprom-signature-tab">
-                                    <div class="container-fluid">
-                                        <div class="row">
-                                            <div class="aboutAll col-md">
-<?php
-if (isset($settings["cape-info"])) {
-        echo $signingStatus . "<br>";
-        ?>
-    <br>
-    <table>
-<?php
-$printBreak = 0;
-        if (isset($currentCapeInfo['signed'])) {
-            if (isset($currentCapeInfo['signed']['licensePorts'])) {
-                $outputs = $currentCapeInfo['signed']['licensePorts'];
-                if ($outputs == 9999) {
-                    $outputs = "Unlimited";
+                },
+                error: function () {
+                    $('#upgradeText').append('\nERROR calling signing API\n');
+                    $('#errorDialogButton').show();
                 }
+            });
+        }
 
-                echo "<tr><td><b>Licensed Outputs:</b></td><td>$outputs</td></tr>";
+        function DownloadOfflineSigningFile() {
+            var order = $('#offlineOrderNumber').val();
+            var orderRegex = /^[0-9]+$/;
+            var key = $('#offlineLicenseKey').val().toUpperCase();
+            var keyRegex = /^FPPAFK-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}$/;
+
+            if (!orderRegex.test(order)) {
+                alert('Invalid Order Number.  The Order Number field should contain only the numbers 0-9.');
+                return;
             }
 
-            if (isset($currentCapeInfo['signed']['licenseKey'])) {
-                if (gettype($currentCapeInfo['signed']['licenseKey']) == "string") {
-                    echo "<tr><td><b>License Key: <i class='fas fa-eye' id='keyVisibilityIcon' onClick='ToggleKeyVisibility();'></i></b></td><td class='keyShow' style='display: none;'>" . $currentCapeInfo['signed']['licenseKey'] . "</td><td class='keyHidden'>******-******-******-******-******</td></tr>";
-                } else {
-                    $first = 1;
-                    foreach ($currentCapeInfo['signed']['licenseKey'] as $key) {
-                        if ($first) {
-                            echo "<tr><td><b>License Keys: <i class='fas fa-eye' id='keyVisibilityIcon' onClick='ToggleKeyVisibility();'></i></b></td><td class='keyShow' style='display: none;'>$key</td><td class='keyHidden'>******-******-******-******-******</td></tr>\n";
-                            $first = 0;
-                        } else {
-                            echo "<td></td><td class='keyShow' style='display: none;'>$key</td><td class='keyHidden'>******-******-******-******-******</td></tr>\n";
-                        }
+            if (!keyRegex.test(key)) {
+                alert("Invalid License Key Format.  The License Key should match the format 'FPPAFK-XXXXXX-XXXXXX-XXXXXX-XXXXXX' where the X's may be any letter or number.");
+                return;
+            }
+
+            $('#offlineLicenseKey').val(key); // Save the toUpperCase()-ed value
+
+            // Update values on the other tab
+            $('#licenseKey').val(key);
+            $('#orderNumber').val(order);
+
+            location.href = 'api/cape/eeprom/signingFile/' + key + '/' + order;
+        }
+
+        function SignEEPROMViaBrowser() {
+            var order = $('#orderNumber').val();
+            var orderRegex = /^[0-9]+$/;
+            var key = $('#licenseKey').val().toUpperCase();
+            var keyRegex = /^FPPAFK-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}-[a-zA-Z0-9]{6}$/;
+
+            if (!orderRegex.test(order)) {
+                alert('Invalid Order Number.  The Order Number field should contain only the numbers 0-9.');
+                return;
+            }
+
+            if (!keyRegex.test(key)) {
+                alert("Invalid License Key Format.  The License Key should match the format 'FPPAFK-XXXXXX-XXXXXX-XXXXXX-XXXXXX' where the X's may be any letter or number.");
+                return;
+            }
+
+            $('#licenseKey').val(key); // Save the toUpperCase()-ed value
+            var url = 'api/cape/eeprom/signingData/' + key + '/' + order;
+
+            $('.dialogCloseButton').hide();
+            $('#upgradePopup').fppDialog({ height: 600, width: 900, title: "Sign Cape EEPROM", dialogClass: 'no-close' });
+            $('#upgradePopup').fppDialog("moveToTop");
+            $('#upgradeText').html('Signing Status:\n');
+
+            $('#upgradeText').append('- Downloading signing packet from FPP\n');
+
+            $.ajax({
+                url: url,
+                type: 'GET',
+                data: '',
+                async: true,
+                dataType: 'json',
+                success: function (data) {
+                    if (data.hasOwnProperty('key')) {
+                        $('#upgradeText').append('- Uploading signing packet to signing API\n');
+                        $.ajax({
+                            url: 'https://<?= $APIhost ?>/api/fpp/eeprom/sign',
+                            type: 'POST',
+                            contentType: 'application/json',
+                            data: JSON.stringify(data),
+                            async: true,
+                            dataType: 'json',
+                            success: function (data) {
+                                if (data.Status == 'OK') {
+                                    $('#upgradeText').append('- Received signed packet back from signing API\n');
+                                    $('#upgradeText').append('- Uploading signed packet to FPP\n');
+                                    $.ajax({
+                                        url: 'api/cape/eeprom/signingData',
+                                        type: 'POST',
+                                        contentType: 'application/json',
+                                        data: JSON.stringify(data),
+                                        async: true,
+                                        dataType: 'json',
+                                        success: function (data) {
+                                            if (data.Status == 'OK') {
+                                                SetRebootFlag();
+                                                $('#upgradeText').append('- Signing Complete.  Please reboot.\n');
+                                                $('#closeDialogButton').show();
+                                            } else {
+                                                $('#upgradeText').append('\nERROR processing signed packet: ' + data.Message + '\n');
+                                                $('#errorDialogButton').show();
+                                            }
+                                        },
+                                        error: function () {
+                                            $('#upgradeText').append('\nERROR uploading signed packet\n');
+                                            $('#errorDialogButton').show();
+                                        }
+                                    });
+                                    // END of second nested AJAX call
+                                } else {
+                                    $('#upgradeText').append('\nERROR signing packet: ' + data.Message + '\n');
+                                    $('#errorDialogButton').show();
+                                }
+                            },
+                            error: function () {
+                                $('#upgradeText').append('\nERROR uploading signing packet\n');
+                                $('#errorDialogButton').show();
+                            }
+                        });
+                        // END of first nested AJAX call
+                    } else {
+                        $('#upgradeText').append('\nERROR retrieving signing packet: ' + data.Message + '\n');
+                        $('#errorDialogButton').show();
                     }
+                },
+                error: function () {
+                    $('#upgradeText').append('\nERROR retrieving signing packet from FPP\n');
+                    $('#errorDialogButton').show();
                 }
-            }
-
-            if ($currentCapeInfo['serialNumber'] == 'FPP-INTERNAL') {
-                if (isset($currentCapeInfo['signed']['capeSerial'])) {
-                    echo "<tr><td><b>Licensed Serial:</b></td><td>" . $currentCapeInfo['signed']['capeSerial'] . "</td></tr>";
-                }
-
-                if (isset($currentCapeInfo['signed']['deviceSerial'])) {
-                    echo "<tr><td><b>Licensed Device:</b></td><td>" . $currentCapeInfo['signed']['deviceSerial'] . "</td></tr>";
-                }
-
-            }
-
-            if (isset($currentCapeInfo['signed']['signTime'])) {
-                echo "<tr><td><b>EEPROM Signed at:</b></td><td>" . date('Y-m-d h:i:s A T', $currentCapeInfo['signed']['signTime']) . "</td></tr>";
-            }
-
-            $printBreak = 1;
-        }
-        ?>
-    </table>
-<?php
-if ($printBreak) {
-            echo "<br>\n";
+            });
         }
 
-        if ($printSigningUI) {
-            if (!isset($currentCapeInfo['verifiedKeyId'])) {
-                echo "<b>NOTE: This cape is using an unsigned EEPROM and the $channelOutputDriver Channel Output driver which operates in a limited manner until the EEPROM is signed.  Pixel outputs will be limited to 50 pixels per output and smart receivers will be disabled.</b><br><br>\n";
+        function SignEEPROMHelper(key, order, redirect = false) {
+            var url = 'api/cape/eeprom/sign/' + key + '/' + order;
+
+            $('#upgradeText').append('- Contacting API to sign EEPROM\n');
+
+            $.ajax({
+                url: url,
+                type: 'POST',
+                data: '',
+                async: true,
+                dataType: 'json',
+                success: function (data) {
+                    if (data.Status == 'OK') {
+                        SetRebootFlag();
+                        $('#upgradeText').append('- Signing Complete.  Please reboot.\n\nYou may also check the <b>EEPROM Signature</b> tab prior to reboot to confirm the EEPROM was signed.');
+                        $('#closeDialogButton').show();
+                    } else {
+                        $('#upgradeText').append('\nERROR signing EEPROM:\n\n' + data.Message);
+                        $('#errorDialogButton').show();
+                    }
+                },
+                error: function () {
+                    $('#upgradeText').append('\nERROR calling signing API\n');
+                    $('#errorDialogButton').show();
+                }
+            });
+        }
+
+        function SignEEPROM() {
+            var order = $('#orderNumber').val();
+            var orderRegex = /^[0-9]+$/;
+            var key = $('#licenseKey').val().toUpperCase();
+            var keyRegex = /^FPPAFK-[A-Z0-9]{6}-[A-Z0-9]{6}-[A-Z0-9]{6}-[A-Z0-9]{6}$/;
+
+            if (!orderRegex.test(order)) {
+                alert('Invalid Order Number.  The Order Number field should contain only the numbers 0-9.');
+                return;
             }
 
-            ?>
-    You may sign the EEPROM using a license key purchased from <a href='https://shop.FalconPlayer.com' target='_blank'>https://shop.FalconPlayer.com</a>.  Once you have purchased a license key, enter the Order Number and License Key below.
-<?php
-if ($offlineMode) {
-                echo "If <b>neither</b> your FPP instance or your browser can reach the internet, you will need to use the 'Offline Signing' tab.  ";
+            if (!keyRegex.test(key)) {
+                alert("Invalid License Key Format.  The License Key should match the format 'FPPAFK-XXXXXX-XXXXXX-XXXXXX-XXXXXX' where the X's may be any letter or number.");
+                return;
             }
 
-            ?>
-    <br>
+            $('#licenseKey').val(key); // Save the toUpperCase()-ed value
 
-    <table <?php if ($offlineMode) {
-                echo "class='internetOnly' style='display: none;'";
+            $('.dialogCloseButton').hide();
+            $('#upgradePopup').fppDialog({ height: 600, width: 900, title: "Sign Cape EEPROM", dialogClass: 'no-close' });
+            $('#upgradePopup').fppDialog("moveToTop");
+            $('#upgradeText').html('Signing Status:\n');
+
+            SignEEPROMHelper(key, order);
+        }
+
+        function UploadSignedPacket() {
+            let signingPacket = document.getElementById("signingPacket").files[0];
+            if (signingPacket == "" || signingPacket == null) {
+                return;
             }
-            ?>>
-        <tr><td><b>Order Number:</b></td><td><input id='orderNumber' type='password' size=12 maxlength=10 value=''>
-                <i class='fas fa-eye' id='orderNumberHideShow' onClick='TogglePasswordHideShow("orderNumber");'></i></td></tr>
-        <tr><td><b>License Key:</b></td><td><input id='licenseKey' type='password' size=36 maxlength=34 placeholder='FPPAFK-XXXXXX-XXXXXX-XXXXXX-XXXXXX'>
-                <i class='fas fa-eye' id='licenseKeyHideShow' onClick='TogglePasswordHideShow("licenseKey");'></i></td></tr>
-        <tr><td></td><td><input type='button' class='buttons' value='Sign EEPROM' onClick='<?php if ($offlineMode) {
-                echo "SignEEPROMViaBrowser";
+            let formData = new FormData();
+            formData.append("signingPacket", signingPacket);
+
+            $.ajax({
+                url: 'api/cape/eeprom/signingData',
+                method: 'POST',
+                data: formData,
+                async: true,
+                contentType: false,
+                processData: false,
+                dataType: 'json',
+                success: function (data) {
+                    if (data.Status == 'OK') {
+                        location.href = 'cape-info.php#eeprom-signature';
+                        reloadPage();
+                    } else {
+                        alert('ERROR getting EEPROM signing data: ' + data.Message);
+                    }
+                },
+                error: function () {
+                    $.jGrowl('Error getting EEPROM signing data', { themeState: 'danger' });
+                }
+            });
+        }
+
+        var keysVisible = 0;
+        function ToggleKeyVisibility() {
+            if (keysVisible) {
+                keysVisible = 0;
+                $('#keyVisibilityIcon').removeClass('fa-eye-slash');
+                $('#keyVisibilityIcon').addClass('fa-eye');
+                $('.keyHidden').show();
+                $('.keyShow').hide();
             } else {
-                echo "SignEEPROM";
+                keysVisible = 1;
+                $('#keyVisibilityIcon').addClass('fa-eye-slash');
+                $('#keyVisibilityIcon').removeClass('fa-eye');
+                $('.keyHidden').hide();
+                $('.keyShow').show();
             }
-            ?>();'></td></tr>
-    </table>
-
-    <br>
-    <b>NOTES:</b>
-    <ul>
-        <li>For capes with a physical EEPROM chip, the signature will be written to the EEPROM chip.  For capes using virtual EEPROM files, the file will be signed.  This signed virtual EEPROM file is preserved across fppos upgrades, but if you reinstall FPP from scratch on the SD card, you will need to re-sign the virtual EEPROM file.</li>
-        <li>If you receive errors activating a license key, email <a href='mailto: support@falconplayer.com'>support@falconplayer.com</a> with information regarding your order number and license key.</li>
-    </ul>
-<?php
-}
-    } else {
-        echo "No EEPROM info found.";
-    }
-    ?>
-
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-<?php
-if ($printSigningUI) {
-        if ($offlineMode) {
-            ?>
-                                <div class="tab-pane fade show" id="eeprom-offline" role="tabpanel" aria-labelledby="eeprom-offline-tab">
-                                    <div class="container-fluid">
-                                        <div class="row">
-                                            <div class="aboutAll col-md">
-
-                                                <h3>Step #1: Download Signing Packet</h3>
-                                                <table>
-                                                    <tr><td><b>Order Number:</b></td><td><input id='offlineOrderNumber' type='password' size=12 maxlength=10 value=''>
-                                                            <i class='fas fa-eye' id='offlineOrderNumberHideShow' onClick='TogglePasswordHideShow("offlineOrderNumber");'></i></td></tr>
-                                                    <tr><td><b>License Key:</b></td><td><input id='offlineLicenseKey' type='password' size=36 maxlength=34 placeholder='FPPAFK-XXXXXX-XXXXXX-XXXXXX-XXXXXX'>
-                                                            <i class='fas fa-eye' id='offlineLicenseKeyHideShow' onClick='TogglePasswordHideShow("offlineLicenseKey");'></i></td></tr>
-                                                    <tr><td colspan='2'><input type='button' class='buttons' value='Download Offline Signing Packet' onClick='DownloadOfflineSigningFile();'></td></tr>
-                                                </table>
-                                                Clicking the download button will prompt you to save a file called 'cape-signing-<?=$settings['HostName']?>.bin'.  Some browsers may be setup to automatically save downloaded files.  If you are not prompted to save the file, check your Download directory for the file.
-
-                                                <hr>
-                                                <h3>Step #2: Get the packet signed.</h3>
-                                                Switch the laptop or other device you are currently using to a network which can access the internet and go to <a href='https://shop.falconplayer.com/offline-signing' target='_blank'>https://shop.falconplayer.com/offline-signing</a> and upload the signing packet.  Return to this page after you have downloaded the signed packet and then complete step #3.  <b>NOTE:</b> The above link should open in a new tab in your browser so you can return to this tab after signing the packet.<br>
-                                                <hr>
-                                                <h3>Step #3: Upload signed packet back to FPP</h3>
-                                                <input type="file" name="signingPacket" id="signingPacket" style='padding-left: 0px;'/><br>
-                                                <input class='buttons' type='button' value='Upload Signed Packet' onClick='UploadSignedPacket();'>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-<?php
-} else if ((!isset($settings['voucherRedeemed'])) || ($settings['voucherRedeemed'] != '1')) {
-            ?>
-                                <div class="tab-pane fade show" id="eeprom-voucher" role="tabpanel" aria-labelledby="eeprom-voucher-tab">
-                                    <div class="container-fluid">
-                                        <div class="row">
-                                            <div class="aboutAll col-md">
-                                                If you have a License Key voucher, you may use this page to redeem the voucher for a License Key
-                                                to enable full functionality of your cape.<br>
-                                                <br>
-                                                <b>NOTE: If you do not already have an account at
-                                                <a href='https://shop.FalconPlayer.com'>https://shop.FalconPlayer.com</a>, one will be automatically
-                                                created for you using the email address and password provided.  If you already have an account,
-                                                you must supply the password for that account below.
-                                                </b>
-
-                                                <table>
-                                                    <tr><td><b>Voucher Number:</b></td><td><input id='voucherNumber' type='password' size=18 maxlength=16 value=''>
-                                                            <i class='fas fa-eye' id='voucherNumberHideShow' onClick='TogglePasswordHideShow("voucherNumber");'></i></td></tr>
-                                                    <tr><td><b>First Name:</b></td><td><input id='voucherFName' type='text' size=36 maxlength=34></td></tr>
-                                                    <tr><td><b>Last Name:</b></td><td><input id='voucherLName' type='text' size=36 maxlength=34></td></tr>
-                                                    <tr><td><b>Email:</b></td><td><input id='voucherEmail' type='text' size=36 maxlength=34></td></tr>
-                                                    <tr><td><b>Password:</b></td><td><input id='voucherPassword' type='password' size=36 maxlength=34 value=''>
-                                                            <i class='fas fa-eye' id='voucherPasswordHideShow' onClick='TogglePasswordHideShow("voucherPassword");'></i></td></tr>
-                                                    <tr><td colspan='2'><input type='button' class='buttons' value='Redeem Voucher' onClick='RedeemVoucher();'></td></tr>
-                                                </table>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-<?php
-}
-    }
-    ?>
-
-                                <div class="tab-pane fade show" id="eeprom-upgrade" role="tabpanel" aria-labelledby="eeprom-upgrade-tab">
-                                    <h2>EEPROM Upgrade / Restore</h2>
-                                    <div class="container-fluid">
-                                        <div class="row">
-                                            <div class="aboutLeft col-8">
-                                                Select a downloadable EEPROM image or a local file to upgrade EEPROM firmware:<br>
-                                                <div><b>Vendor:</b>&nbsp;
-                                                    <select id='eepromVendorList' disabled onChange='eepromVendorListChanged();'>
-                                                        <option value=''>-- Select Vendor --</option>
-                                                    </select><br>
-                                                    <b>Cape/Hat:</b>&nbsp;
-                                                    <select id='eepromVendorCapes' disabled onChange='eepromVendorCapeChanged();'>
-                                                        <option value=''>-- Select Cape --</option>
-                                                    </select><br>
-                                                    <b>Version:</b>&nbsp;
-                                                    <select id='eepromVendorCapeVersions' disabled onChange='eepromVendorCapeVersionChanged();'>
-                                                        <option value=''>-- Select Version --</option>
-                                                    </select><br>
-                                                </div>
-
-                                                <br>
-                                                <input type="file" name="firmware" id="firmware" style='padding-left: 0px;' onChange='firmwareChanged();'><br>
-                                                <input type='button' class="buttons" value='Upgrade' onClick='UpgradeFirmware();' id='UpdateFirmware' disabled>
-                                            </div>
-                                            <div class="aboutRight col-4">
-                                                Select a backup EEPROM firmware to restore:<br>
-                                                <select id='backupFile' onChange='backupChanged();'>
-                                                    <option value=''>-- Choose a backup EEPROM to restore --</option>
-<?php
-$files = scandir('/home/fpp/media/upload/', SCANDIR_SORT_DESCENDING);
-    foreach ($files as $file) {
-        if (preg_match('/^cape-eeprom-Backup-.*\.bin$/', $file)) {
-            $restoreDisabled = '';
-            printf("<option value='%s'>%s</option>\n", $file, $file);
         }
-    }
-    ?>
-                                                </select><br>
-                                                <input type='button' class="buttons" value='Restore' onClick='RestoreFirmware();' id='RestoreFirmware' disabled style='margin-top: 0.33rem !important;'><br>
+
+        function TestInternet() {
+            // This variable is defined in https://api.FalconPlayer.com/js/internetTest.js included above
+            if (typeof theInternetIsUp === 'undefined') {
+                // Do nothing here
+            } else {
+                // Show the online version of the signing UI
+                $('.internetOnly').show();
+            }
+        }
+
+        $(document).ready(function () {
+            GetDownloadableEEPROMList();
+            setTimeout(function () { TestInternet(); }, 100);
+        });
+
+    </script>
+    <title><? echo $pageTitle; ?></title>
+    <style>
+        .no-close .ui-dialog-titlebar-close {
+            display: none
+        }
+    </style>
+</head>
+
+<body>
+    <div id="bodyWrapper">
+        <?php
+        $activeParentMenuItem = 'help';
+        include 'menu.inc';
+        ?>
+        <div class="mainContainer">
+            <div class="title"><?= $capeHardwareType ?> Info</div>
+            <div class="pageContent">
+                <?
+                if (isset($settings["cape-info"])) {
+                    ?>
+                    <div>
+                        <div style="overflow: hidden; padding: 10px;">
+                            <div class='eepromTabs'>
+                                <div id='eepromManager'>
+                                    <ul id='eepromManagerTabs' class="nav nav-pills pageContent-tabs" role="tablist">
+                                        <li class='nav-item'>
+                                            <a class="nav-link active" id="eeprom-about-tab" data-bs-toggle="pill"
+                                                href="#eeprom-about" role="tab" aria-controls="eeprom-about"
+                                                aria-selected="true">
+                                                About
+                                            </a>
+                                        </li>
+                                        <li class='nav-item'>
+                                            <a class="nav-link" id="eeprom-signature-tab" data-bs-toggle="pill"
+                                                href="#eeprom-signature" role="tab" aria-controls="eeprom-signature">
+                                                EEPROM Signature
+                                            </a>
+                                        </li>
+                                        <?php
+                                        if ($printSigningUI) {
+                                            if ($offlineMode) {
+                                                ?>
+                                                <li class='nav-item'>
+                                                    <a class="nav-link" id="eeprom-offline-tab" data-bs-toggle="pill"
+                                                        href="#eeprom-offline" role="tab" aria-controls="eeprom-offline">
+                                                        Offline Signing
+                                                    </a>
+                                                </li>
+                                                <?php
+                                            } else if (((!isset($settings['voucherRedeemed'])) || ($settings['voucherRedeemed'] != '1')) && ((!isset($currentCapeInfo['verifiedKeyId'])) || ($currentCapeInfo['verifiedKeyId'] != 'fp'))) {
+                                                ?>
+                                                    <li class='nav-item'>
+                                                        <a class="nav-link" id="eeprom-voucher-tab" data-bs-toggle="pill"
+                                                            href="#eeprom-voucher" role="tab" aria-controls="eeprom-voucher">
+                                                            Voucher Redemption
+                                                        </a>
+                                                    </li>
+                                                <?php
+                                            }
+                                        }
+                                        ?>
+                                        <li class='nav-item'>
+                                            <a class="nav-link" id="eeprom-upgrade-tab" data-bs-toggle="pill"
+                                                href="#eeprom-upgrade" role="tab" aria-controls="eeprom-upgrade">
+                                                EEPROM Upgrade
+                                            </a>
+                                        </li>
+                                    </ul>
+
+                                    <div class="tab-content" id="eepromTabsContent">
+
+                                        <div class="tab-pane fade show active" id="eeprom-about" role="tabpanel"
+                                            aria-labelledby="eeprom-about-tab">
+
+                                            <h2>About <?= $capeHardwareType ?> </h2>
+                                            <div class="container-fluid">
+                                                <div class="row">
+                                                    <div
+                                                        class='<? if (isset($currentCapeInfo['vendor'])) {
+                                                            echo "aboutLeft col-md";
+                                                        } else {
+                                                            echo "aboutAll";
+                                                        } ?> '>
+                                                        <table class='tblAbout'>
+                                                            <tr>
+                                                                <td><b>Name:</b></td>
+                                                                <td width="100%"><? echo $currentCapeInfo['name'] ?></td>
+                                                            </tr>
+                                                            <?php
+                                                            if (isset($currentCapeInfo['version'])) {
+                                                                echo "<tr><td><b>Version:</b></td><td>" . $currentCapeInfo['version'] . "</td></tr>";
+                                                            }
+                                                            if (isset($currentCapeInfo['serialNumber'])) {
+                                                                echo "<tr><td><b>Serial&nbsp;Number:</b></td><td>" . $currentCapeInfo['serialNumber'] . "</td></tr>";
+                                                            }
+                                                            if (isset($currentCapeInfo['designer'])) {
+                                                                echo "<tr><td><b>Designer:</b></td><td>" . $currentCapeInfo['designer'] . "</td></tr>";
+                                                            }
+                                                            if ((isset($currentCapeInfo['verifiedKeyId'])) && (($channelOutputDriver == 'BBB48String') || ($channelOutputDriver == 'DPIPixels') || ($channelOutputDriver == 'BBShiftString'))) {
+                                                                $key = $currentCapeInfo['verifiedKeyId'];
+                                                                if ($key == 'fp') {
+                                                                    if (isset($currentCapeInfo['signed']['licensePorts'])) {
+                                                                        echo "<tr><td><b>Licensed&nbsp;Outputs:</b></td><td>" . $currentCapeInfo['signed']['licensePorts'] . " ('fp' key)</td></tr>";
+                                                                    } else {
+                                                                        echo "<tr><td><b>Licensed&nbsp;Outputs:</b></td><td>Unknown, licensePorts setting does not exist ('fp' key)</td></tr>";
+                                                                    }
+                                                                } else {
+                                                                    echo "<tr><td><b>Licensed&nbsp;Outputs:</b></td><td>Unlimited ('$key' key)</td></tr>";
+                                                                }
+                                                            } else if (($channelOutputDriver == 'BBB48String') || ($channelOutputDriver == 'DPIPixels') || ($channelOutputDriver == 'BBShiftString')) {
+                                                                echo "<tr><td><b>Licensed&nbsp;Outputs:</b></td><td>None, cape EEPROM is not signed.</td></tr>";
+                                                            }
+                                                            if ($channelOutputDriver != '') {
+                                                                echo "<tr><td><b>Output&nbsp;Driver:</b></td><td>" . $channelOutputDriver . "</td></tr>";
+                                                            }
+                                                            if (((!isset($currentCapeInfo['verifiedKeyId'])) || ($currentCapeInfo['verifiedKeyId'] == 'fp')) && isset($currentCapeInfo['eepromLocation'])) {
+                                                                $locationMsg = '';
+                                                                if (isset($currentCapeInfo['validEepromLocation']) && !$currentCapeInfo['validEepromLocation']) {
+                                                                    $locationMsg = ' - <b>Warning:</b> Location flag specified in EEPROM<br>does not match actual EEPROM location.';
+                                                                }
+
+                                                                $location = 'Physical';
+                                                                if (preg_match('/cape-eeprom.bin/', $currentCapeInfo['eepromLocation'])) {
+                                                                    $location = 'File';
+                                                                }
+                                                                echo "<tr><td valign='top'><b>EEPROM&nbsp;Location:</b></td><td>$location$locationMsg</td></tr>";
+                                                            }
+                                                            if (isset($currentCapeInfo['description'])) {
+                                                                echo "<tr><td colspan=\"2\">";
+                                                                if (isset($currentCapeInfo['vendor']) || $currentCapeInfo['name'] == "Unknown") {
+                                                                    echo $currentCapeInfo['description'];
+                                                                } else {
+                                                                    echo htmlspecialchars($currentCapeInfo['description']);
+                                                                }
+                                                                echo "</td></tr>";
+                                                            }
+                                                            ?>
+                                                        </table>
+                                                    </div>
+                                                    <?php
+                                                    if (isset($currentCapeInfo['vendor'])) {
+                                                        ?>
+                                                        <div class='aboutRight col-md'>
+                                                            <table class='tblAbout'>
+                                                                <tr>
+                                                                    <td><b>Vendor&nbsp;Name:</b></td>
+                                                                    <td><? echo $currentCapeInfo['vendor']['name'] ?></td>
+                                                                </tr>
+                                                                <?php
+                                                                if (isset($currentCapeInfo['vendor']['url'])) {
+                                                                    $url = $currentCapeInfo['vendor']['url'];
+                                                                    $landing = $url;
+                                                                    if (isset($currentCapeInfo['vendor']['landingPage'])) {
+                                                                        $landing = $currentCapeInfo['vendor']['landingPage'];
+                                                                    }
+                                                                    if ($settings['SendVendorSerial'] == 1) {
+                                                                        $landing = $landing . "?sn=" . $currentCapeInfo['serialNumber'] . "&id=" . $currentCapeInfo['id'];
+                                                                    }
+                                                                    if (isset($currentCapeInfo['cs']) && $currentCapeInfo['cs'] != "" && $settings['SendVendorSerial'] == 1) {
+                                                                        $landing = $landing . "&cs=" . $currentCapeInfo['cs'];
+                                                                    }
+                                                                    if ($settings['hideExternalURLs']) {
+                                                                        $landing = "";
+                                                                    }
+                                                                    echo "<tr><td><b>Vendor&nbsp;URL:</b></td><td><a href=\"" . $landing . "\">" . $url . "</a></td></tr>";
+                                                                }
+                                                                if (isset($currentCapeInfo['vendor']['phone'])) {
+                                                                    echo "<tr><td><b>Phone&nbsp;Number:</b></td><td>" . $currentCapeInfo['vendor']['phone'] . "</td></tr>";
+                                                                }
+                                                                if (isset($currentCapeInfo['vendor']['email']) && !$settings['hideExternalURLs']) {
+                                                                    echo "<tr><td><b>E-mail:</b></td><td><a href=\"mailto:" . $currentCapeInfo['vendor']['email'] . "\">" . $currentCapeInfo['vendor']['email'] . "</td></tr>";
+                                                                }
+                                                                if (isset($currentCapeInfo['vendor']['forum']) && !$settings['hideExternalURLs']) {
+                                                                    echo "<tr><td><b>Support Forum:</b></td><td><a href=\"" . $currentCapeInfo['vendor']['forum'] . "\">" . $currentCapeInfo['vendor']['forum'] . "</td></tr>";
+                                                                }
+                                                                if (isset($currentCapeInfo['vendor']['image']) && $settings['FetchVendorLogos']) {
+                                                                    if ($settings['SendVendorSerial'] == 1) {
+                                                                        $iurl = $currentCapeInfo['vendor']['image'] . "?sn=" . $currentCapeInfo['serialNumber'] . "&id=" . $currentCapeInfo['id'];
+                                                                    }
+                                                                    if (isset($currentCapeInfo['cs']) && $currentCapeInfo['cs'] != "" && $settings['SendVendorSerial'] == 1) {
+                                                                        $iurl = $iurl . "&cs=" . $currentCapeInfo['cs'];
+                                                                    }
+                                                                    echo "<tr><td colspan=\"2\"><a href=\"" . $landing . "\"><img style='max-height: 90px; max-width: 300px;' src=\"" . $iurl . "\" ></a></td></tr>";
+                                                                }
+                                                                ?>
+                                                            </table>
+                                                        </div>
+                                                        <?
+                                                    }
+                                                    ?>
+                                                </div>
                                             </div>
                                         </div>
-                                        <br>
-                                        Firmware backups are automatically created whenever an EEPROM is upgraded or signed.  You may delete old
-                                        backups from the <a href='filemanager.php#tab-uploads'>File Manager</a>.
+                                        <div class="tab-pane fade show" id="eeprom-signature" role="tabpanel"
+                                            aria-labelledby="eeprom-signature-tab">
+                                            <div class="container-fluid">
+                                                <div class="row">
+                                                    <div class="aboutAll col-md">
+                                                        <?php
+                                                        if (isset($settings["cape-info"])) {
+                                                            echo $signingStatus . "<br>";
+                                                            ?>
+                                                            <br>
+                                                            <table>
+                                                                <?php
+                                                                $printBreak = 0;
+                                                                if (isset($currentCapeInfo['signed'])) {
+                                                                    if (isset($currentCapeInfo['signed']['licensePorts'])) {
+                                                                        $outputs = $currentCapeInfo['signed']['licensePorts'];
+                                                                        if ($outputs == 9999) {
+                                                                            $outputs = "Unlimited";
+                                                                        }
+
+                                                                        echo "<tr><td><b>Licensed Outputs:</b></td><td>$outputs</td></tr>";
+                                                                    }
+
+                                                                    if (isset($currentCapeInfo['signed']['licenseKey'])) {
+                                                                        if (gettype($currentCapeInfo['signed']['licenseKey']) == "string") {
+                                                                            echo "<tr><td><b>License Key: <i class='fas fa-eye' id='keyVisibilityIcon' onClick='ToggleKeyVisibility();'></i></b></td><td class='keyShow' style='display: none;'>" . $currentCapeInfo['signed']['licenseKey'] . "</td><td class='keyHidden'>******-******-******-******-******</td></tr>";
+                                                                        } else {
+                                                                            $first = 1;
+                                                                            foreach ($currentCapeInfo['signed']['licenseKey'] as $key) {
+                                                                                if ($first) {
+                                                                                    echo "<tr><td><b>License Keys: <i class='fas fa-eye' id='keyVisibilityIcon' onClick='ToggleKeyVisibility();'></i></b></td><td class='keyShow' style='display: none;'>$key</td><td class='keyHidden'>******-******-******-******-******</td></tr>\n";
+                                                                                    $first = 0;
+                                                                                } else {
+                                                                                    echo "<td></td><td class='keyShow' style='display: none;'>$key</td><td class='keyHidden'>******-******-******-******-******</td></tr>\n";
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+
+                                                                    if ($currentCapeInfo['serialNumber'] == 'FPP-INTERNAL') {
+                                                                        if (isset($currentCapeInfo['signed']['capeSerial'])) {
+                                                                            echo "<tr><td><b>Licensed Serial:</b></td><td>" . $currentCapeInfo['signed']['capeSerial'] . "</td></tr>";
+                                                                        }
+
+                                                                        if (isset($currentCapeInfo['signed']['deviceSerial'])) {
+                                                                            echo "<tr><td><b>Licensed Device:</b></td><td>" . $currentCapeInfo['signed']['deviceSerial'] . "</td></tr>";
+                                                                        }
+
+                                                                    }
+
+                                                                    if (isset($currentCapeInfo['signed']['signTime'])) {
+                                                                        echo "<tr><td><b>EEPROM Signed at:</b></td><td>" . date('Y-m-d h:i:s A T', $currentCapeInfo['signed']['signTime']) . "</td></tr>";
+                                                                    }
+
+                                                                    $printBreak = 1;
+                                                                }
+                                                                ?>
+                                                            </table>
+                                                            <?php
+                                                            if ($printBreak) {
+                                                                echo "<br>\n";
+                                                            }
+
+                                                            if ($printSigningUI) {
+                                                                if (!isset($currentCapeInfo['verifiedKeyId'])) {
+                                                                    echo "<b>NOTE: This cape is using an unsigned EEPROM and the $channelOutputDriver Channel Output driver which operates in a limited manner until the EEPROM is signed.  Pixel outputs will be limited to 50 pixels per output and smart receivers will be disabled.</b><br><br>\n";
+                                                                }
+
+                                                                ?>
+                                                                You may sign the EEPROM using a license key purchased from <a
+                                                                    href='https://shop.FalconPlayer.com'
+                                                                    target='_blank'>https://shop.FalconPlayer.com</a>. Once you have
+                                                                purchased a license key, enter the Order Number and License Key
+                                                                below.
+                                                                <?php
+                                                                if ($offlineMode) {
+                                                                    echo "If <b>neither</b> your FPP instance or your browser can reach the internet, you will need to use the 'Offline Signing' tab.  ";
+                                                                }
+
+                                                                ?>
+                                                                <br>
+
+                                                                <table <?php if ($offlineMode) {
+                                                                    echo "class='internetOnly' style='display: none;'";
+                                                                }
+                                                                ?>>
+                                            <tr>
+                                                                        <td><b>Order Number:</b></td>
+                                                                        <td><input id='orderNumber' type='password' size=12
+                                                                                maxlength=10 value=''>
+                                                                            <i class='fas fa-eye' id='orderNumberHideShow'
+                                                                                onClick='TogglePasswordHideShow("orderNumber");'></i>
+                                                                        </td>
+                                                                    </tr>
+                                                                    <tr>
+                                                                        <td><b>License Key:</b></td>
+                                                                        <td><input id='licenseKey' type='password' size=36
+                                                                                maxlength=34
+                                                                                placeholder='FPPAFK-XXXXXX-XXXXXX-XXXXXX-XXXXXX'>
+                                                                            <i class='fas fa-eye' id='licenseKeyHideShow'
+                                                                                onClick='TogglePasswordHideShow("licenseKey");'></i>
+                                                                        </td>
+                                                                    </tr>
+                                                                    <tr>
+                                                                        <td></td>
+                                                                        <td><input type='button' class='buttons' value='Sign EEPROM'
+                                                                                onClick='<?php if ($offlineMode) {
+                                                                                    echo "SignEEPROMViaBrowser";
+                                                                                } else {
+                                                                                    echo "SignEEPROM";
+                                                                                }
+                                                                                ?>();'></td>
+                                                                    </tr>
+                                                                </table>
+
+                                                                <br>
+                                                                <b>NOTES:</b>
+                                                                <ul>
+                                                                    <li>For capes with a physical EEPROM chip, the signature will be
+                                                                        written to the EEPROM chip. For capes using virtual EEPROM
+                                                                        files, the file will be signed. This signed virtual EEPROM
+                                                                        file is preserved across fppos upgrades, but if you
+                                                                        reinstall FPP from scratch on the SD card, you will need to
+                                                                        re-sign the virtual EEPROM file.</li>
+                                                                    <li>If you receive errors activating a license key, email <a
+                                                                            href='mailto: support@falconplayer.com'>support@falconplayer.com</a>
+                                                                        with information regarding your order number and license
+                                                                        key.</li>
+                                                                </ul>
+                                                                <?php
+                                                            }
+                                                        } else {
+                                                            echo "No EEPROM info found.";
+                                                        }
+                                                        ?>
+
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <?php
+                                        if ($printSigningUI) {
+                                            if ($offlineMode) {
+                                                ?>
+                                                <div class="tab-pane fade show" id="eeprom-offline" role="tabpanel"
+                                                    aria-labelledby="eeprom-offline-tab">
+                                                    <div class="container-fluid">
+                                                        <div class="row">
+                                                            <div class="aboutAll col-md">
+
+                                                                <h3>Step #1: Download Signing Packet</h3>
+                                                                <table>
+                                                                    <tr>
+                                                                        <td><b>Order Number:</b></td>
+                                                                        <td><input id='offlineOrderNumber' type='password' size=12
+                                                                                maxlength=10 value=''>
+                                                                            <i class='fas fa-eye' id='offlineOrderNumberHideShow'
+                                                                                onClick='TogglePasswordHideShow("offlineOrderNumber");'></i>
+                                                                        </td>
+                                                                    </tr>
+                                                                    <tr>
+                                                                        <td><b>License Key:</b></td>
+                                                                        <td><input id='offlineLicenseKey' type='password' size=36
+                                                                                maxlength=34
+                                                                                placeholder='FPPAFK-XXXXXX-XXXXXX-XXXXXX-XXXXXX'>
+                                                                            <i class='fas fa-eye' id='offlineLicenseKeyHideShow'
+                                                                                onClick='TogglePasswordHideShow("offlineLicenseKey");'></i>
+                                                                        </td>
+                                                                    </tr>
+                                                                    <tr>
+                                                                        <td colspan='2'><input type='button' class='buttons'
+                                                                                value='Download Offline Signing Packet'
+                                                                                onClick='DownloadOfflineSigningFile();'></td>
+                                                                    </tr>
+                                                                </table>
+                                                                Clicking the download button will prompt you to save a file called
+                                                                'cape-signing-<?= $settings['HostName'] ?>.bin'. Some browsers may be
+                                                                setup to automatically save downloaded files. If you are not
+                                                                prompted to save the file, check your Download directory for the
+                                                                file.
+
+                                                                <hr>
+                                                                <h3>Step #2: Get the packet signed.</h3>
+                                                                Switch the laptop or other device you are currently using to a
+                                                                network which can access the internet and go to <a
+                                                                    href='https://shop.falconplayer.com/offline-signing'
+                                                                    target='_blank'>https://shop.falconplayer.com/offline-signing</a>
+                                                                and upload the signing packet. Return to this page after you have
+                                                                downloaded the signed packet and then complete step #3. <b>NOTE:</b>
+                                                                The above link should open in a new tab in your browser so you can
+                                                                return to this tab after signing the packet.<br>
+                                                                <hr>
+                                                                <h3>Step #3: Upload signed packet back to FPP</h3>
+                                                                <input type="file" name="signingPacket" id="signingPacket"
+                                                                    style='padding-left: 0px;' /><br>
+                                                                <input class='buttons' type='button' value='Upload Signed Packet'
+                                                                    onClick='UploadSignedPacket();'>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <?php
+                                            } else if ((!isset($settings['voucherRedeemed'])) || ($settings['voucherRedeemed'] != '1')) {
+                                                ?>
+                                                    <div class="tab-pane fade show" id="eeprom-voucher" role="tabpanel"
+                                                        aria-labelledby="eeprom-voucher-tab">
+                                                        <div class="container-fluid">
+                                                            <div class="row">
+                                                                <div class="aboutAll col-md">
+                                                                    If you have a License Key voucher, you may use this page to redeem
+                                                                    the voucher for a License Key
+                                                                    to enable full functionality of your cape.<br>
+                                                                    <br>
+                                                                    <b>NOTE: If you do not already have an account at
+                                                                        <a
+                                                                            href='https://shop.FalconPlayer.com'>https://shop.FalconPlayer.com</a>,
+                                                                        one will be automatically
+                                                                        created for you using the email address and password provided.
+                                                                        If you already have an account,
+                                                                        you must supply the password for that account below.
+                                                                    </b>
+
+                                                                    <table>
+                                                                        <tr>
+                                                                            <td><b>Voucher Number:</b></td>
+                                                                            <td><input id='voucherNumber' type='password' size=18
+                                                                                    maxlength=16 value=''>
+                                                                                <i class='fas fa-eye' id='voucherNumberHideShow'
+                                                                                    onClick='TogglePasswordHideShow("voucherNumber");'></i>
+                                                                            </td>
+                                                                        </tr>
+                                                                        <tr>
+                                                                            <td><b>First Name:</b></td>
+                                                                            <td><input id='voucherFName' type='text' size=36
+                                                                                    maxlength=34></td>
+                                                                        </tr>
+                                                                        <tr>
+                                                                            <td><b>Last Name:</b></td>
+                                                                            <td><input id='voucherLName' type='text' size=36
+                                                                                    maxlength=34></td>
+                                                                        </tr>
+                                                                        <tr>
+                                                                            <td><b>Email:</b></td>
+                                                                            <td><input id='voucherEmail' type='text' size=36
+                                                                                    maxlength=34></td>
+                                                                        </tr>
+                                                                        <tr>
+                                                                            <td><b>Password:</b></td>
+                                                                            <td><input id='voucherPassword' type='password' size=36
+                                                                                    maxlength=34 value=''>
+                                                                                <i class='fas fa-eye' id='voucherPasswordHideShow'
+                                                                                    onClick='TogglePasswordHideShow("voucherPassword");'></i>
+                                                                            </td>
+                                                                        </tr>
+                                                                        <tr>
+                                                                            <td colspan='2'><input type='button' class='buttons'
+                                                                                    value='Redeem Voucher' onClick='RedeemVoucher();'>
+                                                                            </td>
+                                                                        </tr>
+                                                                    </table>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                <?php
+                                            }
+                                        }
+                                        ?>
+
+                                        <div class="tab-pane fade show" id="eeprom-upgrade" role="tabpanel"
+                                            aria-labelledby="eeprom-upgrade-tab">
+                                            <h2>EEPROM Upgrade / Restore</h2>
+                                            <div class="container-fluid">
+                                                <div class="row">
+                                                    <div class="aboutLeft col-8">
+                                                        Select a downloadable EEPROM image or a local file to upgrade EEPROM
+                                                        firmware:<br>
+                                                        <div><b>Vendor:</b>&nbsp;
+                                                            <select id='eepromVendorList' disabled
+                                                                onChange='eepromVendorListChanged();'>
+                                                                <option value=''>-- Select Vendor --</option>
+                                                            </select><br>
+                                                            <b>Cape/Hat:</b>&nbsp;
+                                                            <select id='eepromVendorCapes' disabled
+                                                                onChange='eepromVendorCapeChanged();'>
+                                                                <option value=''>-- Select Cape --</option>
+                                                            </select><br>
+                                                            <b>Version:</b>&nbsp;
+                                                            <select id='eepromVendorCapeVersions' disabled
+                                                                onChange='eepromVendorCapeVersionChanged();'>
+                                                                <option value=''>-- Select Version --</option>
+                                                            </select><br>
+                                                        </div>
+
+                                                        <br>
+                                                        <input type="file" name="firmware" id="firmware"
+                                                            style='padding-left: 0px;' onChange='firmwareChanged();'><br>
+                                                        <input type='button' class="buttons" value='Upgrade'
+                                                            onClick='UpgradeFirmware();' id='UpdateFirmware' disabled>
+                                                    </div>
+                                                    <div class="aboutRight col-4">
+                                                        Select a backup EEPROM firmware to restore:<br>
+                                                        <select id='backupFile' onChange='backupChanged();'>
+                                                            <option value=''>-- Choose a backup EEPROM to restore --
+                                                            </option>
+                                                            <?php
+                                                            $files = scandir('/home/fpp/media/upload/', SCANDIR_SORT_DESCENDING);
+                                                            foreach ($files as $file) {
+                                                                if (preg_match('/^cape-eeprom-Backup-.*\.bin$/', $file)) {
+                                                                    $restoreDisabled = '';
+                                                                    printf("<option value='%s'>%s</option>\n", $file, $file);
+                                                                }
+                                                            }
+                                                            ?>
+                                                        </select><br>
+                                                        <input type='button' class="buttons" value='Restore'
+                                                            onClick='RestoreFirmware();' id='RestoreFirmware' disabled
+                                                            style='margin-top: 0.33rem !important;'><br>
+                                                    </div>
+                                                </div>
+                                                <br>
+                                                Firmware backups are automatically created whenever an EEPROM is upgraded or
+                                                signed. You may delete old
+                                                backups from the <a href='filemanager.php#tab-uploads'>File Manager</a>.
+                                            </div>
+                                        </div>
                                     </div>
+                                </div>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+                <?
+                } else {
+                    if ($eepromFile != '') {
+                        ?>
+                    <div class="tab-pane fade show" id="eeprom-upgrade" role="tabpanel" aria-labelledby="eeprom-upgrade-tab">
+                        <h2>EEPROM Install</h2>
+                        <div class="container-fluid">
+                            <div class="row">
+                                <div class="aboutLeft col-md">
+                                    Your cape appears to have an unprogrammed physical EEPROM installed. Select a downloadable
+                                    EEPROM image or a local file to program the EEPROM:<br>
+                                    <div><b>Vendor:</b>&nbsp;
+                                        <select id='eepromVendorList' disabled onChange='eepromVendorListChanged();'>
+                                            <option value=''>-- Select Vendor --</option>
+                                        </select>&nbsp;&nbsp;
+                                        <b>Cape/Hat:</b>&nbsp;
+                                        <select id='eepromVendorCapes' disabled onChange='eepromVendorCapeChanged();'>
+                                            <option value=''>-- Select Cape --</option>
+                                        </select>&nbsp;&nbsp;
+                                        <b>Version:</b>&nbsp;
+                                        <select id='eepromVendorCapeVersions' disabled
+                                            onChange='eepromVendorCapeVersionChanged();'>
+                                            <option value=''>-- Select Version --</option>
+                                        </select>&nbsp;&nbsp;
+                                    </div>
+                                    </br>
+                                    <input type="file" name="firmware" id="firmware" style='padding-left: 0px;'
+                                        onChange='firmwareChanged();'><br>
+                                    <input type='button' class="buttons" value='Upgrade' onClick='UpgradeFirmware(true);'
+                                        id='UpdateFirmware' disabled>
                                 </div>
                             </div>
                         </div>
                     </div>
+                    <?
+                    } else {
+                        ?>
+                    <h3>No Cape or Hat EEPROM found.</h3>
 
-                </div>
-            </div>
+                    Unable to find a physical or virtual EEPROM. If you have a cape without a physical EEPROM installed,
+                    you will need to select a virtual EEPROM from the Pixel Strings Channel Output configuration page.
+                    <?
+                    }
+                }
+                ?>
         </div>
-<?
-} else {
-    if ($eepromFile != '') {
+        <?php
+        include 'common/footer.inc';
         ?>
-                                <div class="tab-pane fade show" id="eeprom-upgrade" role="tabpanel" aria-labelledby="eeprom-upgrade-tab">
-                                    <h2>EEPROM Install</h2>
-                                    <div class="container-fluid">
-                                        <div class="row">
-                                            <div class="aboutLeft col-md">
-                                                Your cape appears to have an unprogrammed physical EEPROM installed. Select a downloadable EEPROM image or a local file to program the EEPROM:<br>
-                                                <div><b>Vendor:</b>&nbsp;
-                                                    <select id='eepromVendorList' disabled onChange='eepromVendorListChanged();'>
-                                                        <option value=''>-- Select Vendor --</option>
-                                                    </select>&nbsp;&nbsp;
-                                                    <b>Cape/Hat:</b>&nbsp;
-                                                    <select id='eepromVendorCapes' disabled onChange='eepromVendorCapeChanged();'>
-                                                        <option value=''>-- Select Cape --</option>
-                                                    </select>&nbsp;&nbsp;
-                                                    <b>Version:</b>&nbsp;
-                                                    <select id='eepromVendorCapeVersions' disabled onChange='eepromVendorCapeVersionChanged();'>
-                                                        <option value=''>-- Select Version --</option>
-                                                    </select>&nbsp;&nbsp;
-                                                </div>
-                                                </br>
-                                                <input type="file" name="firmware" id="firmware" style='padding-left: 0px;' onChange='firmwareChanged();'><br>
-                                                <input type='button' class="buttons" value='Upgrade' onClick='UpgradeFirmware(true);' id='UpdateFirmware' disabled>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-<?
-    } else {
-        ?>
-    <h3>No Cape or Hat EEPROM found.</h3>
-
-    Unable to find a physical or virtual EEPROM.  If you have a cape without a physical EEPROM installed,
-    you will need to select a virtual EEPROM from the Pixel Strings Channel Output configuration page.
-<?
-    }
-}
-?>
     </div>
-<?php
-include 'common/footer.inc';
-?>
-</div>
-<div id='upgradePopup' title='FPP Upgrade' style="display: none">
-    <textarea style='width: 99%; height: 500px;' disabled id='upgradeText'>
+    <div id='upgradePopup' title='FPP Upgrade' style="display: none">
+        <textarea style='width: 99%; height: 500px;' disabled id='upgradeText'>
     </textarea>
-    <input id='closeDialogButton' type='button' class='buttons dialogCloseButton' value='Close' onClick='CloseUpgradeDialog(true);' style='display: none;'>
-    <input id='errorDialogButton' type='button' class='buttons dialogCloseButton' value='Close' onClick='CloseUpgradeDialog(false);' style='display: none;'>
-</div>
+        <input id='closeDialogButton' type='button' class='buttons dialogCloseButton' value='Close'
+            onClick='CloseUpgradeDialog(true);' style='display: none;'>
+        <input id='errorDialogButton' type='button' class='buttons dialogCloseButton' value='Close'
+            onClick='CloseUpgradeDialog(false);' style='display: none;'>
+    </div>
 </body>
+
 </html>

--- a/www/menu.inc
+++ b/www/menu.inc
@@ -6,359 +6,387 @@ $fpp_head_version = "v" . getFPPVersion();
 $git_branch = getFPPBranch();
 
 if (!preg_match("/^$git_branch(-.*)?$/", $fpp_head_version))
-	$fpp_head_version .= " ($git_branch branch)";
+  $fpp_head_version .= " ($git_branch branch)";
 
 if (!isset($activeParentMenuItem)) {
-    $activeParentMenuItem = "";
+  $activeParentMenuItem = "";
 }
 ?>
 
-<?php require_once(dirname(__FILE__)."/config.php"); ?>
+<?php require_once (dirname(__FILE__) . "/config.php"); ?>
 <?php
-function list_plugin_entries($menu) {
-	global $pluginDirectory;
-    $menukey = $menu;
-    if ($menu == "output") {
-        $menukey = "input-output";
-    }
-	if ($menu && file_exists($pluginDirectory)) {
-		$handle = opendir($pluginDirectory);
-		if ( $handle ) {
-			$first = 1;
-			while (($plugin = readdir($handle)) !== false) {
-				if (!in_array($plugin, array('.', '..'))) {
-					// Old naming convention ${MENU}_menu.inc
-					if ( file_exists($pluginDirectory."/".$plugin."/".$menu."_menu.inc") ) {
-						if ($first) {
-							$first = 0;
-                            echo '<h6 class="dropdown-header">- - - - - - - Plugins - - - - - - -</h6>';
-						}
-
-                        ob_start();
-                        -include_once($pluginDirectory."/".$plugin."/".$menu."_menu.inc");
-                        $buffer = ob_get_clean();
-                        $buffer = str_replace(array("<li>","</li>","</li\n>"),"",$buffer);
-                        $buffer = str_replace("<a ","<a class=\"dropdown-item\" ",$buffer);
-                        $buffer = str_replace("plugin.php?plugin", "plugin.php?_menu=" . $menukey . "&plugin", $buffer);
-                        echo $buffer;
-                    }
-
-					// New single menu.inc file which has some logic in it to display relevant menus.
-					// See the example in the fpp-plugin-Template plugin
-					if ( file_exists($pluginDirectory."/".$plugin."/menu.inc") ) {
-                        ob_start();
-                        -include($pluginDirectory."/".$plugin."/menu.inc");
-                        $buffer = ob_get_clean();
-                        $buffer = str_replace(array("<li>","</li>"),"",$buffer);
-                        $buffer = str_replace("<a ","<a class=\"dropdown-item\" ",$buffer);
-                        $buffer = str_replace("plugin.php?plugin", "plugin.php?_menu=" . $menukey . "&plugin",  $buffer);
-                        if ($first && !empty($buffer)) {
-                            $first = 0;
-                            echo '<h6 class="dropdown-header">- - - - - - - Plugins - - - - - - -</h6>';
-                        }
-
-                        echo $buffer;
-					}
-				}
-			}
-		}
-	}
-}
-?>
-
-   <div class="header">
-    <div class="headerLeft">
-          <div class="headerLeftCol fppBrand">
-            <a href="index.php">
-              <img src='<?= $themeInfo["HEADER_LOGO1"] ?>' class="logo" title="Host: <? echo $settings['HostName']; ?>" >
-              <? if (isset($themeInfo["HEADER_LOGO2"]) && $themeInfo["HEADER_LOGO2"] != "" ) {
-                echo "<img src='" . $themeInfo["HEADER_LOGO2"] . "' class='fpp-logo'  title='Host: " . $settings["HostName"] . "' >";
-              }
-              ?>
-            </a>
-            <a href='about.php' class='nonULLink headerLink versionHead'><?php echo $fpp_head_version; ?></a>
-          </div>
-
-    </div>
-    <div class="headerCenter">
-      <div class="headerCenterRow headerHost">
-<?
-    echo("<span class=\"headerHostName headerBox\" id=\"header_host\"><a href='index.php' class='nonULLink'>".$settings['HostName']."</a></span>");
-
-    $currentHeaderSensor = "1";
-    if (isset($settings['currentHeaderSensor'])) {
-       $currentHeaderSensor = $settings['currentHeaderSensor'];
-    }
-
-?>
-    <span class="headerBox" id="header_player"></span>
-    <span class="headerBox largeonly" id="header_sensors" data-defaultsensor="<? echo $currentHeaderSensor; ?>"></span>
-    <span class="headerBox" id="header_IPs"></span>
-    <span class="headerBox" id="header_Time"></span>
-</div>
-    </div>
-    <div class="headerRight largeonly">
-		  <?
-            if ($settings['LogoLink'] != "") echo "<a href='" . $settings['LogoLink'] . "' target='_blank' class='platformLogoLink'>";
-		    if ($settings['Logo'] != "") {
-           echo "<img src='images/" . $settings['Logo'] . "' class='logo' alt='" . $settings['Variant'] . " Logo'>"; }
-		    if ($settings['LogoLink'] != "") echo "</a>";
-            if (isSet($settings['cape-info']) && isSet($settings['cape-info']['vendor']) && isSet($settings['cape-info']['vendor']['image']) 
-                && $settings['FetchVendorLogos'] == 1) {
-                $landing = $settings['cape-info']['vendor']['url'];
-                if (isSet($settings['cape-info']['vendor']['landingPage'])) {
-                    $landing = $settings['cape-info']['vendor']['landingPage'];
-                }
-                if ($settings['SendVendorSerial'] == 1) {
-                     $iurl = $settings['cape-info']['vendor']['image'] . "?sn=" . $settings['cape-info']['serialNumber'] . "&id=" . $settings['cape-info']['id'];
-                } else {
-                     $iurl = $settings['cape-info']['vendor']['image']; 
-                }
-
-                if ($settings['SendVendorSerial'] == 1) {
-                    $landing = $landing . "?sn=" . $settings['cape-info']['serialNumber'] . "&id=" . $settings['cape-info']['id'];
-                }
-                if (isset($settings['cape-info']['cs']) && $settings['cape-info']['cs'] != "" && $settings['SendVendorSerial'] == 1) {
-                    $iurl = $iurl . "&cs=" . $settings['cape-info']['cs'];
-                }
-                if ($settings['hideExternalURLs']) {
-                    $landing = "";
-                }
-                ?>
-                      <div class="capeVendor">
-                        <div class="capeVendorLogo">
-                          <a href="<? echo $landing; ?>" target="capeVendor">
-                           <img src="<? echo $iurl; ?>" class="logo" >
-                          </a>
-                        </div>
-                      </div>
-                <?
-
+function list_plugin_entries($menu)
+{
+  global $pluginDirectory;
+  $menukey = $menu;
+  if ($menu == "output") {
+    $menukey = "input-output";
+  }
+  if ($menu && file_exists($pluginDirectory)) {
+    $handle = opendir($pluginDirectory);
+    if ($handle) {
+      $first = 1;
+      while (($plugin = readdir($handle)) !== false) {
+        if (!in_array($plugin, array('.', '..'))) {
+          // Old naming convention ${MENU}_menu.inc
+          if (file_exists($pluginDirectory . "/" . $plugin . "/" . $menu . "_menu.inc")) {
+            if ($first) {
+              $first = 0;
+              echo '<h6 class="dropdown-header">- - - - - - - Plugins - - - - - - -</h6>';
             }
-          ?>
-		</div>
 
-  </div>
-  <div style='float: right'><a href='#' class='nonULLink' onClick='ClearRestartFlag(); ClearRebootFlag();'><img src='images/1x1.png' width='5' height='5' style="vertical-align: top;" alt=''></a></div>
-  <div class='helpLinkDiv largeonly'><a href='javascript:void();' onClick='DisplayHelp();' class='nonULLink'>&nbsp;Press F1 for help&nbsp;&nbsp;</a></div>
+            ob_start();
+            -include_once ($pluginDirectory . "/" . $plugin . "/" . $menu . "_menu.inc");
+            $buffer = ob_get_clean();
+            $buffer = str_replace(array("<li>", "</li>", "</li\n>"), "", $buffer);
+            $buffer = str_replace("<a ", "<a class=\"dropdown-item\" ", $buffer);
+            $buffer = str_replace("plugin.php?plugin", "plugin.php?_menu=" . $menukey . "&plugin", $buffer);
+            echo $buffer;
+          }
 
-  <button class='buttons' onclick="scrollToTop()" id="scrollTopButton">Top</button>
+          // New single menu.inc file which has some logic in it to display relevant menus.
+          // See the example in the fpp-plugin-Template plugin
+          if (file_exists($pluginDirectory . "/" . $plugin . "/menu.inc")) {
+            ob_start();
+            -include ($pluginDirectory . "/" . $plugin . "/menu.inc");
+            $buffer = ob_get_clean();
+            $buffer = str_replace(array("<li>", "</li>"), "", $buffer);
+            $buffer = str_replace("<a ", "<a class=\"dropdown-item\" ", $buffer);
+            $buffer = str_replace("plugin.php?plugin", "plugin.php?_menu=" . $menukey . "&plugin", $buffer);
+            if ($first && !empty($buffer)) {
+              $first = 0;
+              echo '<h6 class="dropdown-header">- - - - - - - Plugins - - - - - - -</h6>';
+            }
 
-  <div class="fppOuterContainer">
-    <div class="fppMenuContainer">
-  <?
-	if (file_exists("/etc/fpp/rfs_version") && exec('grep "^[^#].*/home/pi/media" /etc/fstab') )
-	{
-		$mounted = 0;
-		$needToMount = 0;
-		$mountPoints = file("/etc/fstab");
-		foreach ($mountPoints as $mountPoint)
-		{
-			if (preg_match("/^[^#].*\/home\/[a-z]*\/media/", $mountPoint))
-			{
-				$needToMount = 1;
-				$mounts = file("/proc/mounts");
-				$mounted = 0;
-				foreach ($mounts as $mount)
-				{
-					if (preg_match("/\/home\/[a-z]*\/media/", $mount))
-					{
-						$mounted = 1;
-						break;
-					}
-				}
-
-				break;
-			}
-		}
-
-
-		if ($needToMount && !$mounted)
-		{
-?>
-  <div class="alert danger">
-    WARNING: <?= $fppHome; ?>/media is not mounted, is a USB flash drive inserted?
-  </div>
-<?
-		}
-	}
-$freeSpace = disk_free_space($mediaDirectory);
-if ($freeSpace < 50000000) {
-?>
-  <div class="alert alert-danger"><b>WARNING:</b> <?= $mediaDirectory ?> is running low on space.  Problems may occur with saving settings or uploading content.</div>
-<?
+            echo $buffer;
+          }
+        }
+      }
+    }
+  }
 }
 ?>
-<!--
+
+<div class="header">
+  <div class="headerLeft">
+    <div class="headerLeftCol fppBrand">
+      <a href="index.php">
+        <img src='<?= $themeInfo["HEADER_LOGO1"] ?>' class="logo" title="Host: <? echo $settings['HostName']; ?>">
+        <? if (isset($themeInfo["HEADER_LOGO2"]) && $themeInfo["HEADER_LOGO2"] != "") {
+          echo "<img src='" . $themeInfo["HEADER_LOGO2"] . "' class='fpp-logo'  title='Host: " . $settings["HostName"] . "' >";
+        }
+        ?>
+      </a>
+      <a href='about.php' class='nonULLink headerLink versionHead'><?php echo $fpp_head_version; ?></a>
+    </div>
+
+  </div>
+  <div class="headerCenter">
+    <div class="headerCenterRow headerHost">
+      <?
+      echo ("<span class=\"headerHostName headerBox\" id=\"header_host\"><a href='index.php' class='nonULLink'>" . $settings['HostName'] . "</a></span>");
+
+      $currentHeaderSensor = "1";
+      if (isset($settings['currentHeaderSensor'])) {
+        $currentHeaderSensor = $settings['currentHeaderSensor'];
+      }
+
+      ?>
+      <span class="headerBox" id="header_player"></span>
+      <span class="headerBox largeonly" id="header_sensors"
+        data-defaultsensor="<? echo $currentHeaderSensor; ?>"></span>
+      <span class="headerBox" id="header_IPs"></span>
+      <span class="headerBox" id="header_Time"></span>
+    </div>
+  </div>
+  <div class="headerRight largeonly">
+    <?
+    if ($settings['LogoLink'] != "")
+      echo "<a href='" . $settings['LogoLink'] . "' target='_blank' class='platformLogoLink'>";
+    if ($settings['Logo'] != "") {
+      echo "<img src='images/" . $settings['Logo'] . "' class='logo' alt='" . $settings['Variant'] . " Logo'>";
+    }
+    if ($settings['LogoLink'] != "")
+      echo "</a>";
+    if (
+      isset($settings['cape-info']) && isset($settings['cape-info']['vendor']) && isset($settings['cape-info']['vendor']['image'])
+      && $settings['FetchVendorLogos'] == 1
+    ) {
+      $landing = $settings['cape-info']['vendor']['url'];
+      if (isset($settings['cape-info']['vendor']['landingPage'])) {
+        $landing = $settings['cape-info']['vendor']['landingPage'];
+      }
+      if ($settings['SendVendorSerial'] == 1) {
+        $iurl = $settings['cape-info']['vendor']['image'] . "?sn=" . $settings['cape-info']['serialNumber'] . "&id=" . $settings['cape-info']['id'];
+      } else {
+        $iurl = $settings['cape-info']['vendor']['image'];
+      }
+
+      if ($settings['SendVendorSerial'] == 1) {
+        $landing = $landing . "?sn=" . $settings['cape-info']['serialNumber'] . "&id=" . $settings['cape-info']['id'];
+      }
+      if (isset($settings['cape-info']['cs']) && $settings['cape-info']['cs'] != "" && $settings['SendVendorSerial'] == 1) {
+        $iurl = $iurl . "&cs=" . $settings['cape-info']['cs'];
+      }
+      if ($settings['hideExternalURLs']) {
+        $landing = "";
+      }
+      ?>
+      <div class="capeVendor">
+        <div class="capeVendorLogo">
+          <a href="<? echo $landing; ?>" target="capeVendor">
+            <img src="<? echo $iurl; ?>" class="logo">
+          </a>
+        </div>
+      </div>
+      <?
+
+    }
+    ?>
+  </div>
+
+</div>
+<div style='float: right'><a href='#' class='nonULLink' onClick='ClearRestartFlag(); ClearRebootFlag();'><img
+      src='images/1x1.png' width='5' height='5' style="vertical-align: top;" alt=''></a></div>
+<div class='helpLinkDiv largeonly'><a href='javascript:void();' onClick='DisplayHelp();' class='nonULLink'>&nbsp;Press
+    F1 for help&nbsp;&nbsp;</a></div>
+
+<button class='buttons' onclick="scrollToTop()" id="scrollTopButton">Top</button>
+
+<div class="fppOuterContainer">
+  <div class="fppMenuContainer">
+    <?
+    if (file_exists("/etc/fpp/rfs_version") && exec('grep "^[^#].*/home/pi/media" /etc/fstab')) {
+      $mounted = 0;
+      $needToMount = 0;
+      $mountPoints = file("/etc/fstab");
+      foreach ($mountPoints as $mountPoint) {
+        if (preg_match("/^[^#].*\/home\/[a-z]*\/media/", $mountPoint)) {
+          $needToMount = 1;
+          $mounts = file("/proc/mounts");
+          $mounted = 0;
+          foreach ($mounts as $mount) {
+            if (preg_match("/\/home\/[a-z]*\/media/", $mount)) {
+              $mounted = 1;
+              break;
+            }
+          }
+
+          break;
+        }
+      }
+
+
+      if ($needToMount && !$mounted) {
+        ?>
+        <div class="alert danger">
+          WARNING: <?= $fppHome; ?>/media is not mounted, is a USB flash drive inserted?
+        </div>
+        <?
+      }
+    }
+    $freeSpace = disk_free_space($mediaDirectory);
+    if ($freeSpace < 50000000) {
+      ?>
+      <div class="alert alert-danger"><b>WARNING:</b> <?= $mediaDirectory ?> is running low on space. Problems may occur
+        with saving settings or uploading content.</div>
+      <?
+    }
+    ?>
+    <!--
   <div id='upgradeFlag' class="alert detract"><span class='inlineBlock'>FPP v7.1 is available for install</span><span class='inlineBlock'><button name="btnUpgrade" type="button" onClick="ViewReleaseNotes('7.1');"  class = "buttons btn-outline-light" ><i class='fas fa-fw fa-sync fa-nbsp'></i>Upgrade FPP</button></span></div>
 -->
-  <div id='restartFlag' class="alert detract"><span class='inlineBlock'>Settings have changed. FPPD Restart Required</span><span class='inlineBlock'><button name="btnRestartFPPD" type="button" onClick="RestartFPPD();" class="buttons btn-outline-light"><i class='fas fa-fw fa-sync fa-nbsp'></i>Restart FPPD</button>
+    <div id='restartFlag' class="alert detract"><span class='inlineBlock'>Settings have changed. FPPD Restart
+        Required</span><span class='inlineBlock'><button name="btnRestartFPPD" type="button" onClick="RestartFPPD();"
+          class="buttons btn-outline-light"><i class='fas fa-fw fa-sync fa-nbsp'></i>Restart FPPD</button>
 
-<?
-  if (basename($_SERVER['PHP_SELF']) == "developer.php")
-  {
-?>
-  <input type='button' class = "buttons btn-outline-light" value='Clear' onClick='ClearRestartFlag();'>
-<?
-  }
-?>
-    </span>
-  </div>
-<?  if (!file_exists(__DIR__."/../src/fppd")) { ?>
-<div id='rebuildPopup' title='FPP Upgrade' style="display: none">
-    <textarea style='width: 99%; height: 97%;' disabled id='rebuildText'>
-    </textarea>
-</div>
-<script>
-function RebuildFPPDDone() {
-    $('#rebuildFPPCloseButton').prop("disabled", false);
-    EnableModalDialogCloseButton("rebuildFPP");
-}
-function RebuildFPPD() {
-    DisplayProgressDialog("rebuildFPP", "Rebuild FPP");
-    StreamURL('manualUpdate.php?wrapped=1', 'rebuildFPPText', 'RebuildFPPDDone', 'RebuildFPPDDone');
-}
-</script>
-  <div id="compileFPPDBanner" class="alert alert-danger"><span class='inlineBlock'>FPPD not found. Rebuild required</span><span class='inlineBlock'><input name="btnRebuild" onClick="RebuildFPPD();" type="button" class = "buttons btn-outline-light" value="Rebuild"></span></div>
-<? } ?>
-  <div id='unsupportedBrowser' class="alert alert-danger">FPP will not work with this browser.  Chrome, Firefox, or Edge is strongly recommended.</div>
-  <div id='rebootFlag' class="alert detract"><span class='inlineBlock'>Base configuration has changed. Reboot Required</span><span class='inlineBlock'><input name="btnReboot" onClick="Reboot();" type="button" class = "buttons btn-outline-light" value="Reboot">
-<?
-  if (basename($_SERVER['PHP_SELF']) == "developer.php")
-  {
-?>
-  <input type='button' class = "buttons btn-outline-light" value='Clear' onClick='ClearRebootFlag();'>
-<?
-  }
-?>
-    </span>
-  </div>
-
-
-  <nav id="fppMenu" class="navbar navbar-expand-lg navbar-dark">
-  <div class="navbar-translate">
-  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-          </div>
-  <div class="collapse navbar-collapse" id="navbarNavDropdown">
-    <ul id="fppMenuList" class="navbar-nav">
-    <li class="nav-item dropdown <? echo $activeParentMenuItem=='status' ? 'active' :''; ?>">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkStatus" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Status/Control
-        </a>
-        <div class="dropdown-menu dropdown-with-icons" aria-labelledby="navbarDropdownMenuLinkStatus">
-        <a class="dropdown-item" href="index.php"><i class="fas fa-info"></i> Status Page</a>
-<?
-if (isSet($settings['cape-info']) && isSet($settings['cape-info']['provides']) && in_array("currentMonitoring", $settings['cape-info']['provides'])) {
-          echo "<a class='dropdown-item' href='currentmonitor.php'><i class='fas fa-bolt'></i> Current Monitor</a>";
-}
-if ((!$settings["IsDesktop"]) || ($settings['uiLevel'] > 2) ) {
-          echo "<a class='dropdown-item' href='networkconfig.php'><i class='fas fa-network-wired'></i> Network</a>";
-}
-?>
-          <a class="dropdown-item" href="multisync.php"><i class="fas fa-cogs"></i> MultiSync</a>
-          <a class="dropdown-item" href="settings.php"><i class="fas fa-cog"></i> FPP Settings</a>
-          <a class="dropdown-item" href="backup.php"><i class="fas fa-sim-card"></i> FPP Backup</a>
-          <a class="dropdown-item" href="proxies.php"><i class="fas fa-globe"></i> Proxy Settings</a>
-          <a class="dropdown-item" href="commandPresets.php"><i class="fas fa-calendar-alt"></i> Command Presets</a>
-          <a class="dropdown-item" href="effects.php"><i class="fas fa-magic"></i> Effects</a>
-          <a class="dropdown-item" href="testing.php"><i class="fas fa-clipboard-check"></i> Display Testing</a>
+        <?
+        if (basename($_SERVER['PHP_SELF']) == "developer.php") {
+          ?>
+          <input type='button' class="buttons btn-outline-light" value='Clear' onClick='ClearRestartFlag();'>
           <?
-          if (file_exists($settings['co-other'])) {
-            $js = json_decode(file_get_contents($settings['co-other']), true);
-            if (isset($js["channelOutputs"])) {
-              foreach($js["channelOutputs"] as $key => $val) {
-                if (($val["enabled"] == 1) && ($val["type"] == "HTTPVirtualDisplay")) {
-                echo "<a class='dropdown-item' href='virtualdisplaywrapper.php'><i class='fas fa-tv'></i> Virtual Display</a>";
+        }
+        ?>
+      </span>
+    </div>
+    <? if (!file_exists(__DIR__ . "/../src/fppd")) { ?>
+      <div id='rebuildPopup' title='FPP Upgrade' style="display: none">
+        <textarea style='width: 99%; height: 97%;' disabled id='rebuildText'>
+      </textarea>
+      </div>
+      <script>
+        function RebuildFPPDDone() {
+          $('#rebuildFPPCloseButton').prop("disabled", false);
+          EnableModalDialogCloseButton("rebuildFPP");
+        }
+        function RebuildFPPD() {
+          DisplayProgressDialog("rebuildFPP", "Rebuild FPP");
+          StreamURL('manualUpdate.php?wrapped=1', 'rebuildFPPText', 'RebuildFPPDDone', 'RebuildFPPDDone');
+        }
+      </script>
+      <div id="compileFPPDBanner" class="alert alert-danger"><span class='inlineBlock'>FPPD not found. Rebuild
+          required</span><span class='inlineBlock'><input name="btnRebuild" onClick="RebuildFPPD();" type="button"
+            class="buttons btn-outline-light" value="Rebuild"></span></div>
+    <? } ?>
+    <div id='unsupportedBrowser' class="alert alert-danger">FPP will not work with this browser. Chrome, Firefox, or
+      Edge is strongly recommended.</div>
+    <div id='rebootFlag' class="alert detract"><span class='inlineBlock'>Base configuration has changed. Reboot
+        Required</span><span class='inlineBlock'><input name="btnReboot" onClick="Reboot();" type="button"
+          class="buttons btn-outline-light" value="Reboot">
+        <?
+        if (basename($_SERVER['PHP_SELF']) == "developer.php") {
+          ?>
+          <input type='button' class="buttons btn-outline-light" value='Clear' onClick='ClearRebootFlag();'>
+          <?
+        }
+        ?>
+      </span>
+    </div>
+
+
+    <nav id="fppMenu" class="navbar navbar-expand-lg navbar-dark">
+      <div class="navbar-translate">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown"
+          aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+      </div>
+      <div class="collapse navbar-collapse" id="navbarNavDropdown">
+        <ul id="fppMenuList" class="navbar-nav">
+          <li class="nav-item dropdown <? echo $activeParentMenuItem == 'status' ? 'active' : ''; ?>">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkStatus" role="button"
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Status/Control
+            </a>
+            <div class="dropdown-menu dropdown-with-icons" aria-labelledby="navbarDropdownMenuLinkStatus">
+              <a class="dropdown-item" href="index.php"><i class="fas fa-info"></i> Status Page</a>
+              <?
+              if (isset($settings['cape-info']) && isset($settings['cape-info']['provides']) && in_array("currentMonitoring", $settings['cape-info']['provides'])) {
+                echo "<a class='dropdown-item' href='currentmonitor.php'><i class='fas fa-bolt'></i> Current Monitor</a>";
+              }
+              if ((!$settings["IsDesktop"]) || ($settings['uiLevel'] > 2)) {
+                echo "<a class='dropdown-item' href='networkconfig.php'><i class='fas fa-network-wired'></i> Network</a>";
+              }
+              ?>
+              <a class="dropdown-item" href="multisync.php"><i class="fas fa-cogs"></i> MultiSync</a>
+              <a class="dropdown-item" href="settings.php"><i class="fas fa-cog"></i> FPP Settings</a>
+              <a class="dropdown-item" href="backup.php"><i class="fas fa-sim-card"></i> FPP Backup</a>
+              <a class="dropdown-item" href="proxies.php"><i class="fas fa-globe"></i> Proxy Settings</a>
+              <a class="dropdown-item" href="commandPresets.php"><i class="fas fa-calendar-alt"></i> Command Presets</a>
+              <a class="dropdown-item" href="effects.php"><i class="fas fa-magic"></i> Effects</a>
+              <a class="dropdown-item" href="testing.php"><i class="fas fa-clipboard-check"></i> Display Testing</a>
+              <?
+              if (file_exists($settings['co-other'])) {
+                $js = json_decode(file_get_contents($settings['co-other']), true);
+                if (isset($js["channelOutputs"])) {
+                  foreach ($js["channelOutputs"] as $key => $val) {
+                    if (($val["enabled"] == 1) && ($val["type"] == "HTTPVirtualDisplay")) {
+                      echo "<a class='dropdown-item' href='virtualdisplaywrapper.php'><i class='fas fa-tv'></i> Virtual Display</a>";
+                    }
+                  }
                 }
               }
-            }
-          }
-          ?>
+              ?>
 
-          <?php list_plugin_entries("status"); ?>
-        </div>
-      </li>
+              <?php list_plugin_entries("status"); ?>
+            </div>
+          </li>
 
-      <li class="nav-item dropdown <? echo $activeParentMenuItem=='content' ? 'active' :''; ?>">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkContent" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Content Setup
-        </a>
-        <div class="dropdown-menu dropdown-with-icons" aria-labelledby="navbarDropdownMenuLinkContent">
-        <a class="dropdown-item" href="filemanager.php"><i class="fas fa-upload"></i> File Manager</a>
-          <a class="dropdown-item" href="playlists.php"><i class="fas fa-list-ol"></i> Playlists</a>
+          <li class="nav-item dropdown <? echo $activeParentMenuItem == 'content' ? 'active' : ''; ?>">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkContent" role="button"
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Content Setup
+            </a>
+            <div class="dropdown-menu dropdown-with-icons" aria-labelledby="navbarDropdownMenuLinkContent">
+              <a class="dropdown-item" href="filemanager.php"><i class="fas fa-upload"></i> File Manager</a>
+              <a class="dropdown-item" href="playlists.php"><i class="fas fa-list-ol"></i> Playlists</a>
 
-<? if (($settings['fppMode'] == 'player') || ($uiLevel >= 1)) { ?>
-          <a class="dropdown-item" href="scheduler.php"><i class="fas fa-clock"></i> Scheduler</a>
-<? } ?>
-          <a class="dropdown-item" href="scriptbrowser.php"><i class="fas fa-scroll"></i> Script Repository Browser</a>
-          <a class="dropdown-item" href="plugins.php"><i class="fas fa-puzzle-piece"></i> Plugin Manager</a>
-          <?php list_plugin_entries("content"); ?>
-        </div>
-      </li>
+              <? if (($settings['fppMode'] == 'player') || ($uiLevel >= 1)) { ?>
+                <a class="dropdown-item" href="scheduler.php"><i class="fas fa-clock"></i> Scheduler</a>
+              <? } ?>
+              <a class="dropdown-item" href="scriptbrowser.php"><i class="fas fa-scroll"></i> Script Repository
+                Browser</a>
+              <a class="dropdown-item" href="plugins.php"><i class="fas fa-puzzle-piece"></i> Plugin Manager</a>
+              <?php list_plugin_entries("content"); ?>
+            </div>
+          </li>
 
-      <li class="nav-item dropdown <? echo $activeParentMenuItem=='input-output' ? 'active' :''; ?>">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkInOut" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Input/Output Setup
-        </a>
-        <div class="dropdown-menu dropdown-with-icons" aria-labelledby="navbarDropdownMenuLinkInOut">
-          <a class="dropdown-item" href="channelinputs.php"><i class="fas fa-project-diagram" style="color:red;"></i> Channel Inputs</a>
-          <a class="dropdown-item" href="channeloutputs.php"><i class="fas fa-project-diagram" style="color:green;"></i> Channel Outputs</a>
-          <a class="dropdown-item" href="outputprocessors.php"><i class="fas fa-microchip"></i> Output Processors</a>
-          <a class="dropdown-item" href="pixeloverlaymodels.php"><i class="fas fa-cubes"></i> Pixel Overlay Models</a>
-          <a class="dropdown-item" href="gpio.php"><i class="fas fa-exchange-alt"></i> GPIO Inputs</a>
-          <?php list_plugin_entries("output"); ?>
-        </div>
-      </li>
+          <li class="nav-item dropdown <? echo $activeParentMenuItem == 'input-output' ? 'active' : ''; ?>">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkInOut" role="button"
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Input/Output Setup
+            </a>
+            <div class="dropdown-menu dropdown-with-icons" aria-labelledby="navbarDropdownMenuLinkInOut">
+              <a class="dropdown-item" href="channelinputs.php"><i class="fas fa-project-diagram"
+                  style="color:red;"></i> Channel Inputs</a>
+              <a class="dropdown-item" href="channeloutputs.php"><i class="fas fa-project-diagram"
+                  style="color:green;"></i> Channel Outputs</a>
+              <a class="dropdown-item" href="outputprocessors.php"><i class="fas fa-microchip"></i> Output
+                Processors</a>
+              <a class="dropdown-item" href="pixeloverlaymodels.php"><i class="fas fa-cubes"></i> Pixel Overlay
+                Models</a>
+              <a class="dropdown-item" href="gpio.php"><i class="fas fa-exchange-alt"></i> GPIO Inputs</a>
+              <?php list_plugin_entries("output"); ?>
+            </div>
+          </li>
 
-      <li class="nav-item dropdown <? echo $activeParentMenuItem=='help' ? 'active' :''; ?>">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkHelp" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Help
-        </a>
-        <div class="dropdown-menu dropdown-with-icons dropdown-menu-end" aria-labelledby="navbarDropdownMenuLinkHelp">
-          <a class="dropdown-item" href="about.php"><i class="fas fa-info-circle"></i> About</a>
-<?php
-$eepromFile = "/home/fpp/media/tmp/eeprom.bin";
-if (!file_exists($eepromFile) && file_exists("/home/fpp/media/config/cape-eeprom.bin")) {
-    $eepromFile = "/home/fpp/media/config/cape-eeprom.bin";
-}
+          <li class="nav-item dropdown <? echo $activeParentMenuItem == 'help' ? 'active' : ''; ?>">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkHelp" role="button"
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Help
+            </a>
+            <div class="dropdown-menu dropdown-with-icons dropdown-menu-end"
+              aria-labelledby="navbarDropdownMenuLinkHelp">
+              <a class="dropdown-item" href="about.php"><i class="fas fa-info-circle"></i> About</a>
+              <?php
+              $eepromFile = "/home/fpp/media/tmp/eeprom.bin";
+              if (!file_exists($eepromFile) && file_exists("/home/fpp/media/config/cape-eeprom.bin")) {
+                $eepromFile = "/home/fpp/media/config/cape-eeprom.bin";
+              }
 
-if (file_exists($eepromFile)) {
-    echo "<a class='dropdown-item' href='cape-info.php'><i class='fas fa-microchip'></i> Cape Info</a>\n";
-}
-$externalLinkClass = "dropdown-item";
-if ($settings["hideExternalURLs"]) {
-    $externalLinkClass = "hiddenExternalLink";
-}
-?>
-          <a class="<?= $externalLinkClass ?> link-to-fpp-manual" href="https://added-by-javascript.net" target="_blank"><i class="fas fa-book"></i> FPP Manual <i class="fas fa-external-link-alt external-link"></i></a>
-          <a class="<?= $externalLinkClass ?>" href="https://falconchristmas.com/forum" target="_blank"><i class="fas fa-comments"></i> Forums <i class="fas fa-external-link-alt external-link"></i></a>
-          <!--
+              if (file_exists($eepromFile)) {
+                echo "<a class='dropdown-item' href='cape-info.php'><i class='fas fa-microchip'></i> Cape Info</a>\n";
+              }
+              $externalLinkClass = "dropdown-item";
+              if ($settings["hideExternalURLs"]) {
+                $externalLinkClass = "hiddenExternalLink";
+              }
+              ?>
+              <a class="<?= $externalLinkClass ?> link-to-fpp-manual" href="https://added-by-javascript.net"
+                target="_blank"><i class="fas fa-book"></i> FPP Manual <i
+                  class="fas fa-external-link-alt external-link"></i></a>
+              <a class="<?= $externalLinkClass ?>" href="https://falconchristmas.com/forum" target="_blank"><i
+                  class="fas fa-comments"></i> Forums <i class="fas fa-external-link-alt external-link"></i></a>
+              <!--
           <a class="<?= $externalLinkClass ?>" href="http://falconchristmas.com/wiki/index.php/Falcon_FPP" target="_blank"><i class="fas fa-external-link-square-alt"></i> Wiki/Help <i class="fas fa-external-link-alt external-link"></i></a>
           -->
-          <a class="dropdown-item" href="help.php"><i class="fas fa-question-circle"></i> Help Index</a>
-          <a class="dropdown-item" href="apihelp.php"><i class="fas fa-plug"></i> REST API Help</a>
-          <a class="dropdown-item" href="commandhelp.php"><i class="fas fa-cubes"></i> FPP Commands Help</a>
-          <a class="dropdown-item" href="cliHelp.php"><i class="fas fa-life-ring"></i> fpp &amp; fppmm Usage</a>
-          <a class="dropdown-item" href="credits.php"><i class="fas fa-stream"></i> Credits</a>
-          <a class="<?= $externalLinkClass ?>" href="https://www.paypal.com/donate/?hosted_button_id=ASF9XYZ2V2F5G" target='_blank'><i class="fas fa-solid fa-gift"></i> Donate to FPP <i class="fas fa-external-link-alt external-link"></i></a>
-          <hr class="dropdown-divider">
-          <a class="dropdown-item" href="healthCheck.php"><i class="fas fa-thermometer-half"></i> System Health Check</a>
-          <a class="dropdown-item" href="troubleshooting.php"><i class="fas fa-code"></i> Troubleshooting Commands</a>
-          <?
-          $baseLink = $_SERVER['HTTP_HOST'];
-          if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-            $baseLink = $_SERVER['HTTP_X_FORWARDED_HOST'] . '/proxy/' . $_SERVER['SERVER_ADDR'];
-          }
-          ?>
-          <a class="<?= $externalLinkClass ?>" href="http://<?=$baseLink?>:4200" target="_blank"><i class="fas fa-terminal"></i> SSH Shell</a>
-          <?php list_plugin_entries("help"); ?>
-        </div>
-      </li>
-    </ul>
-    </div>
-</nav>
+              <a class="dropdown-item" href="help.php"><i class="fas fa-question-circle"></i> Help Index</a>
+              <a class="dropdown-item" href="apihelp.php"><i class="fas fa-plug"></i> REST API Help</a>
+              <a class="dropdown-item" href="commandhelp.php"><i class="fas fa-cubes"></i> FPP Commands Help</a>
+              <a class="dropdown-item" href="cliHelp.php"><i class="fas fa-life-ring"></i> fpp &amp; fppmm Usage</a>
+              <a class="dropdown-item" href="credits.php"><i class="fas fa-stream"></i> Credits</a>
+              <a class="<?= $externalLinkClass ?>" href="https://www.paypal.com/donate/?hosted_button_id=ASF9XYZ2V2F5G"
+                target='_blank'><i class="fas fa-solid fa-gift"></i> Donate to FPP <i
+                  class="fas fa-external-link-alt external-link"></i></a>
+              <hr class="dropdown-divider">
+              <a class="dropdown-item" href="healthCheck.php"><i class="fas fa-thermometer-half"></i> System Health
+                Check</a>
+              <a class="dropdown-item" href="troubleshooting.php"><i class="fas fa-code"></i> Troubleshooting
+                Commands</a>
+              <?
+              $baseLink = $_SERVER['HTTP_HOST'];
+              if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+                $baseLink = $_SERVER['HTTP_X_FORWARDED_HOST'] . '/proxy/' . $_SERVER['SERVER_ADDR'];
+              }
+              ?>
+              <a class="<?= $externalLinkClass ?>" href="http://<?= $baseLink ?>:4200" target="_blank"><i
+                  class="fas fa-terminal"></i> SSH Shell</a>
+              <?php list_plugin_entries("help"); ?>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </nav>
 
 
-</div>
+  </div>

--- a/www/menu.inc
+++ b/www/menu.inc
@@ -109,17 +109,22 @@ function list_plugin_entries($menu)
     if ($settings['LogoLink'] != "")
       echo "</a>";
     if (
-      isset($settings['cape-info']) && isset($settings['cape-info']['vendor']) && isset($settings['cape-info']['vendor']['image'])
+      isset($settings['cape-info']) && isset($settings['cape-info']['vendor']) && (isset($settings['cape-info']['vendor']['image']) || isset($settings['cape-info']['header_cape_image']))
       && $settings['FetchVendorLogos'] == 1
     ) {
       $landing = $settings['cape-info']['vendor']['url'];
       if (isset($settings['cape-info']['vendor']['landingPage'])) {
         $landing = $settings['cape-info']['vendor']['landingPage'];
       }
+
+      isset($settings['cape-info']['header_cape_image']) ?
+        $image_url = $settings['cape-info']['header_cape_image'] :
+        $image_url = $settings['cape-info']['vendor']['image'];
+
       if ($settings['SendVendorSerial'] == 1) {
-        $iurl = $settings['cape-info']['vendor']['image'] . "?sn=" . $settings['cape-info']['serialNumber'] . "&id=" . $settings['cape-info']['id'];
+        $iurl = $image_url . "?sn=" . $settings['cape-info']['serialNumber'] . "&id=" . $settings['cape-info']['id'];
       } else {
-        $iurl = $settings['cape-info']['vendor']['image'];
+        $iurl = $image_url;
       }
 
       if ($settings['SendVendorSerial'] == 1) {
@@ -212,7 +217,7 @@ function list_plugin_entries($menu)
     <? if (!file_exists(__DIR__ . "/../src/fppd")) { ?>
       <div id='rebuildPopup' title='FPP Upgrade' style="display: none">
         <textarea style='width: 99%; height: 97%;' disabled id='rebuildText'>
-      </textarea>
+                  </textarea>
       </div>
       <script>
         function RebuildFPPDDone() {


### PR DESCRIPTION
This PR adds the ability to define a separate logo in the cape eeprom for the header image, this seperates it from the vendor image displayed on the cape-info.php page.

It is backwards compatible and if the new:
$settings['cape-info']['header_cape_image'] 
hasn't been set it defers back to using the 
$settings['cape-info']['vendor']['image'] as it used previously

This makes it easier to have transparent logo's which work well in the header with dark backgrounds and
seperate vendor logos on the white background - also makes image sizing for placeholders easier to stop distortion