### PR TITLE
Further CSP functionality enhancements

### DIFF
--- a/docs/ApacheContentSecurityPolicy.md
+++ b/docs/ApacheContentSecurityPolicy.md
@@ -20,8 +20,7 @@ in the pluggins fpp_install.sh file:
 ${FPPDIR}/scripts/ManageApacheContentPolicy.sh add connect-src https://domaintotrust.co.uk
 ${FPPDIR}/scripts/ManageApacheContentPolicy.sh add img-src https://anotherdomain.com
 
-# Need to force reboot for CSP change to take affect
-setSetting rebootFlag 1
+# No need to restart or reboot as the apache config is gracefully reloaded in the background
 ```
 
 Possible Keys are: 'default-src', 'connect-src', 'img-src', 'script-src', 'style-src', 'object-src'
@@ -34,3 +33,4 @@ Possible Keys are: 'default-src', 'connect-src', 'img-src', 'script-src', 'style
 4. script-src - defines domains which are allowed to provide script content
 5. style-src - defines domains which are allowed to provide style content
 6. object-src - defines domains which are allowed to provide object content
+

--- a/scripts/ManageApacheContentPolicy.sh
+++ b/scripts/ManageApacheContentPolicy.sh
@@ -117,16 +117,19 @@ case "$1" in
     add)
         add_domain "$2" "$3"
         generate_csp
+        gracefullyReloadApacheConf
         ;;
     remove)
         remove_domain "$2" "$3"
         generate_csp
+        gracefullyReloadApacheConf
         ;;
     show)
         echo_current_settings
         ;;
     regenerate)
         generate_csp
+        gracefullyReloadApacheConf
         ;;
     *)
         echo "Usage: $0 {add|remove} key domain"

--- a/scripts/ManageApacheContentPolicy.sh
+++ b/scripts/ManageApacheContentPolicy.sh
@@ -25,7 +25,7 @@ DEFAULT_VALUES=(
     ["style-src"]="'self' 'unsafe-inline'"
 )
 
-#Generate local CSP JSON override file in NOT exists
+# Generate local CSP JSON override file if NOT exists
 if [ ! -f $JSON_FILE ]; then
     cp $JSON_STRUCT $JSON_FILE
 fi
@@ -67,9 +67,31 @@ remove_domain() {
     fi
 }
 
+# Function to detect Cape Domains from cape config
+detectCapeDomains() {
+    if [ ! -f /home/fpp/media/tmp/cape-info.json ]; then
+        return
+    fi
+
+    cape_json_data=$(cat /home/fpp/media/tmp/cape-info.json)
+
+    # Extract base URLs
+    header_cape_image_url=$(echo "$cape_json_data" | jq -r '.header_cape_image // empty' | sed 's|\(https\?://[^/]*\).*|\1|')
+    vendor_image_url=$(echo "$cape_json_data" | jq -r '.vendor.image // empty' | sed 's|\(https\?://[^/]*\).*|\1|')
+    vendor_url=$(echo "$cape_json_data" | jq -r '.vendor.url // empty' | sed 's|\(https\?://[^/]*\).*|\1|')
+    vendor_landing_page_url=$(echo "$cape_json_data" | jq -r '.vendor.landingPage // empty' | sed 's|\(https\?://[^/]*\).*|\1|')
+
+    # Combine URLs and remove duplicates
+    urls=("$header_cape_image_url" "$vendor_image_url" "$vendor_url" "$vendor_landing_page_url")
+    distinct_urls=($(printf "%s\n" "${urls[@]}" | sort -u))
+
+    # Output the distinct URLs
+    echo "${distinct_urls[@]}"
+}
+
 # Function to generate the CSP header
 generate_csp() {
-  # Initialize an associative array to store the combined values
+    # Initialize an associative array to store the combined values
     declare -A combined_values
 
     # Include default values
@@ -88,6 +110,18 @@ generate_csp() {
             combined_values[$key]="$value"
         fi
     done < <(jq -r 'to_entries | map("\(.key) \(.value | join(" "))") | .[]' $JSON_FILE)
+
+    # Detect cape domains and add them to default-src
+    cape_domains=$(detectCapeDomains)
+    if [ -n "$cape_domains" ]; then
+        combined_values["img-src"]="${combined_values["img-src"]} $cape_domains"
+        combined_values["connect-src"]="${combined_values["connect-src"]} $cape_domains"
+    fi
+
+    # Remove duplicate values for each key
+    for key in "${!combined_values[@]}"; do
+        combined_values[$key]=$(echo "${combined_values[$key]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+    done
 
     # Construct the CSP_HEADER from combined values
     CSP_HEADER=""

--- a/scripts/common
+++ b/scripts/common
@@ -198,6 +198,23 @@ setSetting() {
     fi
 }
 
+gracefullyReloadApacheConf() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS
+        sudo apachectl graceful
+    elif [[ -f /etc/debian_version ]]; then
+        # Debian/Ubuntu
+        sudo systemctl reload apache2
+    elif [[ -f /etc/redhat-release ]]; then
+        # RHEL/CentOS/Fedora
+        sudo systemctl reload httpd
+    else
+        echo "Unsupported OS"
+        return 1
+    fi
+    echo "Apache configuration reloaded successfully."
+}
+
 ###################################################################
 # Handle calling a function directly
 #

--- a/upgrade/94/upgrade.sh
+++ b/upgrade/94/upgrade.sh
@@ -7,5 +7,5 @@ BINDIR=$(cd $(dirname $0) && pwd)
 #copy across new apache conf to version which includes seperate csp policy file
 cat /opt/fpp/etc/apache2.site > /etc/apache2/sites-enabled/000-default.conf
 
-# Set the reboot flag so the config/cmdline changes will be picked up
-    setSetting rebootFlag 1
+# Gracefully reload apache config
+gracefullyReloadApacheConf


### PR DESCRIPTION
Apache now gracefully reloads config without restart
Domains to trust auto detected from installed cape-info and added to CSP config