### PR TITLE
Allow proxying of websocket connections

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -294,6 +294,10 @@ SetupFPPNetworkConfigViaSystemdNetworkd() {
                 echo "RewriteEngine on" >> ${FPPHOME}/media/config/proxies
                 echo "RewriteBase /proxy/" >> ${FPPHOME}/media/config/proxies
                 echo "" >> ${FPPHOME}/media/config/proxies
+                echo 'RewriteCond %{HTTP:Upgrade}     "websocket" [NC]' >> ${FPPHOME}/media/config/proxies
+                echo 'RewriteCond %{HTTP:Connection}  "Upgrade" [NC]' >> ${FPPHOME}/media/config/proxies
+                echo 'RewriteRule ^(.*)/(.*)$ "ws://$1/$2" [P]'  >> ${FPPHOME}/media/config/proxies
+                echo "" >> ${FPPHOME}/media/config/proxies
                 echo 'RewriteRule ^(.*)/(.*)$  http://$1/$2  [P,L]' >> ${FPPHOME}/media/config/proxies
                 echo 'RewriteRule ^(.*)$  $1/  [R,L]' >> ${FPPHOME}/media/config/proxies
             fi

--- a/src/boot/FPPINIT.cpp
+++ b/src/boot/FPPINIT.cpp
@@ -605,7 +605,7 @@ static void setupNetwork() {
                 if (!FileExists(FPP_MEDIA_DIR + "/config/proxies")) {
                     // DHCPServer is on, lets make sure proxies are enabled
                     // so they can be found via the proxies page
-                    std::string c2 = "RewriteEngine on\nRewriteBase /proxy/\n\nRewriteRule ^(.*)/(.*)$  http://$1/$2  [P,L]\nRewriteRule ^(.*)$  $1/  [R,L]\n";
+                    std::string c2 = "RewriteEngine on\nRewriteBase /proxy/\n\nRewriteCond %{HTTP:Upgrade}     \"websocket\" [NC]\nRewriteCond %{HTTP:Connection}  \"Upgrade\" [NC]\nRewriteRule ^(.*)/(.*)$ \"ws://$1/$2\" [P]\n\nRewriteRule ^(.*)/(.*)$  http://$1/$2  [P,L]\nRewriteRule ^(.*)$  $1/  [R,L]\n";
                     PutFileContents(FPP_MEDIA_DIR + "/config/proxies", c2);
                 }
             }

--- a/www/api/controllers/proxies.php
+++ b/www/api/controllers/proxies.php
@@ -46,6 +46,12 @@ function WriteProxyFile($proxies)
     $mediaDirectory = $settings['mediaDirectory'];
 
     $newht = "RewriteEngine on\nRewriteBase /proxy/\n\n";
+
+    $newht = $newht . "RewriteCond %{HTTP:Upgrade}     \"websocket\" [NC]\n";
+    $newht = $newht . "RewriteCond %{HTTP:Connection}  \"Upgrade\" [NC]\n";
+    $newht = $newht . "RewriteRule ^(.*)/(.*)$ \"ws://$1/$2\" [P]\n";
+    $newht = $newht . "\n";
+
     foreach ($proxies as $item) {
         $host = $item['host'];
         $description = $item['description'];


### PR DESCRIPTION
Some controllers use WebSockets on their web interfaces, and it would be lovely if they made it through the FPP proxy.

This is the config amendment to allow that to happen.

Only one issue - if this is upgraded to (as opposed to fresh-installed), the media/config/proxies file won't be amended until someone changes something in proxies.php (I think?). Is there an easy way to get this file regenerated at update time? 

Thanks