### PR TITLE
networkconfig.php : escape HTML special chars in scanned SSIDs

### DIFF
--- a/www/networkconfig.php
+++ b/www/networkconfig.php
@@ -177,6 +177,16 @@
             return self.indexOf(value) === index;
         }
 
+        function escapeHtml(unsafe)
+        {
+            return unsafe
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
+        }
+
         function LoadSIDS(interface) {
             $("#wifisearch").show();
             $.get("api/network/wifi/scan/" + interface,
@@ -194,9 +204,11 @@
                 ssids.sort();
                 html = [];
                 ssids.forEach(function (n) {
-                    html.push("<option value='");
-                    html.push(n);
-                    html.push("'>");
+                    if(typeof(n) != "undefined") {
+                        html.push("<option value='");
+                        html.push(escapeHtml(n));
+                        html.push("'>");
+                    }
                 });
                 $("#eth_ssids").html(html.join(''));
             }).fail(function () {


### PR DESCRIPTION
Scanned SSIDs with special characters (e.g. "_It's not me it's you_") would break the drop-down HTML. 

Patched using `.replace()` => should work with all browsers (as opposed to `.replaceAll()` which is only supported by recent browsers)

The patch also filters out `undefined` networks which would create an empty <option> entry at the end of the dropdown