### PR TITLE
Fix file copy from SD card

### DIFF
--- a/src/boot/FPPINIT.cpp
+++ b/src/boot/FPPINIT.cpp
@@ -161,6 +161,7 @@ static void handleBootPartition() {
     if (DirectoryExists(bootDir + "/fpp")) {
         if (!FileExists(bootDir + "/fpp/copy_done")) {
             std::string cmd = "/usr/bin/cp -a " + bootDir + "/fpp/* " + FPP_MEDIA_DIR;
+            exec(cmd);
             PutFileContents(bootDir + "/fpp/copy_done", "1");
         }
     }


### PR DESCRIPTION
The new C++-based fppinit for FPP 8.x builds the correct command to copy config files and scripts from the SD card but missed `exec`ing it. This PR simply adds the missing `exec`.