### PR TITLE
JS Settings framework and filemanager fixes

### DIFF
--- a/etc/apache2.site
+++ b/etc/apache2.site
@@ -194,7 +194,7 @@ AddDefaultCharset utf-8
 <IfModule mod_headers.c>
     Header always set X-Content-Type-Options "nosniff"
 	header always set X-XSS-Protection "1; mode=block"
-	Header always set Content-Security-Policy "img-src 'self' data: blob:"
+	Header always set Content-Security-Policy "img-src 'self' https://www.paypal.com https://www.paypalobjects.com data: blob:"
 	Header unset Expires
     Header unset Host
     Header unset P3P

--- a/www/filemanager.php
+++ b/www/filemanager.php
@@ -194,7 +194,7 @@
                         <div class="tab-pane fade show active" id="tab-sequence" role="tabpanel"
                             aria-labelledby="tab-sequence-tab">
 
-                            <div id="divSeq">
+                            <div id="divSequences">
                                 <div class="backdrop">
                                     <div class="row justify-content-between fileDetailsHeader">
                                         <div class="col-auto">
@@ -318,7 +318,7 @@
                         </div>
 
                         <div class="tab-pane fade" id="tab-video" role="tabpanel" aria-labelledby="tab-video-tab">
-                            <div id="divVideo">
+                            <div id="divVideos">
 
                                 <div class="backdrop">
                                     <div class="row justify-content-between fileDetailsHeader">

--- a/www/js/fpp-filemanager.js
+++ b/www/js/fpp-filemanager.js
@@ -149,7 +149,7 @@ function UpdateFileCount ($dir) {
 		.not('.filtered').length;
 	if ($('#tbl' + $dir + ' tbody tr.filtered').length > 0) {
 		//is filtered
-		$('#div' + $dir + ' .fileCountlabelHeading')[0].innerHTML = innerHtml =
+		$('#div' + $dir + ' .fileCountlabelHeading')[0].innerHTML =
 			'<span class="filtered">Filtered items:<span>';
 		$('#fileCount_' + $dir)
 			.removeClass('text-bg-secondary')

--- a/www/settings.json
+++ b/www/settings.json
@@ -926,7 +926,10 @@
 			"default": "0",
 			"type": "checkbox",
 			"checkedValue": "1",
-			"uncheckedValue": "0"
+			"uncheckedValue": "0",
+			"exposedAsJSToPages": [
+				"all"
+			]
 		},
 		"DisableScheduler": {
 			"name": "DisableScheduler",
@@ -935,7 +938,10 @@
 			"tip": "The Disable Scheduler setting allows disabling all scheduling rather than having to go to each schedule entry and deactivate.",
 			"type": "checkbox",
 			"level": 1,
-			"restart": 1
+			"restart": 1,
+			"exposedAsJSToPages": [
+				"all"
+			]
 		},
 		"E131BridgingInterval": {
 			"name": "E131BridgingInterval",
@@ -1056,7 +1062,10 @@
 				"150 pixels": 150,
 				"175 pixels": 175,
 				"200 pixels": 200
-			}
+			},
+			"exposedAsJSToPages": [
+				"filemanager"
+			]
 		},
 		"fileManagerTableFilter": {
 			"name": "fileManagerTableFilter",
@@ -1065,7 +1074,10 @@
 			"default": "1",
 			"type": "checkbox",
 			"checkedValue": "1",
-			"uncheckedValue": "0"
+			"uncheckedValue": "0",
+			"exposedAsJSToPages": [
+				"filemanager"
+			]
 		},
 		"FPP_UUID": {
 			"name": "FPP_UUID",
@@ -1088,7 +1100,10 @@
 			"options": {
 				"Player": "player",
 				"Remote": "remote"
-			}
+			},
+			"exposedAsJSToPages": [
+				"all"
+			]
 		},
 		"FPDEnabled": {
 			"name": "FPDEnabled",
@@ -1298,7 +1313,10 @@
 			"restart": 2,
 			"default": "Global",
 			"type": "select",
-			"optionsURL": "api/settings/Locale/options"
+			"optionsURL": "api/settings/Locale/options",
+			"exposedAsJSToPages": [
+				"all"
+			]
 		},
 		"LogLevel_General": {
 			"name": "LogLevel_General",
@@ -1985,7 +2003,10 @@
 			"gatherStats": true,
 			"restart": 0,
 			"default": 0,
-			"type": "checkbox"
+			"type": "checkbox",
+			"exposedAsJSToPages": [
+				"index"
+			]
 		},
 		"piRTC": {
 			"name": "piRTC",
@@ -2048,7 +2069,10 @@
 			"tip": "Allow scheduling down to the second instead of scheduling on minute boundaries.  Enabling this setting will show the seconds value in the Scheduler UI for the Start and End times on schedule entries.",
 			"type": "checkbox",
 			"level": 1,
-			"restart": 1
+			"restart": 1,
+			"exposedAsJSToPages": [
+				"scheduler"
+			]
 		},
 		"screensaver": {
 			"name": "screensaver",
@@ -2230,7 +2254,10 @@
 				"Enabled": "Enabled",
 				"Disabled": "Disabled",
 				"Banner": "Banner"
-			}
+			},
+			"exposedAsJSToPages": [
+				"all"
+			]
 		},
 		"tableColorPair1A": {
 			"name": "tableColorPair1A",
@@ -2314,7 +2341,10 @@
 			"options": {
 				"Celsius": 0,
 				"Fahrenheit": 1
-			}
+			},
+			"exposedAsJSToPages": [
+				"all"
+			]
 		},
 		"TetherInterface": {
 			"name": "TetherInterface",
@@ -2356,7 +2386,10 @@
 				"HH:MM (23:40)": "%H:%M",
 				"HH:MM AM/PM (11:40 PM)": "%I:%M %p"
 			},
-			"note": "Any addition of a new format in the options array here will need corresponding additions in js/fpp.js to the Convert24H*UIFormat functions"
+			"note": "Any addition of a new format in the options array here will need corresponding additions in js/fpp.js to the Convert24H*UIFormat functions",
+			"exposedAsJSToPages": [
+				"all"
+			]
 		},
 		"uiLevel": {
 			"name": "uiLevel",


### PR DESCRIPTION
In response to #2089 this PR brings in the framework to hide elements of the JS settings array to only display relevent ones per page.

The www/settings.json now has an optional attribute to define what pages the setting should appear on.

There are multiple settings which aren't currently defined in the settings.json so they have been auto included with a comment to reference the fact the setting json needs updating

This is the first step in the process.... next step will be to build out the settings.json