### PR TITLE
Experimental Feature to force audioDeviceName in SDLOut.cpp

### DIFF
--- a/src/mediaoutput/SDLOut.cpp
+++ b/src/mediaoutput/SDLOut.cpp
@@ -736,37 +736,43 @@ bool SDL::openAudio() {
         }
 
         std::string audioDeviceName;
+        std::string forceAudioId = getSetting("ForceAudioId");
+        
+        if (!forceAudioId.empty()) {
+            audioDeviceName = forceAudioId.c_str();                                                                                                                                                                                    
+        } else {
 #ifdef PLATFORM_OSX
-        std::string dev = getSetting("AudioOutput", "--System Default--");
-        if (dev != "--System Default--") {
-            int cnt = SDL_GetNumAudioDevices(0);
-            for (int x = 0; x < cnt; x++) {
-                std::string dn = SDL_GetAudioDeviceName(x, 0);
-                if (endsWith(dn, dev)) {
-                    audioDeviceName = SDL_GetAudioDeviceName(x, 0);
-                }
-            }
-        }
+            std::string dev = getSetting("AudioOutput", "--System Default--");
+            if (dev != "--System Default--") {
+                int cnt = SDL_GetNumAudioDevices(0);
+                for (int x = 0; x < cnt; x++) {
+                    std::string dn = SDL_GetAudioDeviceName(x, 0);                                                                                                                                                                     
+                    if (endsWith(dn, dev)) {
+                        audioDeviceName = SDL_GetAudioDeviceName(x, 0);                                                                                                                                                                
+                    }                                                                                                                                                                                                                  
+                }                                                                                                                                                                                                                      
+            }                                                                                                                                                                                                                          
 #else
-        std::string fn = "/sys/class/sound/card" + getSetting("AudioOutput", "0") + "/id";
-        std::string dev = "";
-        if (FileExists(fn)) {
-            dev = GetFileContents(fn);
-            TrimWhiteSpace(dev);
-            if (dev[dev.size() - 1] == '\n' || dev[dev.size() - 1] == '\r') {
-                dev = dev.substr(0, dev.size() - 2);
-            }
-        }
-        if (dev != "") {
-            int cnt = SDL_GetNumAudioDevices(0);
-            for (int x = 0; x < cnt; x++) {
-                std::string dn = SDL_GetAudioDeviceName(x, 0);
-                if (startsWith(dn, dev)) {
-                    audioDeviceName = dn;
-                }
-            }
-        }
+            std::string fn = "/sys/class/sound/card" + getSetting("AudioOutput", "0") + "/id";
+            std::string dev = "";
+            if (FileExists(fn)) {
+                dev = GetFileContents(fn);                                                                                                                                                                                             
+                TrimWhiteSpace(dev);                                                                                                                                                                                                   
+                if (dev[dev.size() - 1] == '\n' || dev[dev.size() - 1] == '\r') {
+                    dev = dev.substr(0, dev.size() - 2);                                                                                                                                                                               
+                }                                                                                                                                                                                                                      
+            }                                                                                                                                                                                                                          
+            if (dev != "") {
+                int cnt = SDL_GetNumAudioDevices(0);
+                for (int x = 0; x < cnt; x++) {
+                    std::string dn = SDL_GetAudioDeviceName(x, 0);                                                                                                                                                                     
+                    if (startsWith(dn, dev)) {
+                        audioDeviceName = dn;                                                                                                                                                                                          
+                    }                                                                                                                                                                                                                  
+                }                                                                                                                                                                                                                      
+            }                                                                                                                                                                                                                          
 #endif
+        }         
         LogDebug(VB_MEDIAOUT, "Using output device: %s\n", audioDeviceName.c_str());
         int clayout = getSettingInt("AudioLayout");
         _wanted_spec.channels = ChannelsForLayout(clayout);

--- a/www/settings.json
+++ b/www/settings.json
@@ -76,6 +76,7 @@
 				"VideoOutput",
 				"HardwareDecoding",
 				"VLCOptions",
+				"ForceAudioId",
 				"mediaOffset",
 				"remoteIgnoreSync",
 				"disableIPAnnouncement",
@@ -2361,6 +2362,17 @@
 				"!MacOS"
 			]
 		},
+		"ForceAudioId": {
+                        "name": "ForceAudioId",
+                        "description": "Force Audio Card ID",
+                        "type": "text",
+                        "gatherStats": true,
+                        "tip": "The audio card id is usualy set by the id file in the audio card folder. However, sometimes this id can be wrong. This lets you set it manually. This could help with the error Could not open audio device - ALSA: Couldnt open audio device: Invalid argument",
+                        "size": 64,
+                        "maxlength": 256,
+                        "level": 1,
+                        "restart": 2
+                },
 		"TimeZone": {
 			"name": "TimeZone",
 			"description": "Time Zone",

--- a/www/settings.json
+++ b/www/settings.json
@@ -2370,7 +2370,7 @@
                         "tip": "The audio card id is usualy set by the id file in the audio card folder. However, sometimes this id can be wrong. This lets you set it manually. This could help with the error Could not open audio device - ALSA: Couldnt open audio device: Invalid argument",
                         "size": 64,
                         "maxlength": 256,
-                        "level": 1,
+                        "level": 2,
                         "restart": 2
                 },
 		"TimeZone": {


### PR DESCRIPTION
This adds an experimental field to the AV settings page to manually set the Audio Card Id.

We were having an issue where the installed drivers for our audio card had the wrong id in the card folder.
We manually set the audioDeviceName in the SDLOut.cpp file and it worked, so I added it as an option in the settings page.