### PR TITLE
update fpp.js/validateIPaddress() to fail on leading zeroes

### DIFF
--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -4117,7 +4117,7 @@ function validateIPaddress (id, allowHostnames = false) {
 	var ip = ipb.value;
 
 	var isIpRegex =
-		/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+		/^(?:(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$/;
 	// hostnames must begin with a letter, contain only letters/numbers/hyphens, and end with a letter
 	// or number
 	var isHostnameRegex =
@@ -4575,18 +4575,19 @@ function updateWarnings (jsonStatus) {
 				}
 			});
 		}
-        var txt = '<b>Abnormal Conditions - May cause poor performance or other issues';
-        var hasID = false;
-        for (var i = 0; i < currentWarnings.length; i++) {
+		var txt =
+			'<b>Abnormal Conditions - May cause poor performance or other issues';
+		var hasID = false;
+		for (var i = 0; i < currentWarnings.length; i++) {
 			var warningID = currentWarnings[i]['id'];
-            if (warningID != 0) {
-                hasID = true;
-            }
-        }
-        if (hasID) {
-            txt += ' (Click link icon for help)';
-        }
-        txt += '</b><br/><ul style="list-style-type: none;">';
+			if (warningID != 0) {
+				hasID = true;
+			}
+		}
+		if (hasID) {
+			txt += ' (Click link icon for help)';
+		}
+		txt += '</b><br/><ul style="list-style-type: none;">';
 
 		for (var i = 0; i < currentWarnings.length; i++) {
 			var warningID = currentWarnings[i]['id'];


### PR DESCRIPTION
Had an issue today (in the Zoom Room) with a user putting in a leading zero to the IP address field because the OLED was showing leading zeroes.

```javascript
validateIPaddress("192.168.1.1"); // true
validateIPaddress("10.0.0.0");   // true
validateIPaddress("01.02.03.04"); // false (leading zeros)
validateIPaddress("256.1.1.1");  // false (out of range)
```

<img width="528" alt="image" src="https://github.com/user-attachments/assets/35cc0fe7-d0f9-4e04-ba36-2a50dd0eb43c">
<img width="506" alt="image" src="https://github.com/user-attachments/assets/26f35e2b-524a-4f95-b71f-ad79b5ebf96d">
<img width="519" alt="image" src="https://github.com/user-attachments/assets/fd816e16-1d13-456e-8fb4-3df84956da7e">
