### PR TITLE
Apache CSP mechanism to allow plugins to control trusted domains 

### DIFF
--- a/docs/ApacheContentSecurityPolicy.md
+++ b/docs/ApacheContentSecurityPolicy.md
@@ -13,6 +13,9 @@ For pluggins to be able to trust particular domains they need to add them to the
 in the pluggins fpp_install.sh file:
 
 ```
+# Include common scripts functions and variables
+. ${FPPDIR}/scripts/common
+
 # Add required Apache CSP (Content-Security-Policy allowed domains
 ${FPPDIR}/scripts/ManageApacheContentPolicy.sh add connect-src https://domaintotrust.co.uk
 ${FPPDIR}/scripts/ManageApacheContentPolicy.sh add img-src https://anotherdomain.com

--- a/docs/ApacheContentSecurityPolicy.md
+++ b/docs/ApacheContentSecurityPolicy.md
@@ -1,0 +1,33 @@
+# Apache CSP (Content Security Policy)
+
+In order to help reduce security threats fpp has CSP enabled for Apache2
+
+This allows us to define which domains are trusted to pull in content of various types - images, scripts etc..
+
+When developing the core fpp application the mechanism to define default trusted sites is to add them to the script which controls the CSP creation in:
+
+`/opt/fpp/scripts/ManageApacheContentPolicy.sh`
+
+For pluggins to be able to trust particular domains they need to add them to the local configuration on installation by calling this script with arguments, here's an example:
+
+in the pluggins fpp_install.sh file:
+
+```
+# Add required Apache CSP (Content-Security-Policy allowed domains
+${FPPDIR}/scripts/ManageApacheContentPolicy.sh add connect-src https://domaintotrust.co.uk
+${FPPDIR}/scripts/ManageApacheContentPolicy.sh add img-src https://anotherdomain.com
+
+# Need to force reboot for CSP change to take affect
+setSetting rebootFlag 1
+```
+
+Possible Keys are: 'default-src', 'connect-src', 'img-src', 'script-src', 'style-src', 'object-src'
+
+## Key Definitions:
+
+1. default-src - catchall which would completely trust a domain
+2. connect-src - defines domains which are allowed to provide xhr data
+3. img-src - defines domains which are allowed to provide images
+4. script-src - defines domains which are allowed to provide script content
+5. style-src - defines domains which are allowed to provide style content
+6. object-src - defines domains which are allowed to provide object content

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,6 @@
 - [FSEQ_Sequence_File_Format.txt](./FSEQ_Sequence_File_Format.txt) - Describes the format of the `.fseq` file format.
 - [MQTT.md](./MQTT.md) - Describes the topics supported by FPP for communicating via MQTT.
 - [DeveloperNotes.md](./DeveloperNotes.md) - Various developer topics including Valgrind, CCache, etc...
-- [WarningHandling.md](.WarningHandling.md) - Describes the warning framework and the steps required to define, set and display warning
+- [WarningHandling.md](./WarningHandling.md) - Describes the warning framework and the steps required to define, set and display warning
+- [ApacheContentSecurityPolicy.md](./ApacheContentSecurityPolicy.md) - Describes the Apache2 CSP mechanism for trusting domains
 

--- a/etc/apache2.csp
+++ b/etc/apache2.csp
@@ -1,3 +1,3 @@
 <IfModule mod_headers.c>
-    Header set Content-Security-Policy "default-src 'self' http://www.w3.org ; script-src 'self' 'unsafe-inline' https://raw.githubusercontent.com/FalconChristmas/fpp-data https://raw.githubusercontent.co; style-src 'self' 'unsafe-inline' ; object-src 'none' ; connect-src 'self' https://raw.githubusercontent.com ; img-src 'self' http://www.w3.org https://www.paypal.com https://www.paypalobjects.com https://a.espncdn.com"
+    Header set Content-Security-Policy "default-src 'self' http://www.w3.org ; script-src 'self' 'unsafe-inline' https://api.falconplayer.com ; style-src 'self' 'unsafe-inline' ; object-src 'none'  ; connect-src 'self' https://raw.githubusercontent.com https://kulplights.com https://www.hansonelectronics.com.au https://www.wiredwatts.com; img-src 'self' blob: http://www.w3.org https://www.paypal.com https://www.paypalobjects.com https://a.espncdn.com"
 </IfModule>

--- a/etc/apache2.csp
+++ b/etc/apache2.csp
@@ -1,0 +1,3 @@
+<IfModule mod_headers.c>
+    Header set Content-Security-Policy "default-src 'self' http://www.w3.org ; script-src 'self' 'unsafe-inline' https://raw.githubusercontent.com/FalconChristmas/fpp-data https://raw.githubusercontent.co; style-src 'self' 'unsafe-inline' ; object-src 'none' ; connect-src 'self' https://raw.githubusercontent.com ; img-src 'self' http://www.w3.org https://www.paypal.com https://www.paypalobjects.com https://a.espncdn.com"
+</IfModule>

--- a/etc/apache2.site
+++ b/etc/apache2.site
@@ -191,10 +191,15 @@ AddDefaultCharset utf-8
                      .xml
 </IfModule>
 
+  # Pull in the Apache2 ContentPolicy
+  Include /opt/fpp/etc/apache2.csp
+
 <IfModule mod_headers.c>
-    Header always set X-Content-Type-Options "nosniff"
+  # Set other security settings
+
+  Header always set X-Content-Type-Options "nosniff"
 	header always set X-XSS-Protection "1; mode=block"
-	Header always set Content-Security-Policy "img-src 'self' https://www.paypal.com https://www.paypalobjects.com data: blob:"
+	
 	Header unset Expires
     Header unset Host
     Header unset P3P

--- a/etc/csp_allowed_domains.json
+++ b/etc/csp_allowed_domains.json
@@ -1,0 +1,13 @@
+{
+  "default-src": [],
+  "img-src": [
+    "https://a.espncdn.com"
+  ],
+  "script-src": [
+    "https://raw.githubusercontent.com/FalconChristmas/fpp-data",
+    "https://raw.githubusercontent.co"
+  ],
+  "style-src": [],
+  "connect-src": [],
+  "object-src": []
+}

--- a/scripts/ManageApacheContentPolicy.sh
+++ b/scripts/ManageApacheContentPolicy.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+##############################################################################
+# Some internal setup
+PATH="/sbin:/bin:/usr/sbin:/usr/bin"
+
+BINDIR=$(cd $(dirname $0) && pwd)
+
+. ${BINDIR}/common
+. ${BINDIR}/functions
+
+#############################################################################
+# Path to your JSON file
+JSON_FILE=$FPPDIR"/etc/csp_allowed_domains.json"
+
+# Default key values hard-coded to include in all configs
+declare -A DEFAULT_VALUES
+DEFAULT_VALUES=( 
+    ["default-src"]="'self' http://www.w3.org"
+    ["connect-src"]="'self' https://raw.githubusercontent.com"
+    ["object-src"]="'none'"
+    ["img-src"]="'self' http://www.w3.org https://www.paypal.com https://www.paypalobjects.com"
+    ["script-src"]="'self' 'unsafe-inline'"
+    ["style-src"]="'self' 'unsafe-inline'"
+)
+
+# Function to check if a key exists in the JSON file
+key_exists() {
+    key=$1
+    jq --arg key "$key" 'has($key)' $JSON_FILE
+}
+
+# Function to check if a domain exists under a specific key in the JSON file
+domain_exists() {
+    key=$1
+    domain=$2
+    jq --arg key "$key" --arg domain "$domain" '(.[$key] // []) | index($domain)' $JSON_FILE
+}
+
+# Function to add a domain to the JSON file
+add_domain() {
+    key=$1
+    domain=$2
+    if [ $(key_exists "$key") = true ] && [ $(domain_exists "$key" "$domain") = null ]; then
+        jq --arg key "$key" --arg domain "$domain" '(.[$key] // []) |= . + [$domain]' $JSON_FILE > tmp.json && mv tmp.json $JSON_FILE
+        echo "Domain '$domain' added under '$key'."
+    else
+        echo "Domain '$domain' already exists under '$key' or key doesn't exist."
+    fi
+}
+
+# Function to remove a domain from the JSON file
+remove_domain() {
+    key=$1
+    domain=$2
+    if [ $(key_exists "$key") = true ] && [ $(domain_exists "$key" "$domain") != null ]; then
+        jq --arg key "$key" --arg domain "$domain" '(.[$key] // []) |= map(select(. != $domain))' $JSON_FILE > tmp.json && mv tmp.json $JSON_FILE
+        echo "Domain '$domain' removed from '$key'."
+    else
+        echo "Domain '$domain' doesn't exist under '$key' or key doesn't exist."
+    fi
+}
+
+# Function to generate the CSP header
+generate_csp() {
+  # Initialize an associative array to store the combined values
+    declare -A combined_values
+
+    # Include default values
+    for key in "${!DEFAULT_VALUES[@]}"; do
+        combined_values[$key]="${DEFAULT_VALUES[$key]}"
+    done
+
+    # Read current CSP values from JSON file and combine them with default values
+    while IFS= read -r entry; do
+        key=$(echo "$entry" | awk '{print $1}')
+        value=$(echo "$entry" | awk '{$1=""; print $0}' | xargs)
+        
+        if [ -n "${combined_values[$key]}" ]; then
+            combined_values[$key]="${combined_values[$key]} $value"
+        else
+            combined_values[$key]="$value"
+        fi
+    done < <(jq -r 'to_entries | map("\(.key) \(.value | join(" "))") | .[]' $JSON_FILE)
+
+    # Construct the CSP_HEADER from combined values
+    CSP_HEADER=""
+    for key in "${!combined_values[@]}"; do
+        CSP_HEADER="$CSP_HEADER; $key ${combined_values[$key]}"
+    done
+
+    # Ensure CSP_HEADER is trimmed correctly
+    CSP_HEADER=$(echo "$CSP_HEADER" | sed 's/^ *; *//; s/ *; *$//')
+    # echo "Final CSP_HEADER: $CSP_HEADER"
+
+    cat <<EOL > $FPPDIR/etc/apache2.csp
+<IfModule mod_headers.c>
+    Header set Content-Security-Policy "$CSP_HEADER"
+</IfModule>
+EOL
+    echo "CSP header generated."
+}
+
+# Function to echo current JSON settings
+echo_current_settings() {
+    jq . $JSON_FILE
+}
+
+# Parse arguments
+case "$1" in
+    add)
+        add_domain "$2" "$3"
+        generate_csp
+        ;;
+    remove)
+        remove_domain "$2" "$3"
+        generate_csp
+        ;;
+    show)
+        echo_current_settings
+        ;;
+    *)
+        echo "Usage: $0 {add|remove} key domain"
+        echo "Possible Keys are: 'default-src','img-src','script-src','style-src'"
+        echo "To view current config:"
+        echo "Usage: $0 {show}"
+        exit 1
+        ;;
+esac

--- a/scripts/ManageApacheContentPolicy.sh
+++ b/scripts/ManageApacheContentPolicy.sh
@@ -16,10 +16,10 @@ JSON_FILE=$FPPDIR"/etc/csp_allowed_domains.json"
 declare -A DEFAULT_VALUES
 DEFAULT_VALUES=( 
     ["default-src"]="'self' http://www.w3.org"
-    ["connect-src"]="'self' https://raw.githubusercontent.com"
-    ["object-src"]="'none'"
-    ["img-src"]="'self' http://www.w3.org https://www.paypal.com https://www.paypalobjects.com"
-    ["script-src"]="'self' 'unsafe-inline'"
+    ["connect-src"]="'self' https://raw.githubusercontent.com https://kulplights.com https://www.hansonelectronics.com.au https://www.wiredwatts.com"
+    ["object-src"]="'none' "
+    ["img-src"]="'self' blob: http://www.w3.org https://www.paypal.com https://www.paypalobjects.com"
+    ["script-src"]="'self' 'unsafe-inline' https://api.falconplayer.com"
     ["style-src"]="'self' 'unsafe-inline'"
 )
 
@@ -118,11 +118,16 @@ case "$1" in
     show)
         echo_current_settings
         ;;
+    regenerate)
+        generate_csp
+        ;;
     *)
         echo "Usage: $0 {add|remove} key domain"
-        echo "Possible Keys are: 'default-src','img-src','script-src','style-src'"
+        echo "Possible Keys are: 'default-src','connect-src', 'img-src','script-src','style-src','object-src'"
         echo "To view current config:"
         echo "Usage: $0 {show}"
+        echo "To regenerate current config without making changes:"
+        echo "Usage: $0 {regenerate}"
         exit 1
         ;;
 esac

--- a/upgrade/94/upgrade.sh
+++ b/upgrade/94/upgrade.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#####################################
+
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/../../scripts/common
+
+#copy across new apache conf to version which includes seperate csp policy file
+cat /opt/fpp/etc/apache2.site > /etc/apache2/sites-enabled/000-default.conf
+
+# Set the reboot flag so the config/cmdline changes will be picked up
+    setSetting rebootFlag 1


### PR DESCRIPTION
This PR creates the ability for plugins to add domains to the trust CSP list via a script which needs to be called during their install

New documention outlines the process