### PR TITLE
Some additional Warnings refactor

### DIFF
--- a/src/Warnings.h
+++ b/src/Warnings.h
@@ -11,12 +11,10 @@
  * included LICENSE.LGPL file.
  */
 
+#include <chrono>
 #include <list>
 #include <map>
-#include <mutex>
-#include <set>
-#include <shared_mutex>
-#include <thread>
+#include <string>
 
 #if __has_include(<jsoncpp/json/json.h>)
 #include <jsoncpp/json/json.h>
@@ -34,7 +32,7 @@ public:
     std::string plugin() const;
     int id() const;
 
-    int timeout;
+    std::chrono::steady_clock::time_point timeout;
 };
 
 class WarningListener {
@@ -64,14 +62,5 @@ public:
     static void ClearWarningsFile();
 
 private:
-    static std::shared_mutex warningsLock;
-    static std::list<FPPWarning> warnings;
-    static uint64_t timeToRemove;
-
-    static std::set<WarningListener*> listenerList;
-    static std::mutex listenerListLock;
-
-    static void NotifyListenersMain(); // main for notify thread
-    static void writeWarningsFile(const std::list<FPPWarning>& warnings);
-    static void UpdateWarningsAndNotify(bool notify);
+    static void WarningsThreadMain(); // main for notify thread
 };


### PR DESCRIPTION
Some additional stuff relevant to my previous work on #2026 

Notably:
* Moved things that don't need public visibility out of Warnings.h and into the compilation unit
* The main thread no longer needs to prune warnings in `GetWarnings()`; this happens asynchronously in the FPP-Warnings thread
* The FPP-Warnings thread now sleeps until the next timeout period when it wakes up to prune expired warnings, but can still be notified if a new warning comes in.
* Net negative lines of code is always good 😉