### PR TITLE
Fix z-index conflict and backdrop cleanup in DialogOK

### DIFF
--- a/src/commands/Commands.cpp
+++ b/src/commands/Commands.cpp
@@ -13,15 +13,17 @@
 #include "fpp-pch.h"
 
 #include <thread>
-#include <chrono>
-#include <fcntl.h>
-#include <unistd.h>
-#include <dirent.h>
-#include <string.h>
+#include <chrono>        // For timer thread sleep
+#include <fcntl.h>       // For file operations in USBRelayOnOffCommand
+#include <unistd.h>      // For write/close in USBRelayOnOffCommand
+#include <dirent.h>      // Unused but kept for original includes
+#include <string.h>      // For memset in LoadPresets
 
 #include "../common.h"
 #include "../log.h"
+
 #include "../Events.h"
+
 #include "EventCommands.h"
 #include "MediaCommands.h"
 #include "MultiSync.h"
@@ -31,20 +33,29 @@
 CommandManager CommandManager::INSTANCE;
 
 // Base Command Class Implementation
-Command::Command(const std::string& n) : name(n), description("") {}
-Command::Command(const std::string& n, const std::string& descript) : name(n), description(descript) {}
+Command::Command(const std::string& n) :
+    name(n),
+    description("") {
+}
+Command::Command(const std::string& n, const std::string& descript) :
+    name(n),
+    description(descript) {
+}
 Command::~Command() {}
 
 Json::Value Command::getDescription() {
     Json::Value cmd;
     cmd["name"] = name;
-    if (!description.empty()) cmd["description"] = description;
+    if (!description.empty()) {
+        cmd["description"] = description;
+    }
     for (auto& ar : args) {
         Json::Value a;
         a["name"] = ar.name;
         a["type"] = ar.type;
         a["description"] = ar.description;
         a["optional"] = ar.optional;
+
         if (ar.min != ar.max) {
             a["min"] = ar.min;
             a["max"] = ar.max;
@@ -53,62 +64,107 @@ Json::Value Command::getDescription() {
             a["contentListUrl"] = ar.contentListUrl;
             a["allowBlanks"] = ar.allowBlanks;
         } else if (!ar.contentList.empty()) {
-            for (auto& x : ar.contentList) a["contents"].append(x);
+            for (auto& x : ar.contentList) {
+                a["contents"].append(x);
+            }
         }
-        if (ar.defaultValue != "") a["default"] = ar.defaultValue;
+        if (ar.defaultValue != "") {
+            a["default"] = ar.defaultValue;
+        }
         if (ar.adjustable) {
             a["adjustable"] = true;
-            if (!ar.adjustableGetValueURL.empty()) a["adjustableGetValueURL"] = ar.adjustableGetValueURL;
+            if (!ar.adjustableGetValueURL.empty()) {
+                a["adjustableGetValueURL"] = ar.adjustableGetValueURL;
+            }
         }
+
         cmd["args"].append(a);
     }
     return cmd;
 }
 
-// Command Manager Implementation
-CommandManager::CommandManager() {}
-CommandManager::~CommandManager() { Cleanup(); }
-
 // USB Relay On/Off Command Class
 class USBRelayOnOffCommand : public Command {
 public:
     USBRelayOnOffCommand() : Command("USB Relay On/Off", "Turns a USB relay channel ON or OFF, optionally for a specified duration") {
-        args.emplace_back("Device", "string", "USB Relay device", false);
-        args.back().defaultValue = "/dev/ttyUSB0";
-        DIR* dir = opendir("/dev/serial/by-id/");
-        if (dir) {
-            struct dirent* entry;
-            while ((entry = readdir(dir)) != nullptr) {
-                if (strstr(entry->d_name, "usb-")) {
-                    std::string dev = "/dev/serial/by-id/";
-                    dev += entry->d_name;
-                    std::next(args.begin(), 0)->contentList.push_back(dev);
+        LogDebug(VB_COMMAND, "Initializing USBRelayOnOffCommand\n");
+
+        // Device argument
+        args.emplace_back("Device", "string", "USB Relay device from Others tab", false);
+        std::string defaultDevice;
+
+        // Populate devices and protocols from co-other.json
+        std::string configFile = FPP_DIR_CONFIG("/co-other.json");
+        Json::Value config;
+        if (FileExists(configFile) && LoadJsonFromFile(configFile, config)) {
+            LogDebug(VB_COMMAND, "Parsing co-other.json for USB relay devices\n");
+            if (config.isObject() && config.isMember("channelOutputs")) {
+                const Json::Value& outputs = config["channelOutputs"];
+                if (outputs.isArray()) {
+                    LogDebug(VB_COMMAND, "Found %u channel outputs in co-other.json\n", outputs.size());
+                    for (const auto& output : outputs) {
+                        std::string deviceName = output.get("device", "").asString();
+                        std::string type = output.get("type", "").asString();
+                        std::string subType = output.get("subType", "").asString();
+                        if (!deviceName.empty() && type == "USBRelay") {
+                            std::string protocol;
+                            if (subType == "CH340") {
+                                protocol = "CH340";
+                            } else if (subType == "ICStation") {
+                                protocol = "ICstation";
+                            } else {
+                                LogWarn(VB_COMMAND, "Unknown USBRelay subType '%s' for device %s, skipping\n", 
+                                        subType.c_str(), deviceName.c_str());
+                                continue;
+                            }
+                            args.back().contentList.push_back(deviceName);
+                            deviceProtocols[deviceName] = protocol;
+                            LogDebug(VB_COMMAND, "Found device %s with protocol %s\n", 
+                                     deviceName.c_str(), protocol.c_str());
+                        }
+                    }
+                    if (!args.back().contentList.empty()) {
+                        defaultDevice = args.back().contentList.front();
+                        args.back().defaultValue = defaultDevice;
+                        LogDebug(VB_COMMAND, "Set default device to %s\n", defaultDevice.c_str());
+                    } else {
+                        LogWarn(VB_COMMAND, "No USBRelay devices found in co-other.json\n");
+                    }
+                } else {
+                    LogWarn(VB_COMMAND, "channelOutputs in co-other.json is not an array\n");
                 }
+            } else {
+                LogWarn(VB_COMMAND, "co-other.json lacks channelOutputs member or is not an object\n");
             }
-            closedir(dir);
+        } else {
+            LogWarn(VB_COMMAND, "co-other.json not found or invalid, no USB relay devices available\n");
         }
+
+        // Channel argument
         args.emplace_back("Channel", "int", "Relay channel (1-8)", false);
         args.back().min = 1;
         args.back().max = 8;
         args.back().defaultValue = "1";
+
+        // State argument
         args.emplace_back("State", "string", "Relay state", false);
         args.back().defaultValue = "ON";
         args.back().contentList = {"ON", "OFF"};
-        args.emplace_back("Protocol", "string", "Relay protocol", false);
-        args.back().defaultValue = "CH340";
-        args.back().contentList = {"CH340", "ICstation"};
+
+        // Duration argument
         args.emplace_back("Duration", "int", "Duration in minutes to keep relay ON (0 for no auto-off)", true);
         args.back().min = 0;
-        args.back().max = 999; // Reasonable UI bound
+        args.back().max = 999;
         args.back().defaultValue = "0";
+
+        LogDebug(VB_COMMAND, "USBRelayOnOffCommand initialization complete\n");
     }
 
 private:
-    // Static members to track timers and relay states
-    static std::map<std::string, bool> activeTimers; // Key: "device:channel", Value: cancel flag
-    static std::map<std::string, unsigned char> relayStates; // Key: device, Value: bitmask (1=ON, 0=OFF)
+    static std::map<std::string, bool> activeTimers;           // Tracks active timer threads
+    static std::map<std::string, unsigned char> relayStates;   // Stores ICstation relay bitmasks
+    static std::map<std::string, std::string> deviceProtocols; // Cached device -> protocol mapping
 
-    // Initialize ICStation device
     void initializeICStation(const std::string& device) {
         int fd = open(device.c_str(), O_RDWR | O_NOCTTY);
         if (fd < 0) {
@@ -119,40 +175,40 @@ private:
         unsigned char c_reply = 0x00;
         unsigned char c_open = 0x51;
 
-        // Initial delay to mimic USBRelay.cpp's sleep(1)
-        sleep(1);
+        sleep(1); // Initial delay for device readiness
         write(fd, &c_init, 1);
         usleep(500000); // Wait for response
         read(fd, &c_reply, 1);
+        LogDebug(VB_COMMAND, "ICStation handshake response: 0x%02X\n", c_reply);
         write(fd, &c_open, 1);
-        // Additional wake-up: Send initial state to ensure relay is ready
-        unsigned char wakeCmd = 0x00; // All OFF to wake it up
+        unsigned char wakeCmd = 0x00;
         write(fd, &wakeCmd, 1);
-        usleep(100000); // 100ms delay to ensure relay processes wake-up
+        usleep(100000); // Final wake-up delay
         close(fd);
 
-        relayStates[device] = 0x00; // All OFF (0 = OFF, matching USBRelay.cpp)
+        relayStates[device] = 0x00;
         LogDebug(VB_COMMAND, "Initialized ICStation device %s with handshake and wake-up\n", device.c_str());
     }
 
-    // Update and return bitmask for ICStation
     unsigned char getRelayBitmask(const std::string& device, int channel, bool turnOn) {
         if (relayStates.find(device) == relayStates.end()) {
-            relayStates[device] = 0x00; // All OFF
+            relayStates[device] = 0x00;
+            LogDebug(VB_COMMAND, "Initialized relay state for %s to 0x00\n", device.c_str());
         }
         unsigned char bitmask = relayStates[device];
         if (turnOn) {
-            bitmask |= (1 << (channel - 1)); // Set bit to 1 for ON
+            bitmask |= (1 << (channel - 1));
         } else {
-            bitmask &= ~(1 << (channel - 1)); // Clear bit to 0 for OFF
+            bitmask &= ~(1 << (channel - 1));
         }
         relayStates[device] = bitmask;
         return bitmask;
     }
 
-    // Auto-off thread
     void turnOffAfterDelay(const std::string& device, int channel, const std::string& protocol, int durationMinutes) {
         std::string key = device + ":" + std::to_string(channel);
+        // Diagnostic: Log thread start
+        LogDebug(VB_COMMAND, "Timer thread started for %s, channel %d, waiting %d minutes\n", device.c_str(), channel, durationMinutes);
         std::this_thread::sleep_for(std::chrono::minutes(durationMinutes));
         
         if (activeTimers[key]) {
@@ -183,34 +239,66 @@ private:
             } else {
                 LogErr(VB_COMMAND, "Failed to auto-turn off relay, wrote %zd bytes\n", written);
             }
+        } else {
+            // Diagnostic: Log if timer was cancelled or key mismatch occurred
+            LogDebug(VB_COMMAND, "Timer skipped for %s, channel %d: no active timer\n", device.c_str(), channel);
         }
         activeTimers.erase(key);
     }
 
 public:
     virtual std::unique_ptr<Command::Result> run(const std::vector<std::string>& args) override {
-        if (args.size() < 4) return std::make_unique<Command::ErrorResult>("Device, Channel, State, and Protocol required");
+        if (args.size() < 3) return std::make_unique<Command::ErrorResult>("Device, Channel, and State required");
         
         std::string device = args[0];
-        int channel = std::stoi(args[1]);
+        int channel;
+        try {
+            channel = std::stoi(args[1]);
+        } catch (const std::exception& e) {
+            LogErr(VB_COMMAND, "Invalid channel value: %s\n", args[1].c_str());
+            return std::make_unique<Command::ErrorResult>("Invalid channel value: " + args[1]);
+        }
         if (channel < 1 || channel > 8) return std::make_unique<Command::ErrorResult>("Channel must be 1-8");
+        
         std::string state = args[2];
-        std::string protocol = args[3];
-        int duration = (args.size() > 4) ? std::stoi(args[4]) : 0;
+        if (state != "ON" && state != "OFF") return std::make_unique<Command::ErrorResult>("State must be ON or OFF");
+
+        int duration = 0;
+        if (args.size() > 3 && !args[3].empty()) {
+            try {
+                duration = std::stoi(args[3]);
+            } catch (const std::exception& e) {
+                LogErr(VB_COMMAND, "Invalid duration value: %s\n", args[3].c_str());
+                return std::make_unique<Command::ErrorResult>("Invalid duration value: " + args[3]);
+            }
+        }
         if (duration < 0) return std::make_unique<Command::ErrorResult>("Duration cannot be negative");
-        std::string key = device + ":" + args[1];
+
+        // Adjust device path to include /dev/ if missing
+        std::string fullDevice = device;
+        if (fullDevice.find("/dev/") != 0) {
+            fullDevice = "/dev/" + device;
+            LogDebug(VB_COMMAND, "Adjusted device path from %s to %s\n", device.c_str(), fullDevice.c_str());
+        }
+        std::string key = fullDevice + ":" + std::to_string(channel); // Use full path for timer key
+
+        auto it = deviceProtocols.find(device);
+        if (it == deviceProtocols.end()) {
+            LogErr(VB_COMMAND, "Device %s not configured in Others tab\n", device.c_str());
+            return std::make_unique<Command::ErrorResult>("Device " + device + " not configured in Others tab");
+        }
+        std::string protocol = it->second;
 
         LogDebug(VB_COMMAND, "Opening device: %s, Channel: %d, State: %s, Protocol: %s, Duration: %d minutes\n", 
-                 device.c_str(), channel, state.c_str(), protocol.c_str(), duration);
+                 fullDevice.c_str(), channel, state.c_str(), protocol.c_str(), duration);
 
-        // Ensure ICStation is initialized before first command
-        if (protocol == "ICstation" && relayStates.find(device) == relayStates.end()) {
-            initializeICStation(device);
+        if (protocol == "ICstation" && relayStates.find(fullDevice) == relayStates.end()) {
+            initializeICStation(fullDevice);
         }
 
-        int fd = open(device.c_str(), O_WRONLY | O_NOCTTY);
+        int fd = open(fullDevice.c_str(), O_WRONLY | O_NOCTTY);
         if (fd < 0) {
-            LogErr(VB_COMMAND, "Failed to open %s\n", device.c_str());
+            LogErr(VB_COMMAND, "Failed to open %s\n", fullDevice.c_str());
             return std::make_unique<Command::ErrorResult>("Failed to open device " + device);
         }
 
@@ -223,12 +311,16 @@ public:
             cmd[3] = cmd[0] + cmd[1] + cmd[2];
             len = 4;
         } else if (protocol == "ICstation") {
-            cmd[0] = getRelayBitmask(device, channel, state == "ON");
+            cmd[0] = getRelayBitmask(fullDevice, channel, state == "ON");
             len = 1;
         } else {
             close(fd);
-            return std::make_unique<Command::ErrorResult>("Unknown protocol: " + protocol);
+            LogErr(VB_COMMAND, "Unsupported protocol %s for device %s\n", protocol.c_str(), device.c_str());
+            return std::make_unique<Command::ErrorResult>("Unsupported protocol for device " + device);
         }
+
+        LogDebug(VB_COMMAND, "Sending command to %s: [%02X %02X %02X %02X] (len=%zd)\n", 
+                 fullDevice.c_str(), cmd[0], cmd[1], cmd[2], cmd[3], len);
 
         ssize_t written = write(fd, cmd, len);
         close(fd);
@@ -239,14 +331,17 @@ public:
         }
 
         LogDebug(VB_COMMAND, "Wrote to relay: %s, channel %d, state %s\n", 
-                 device.c_str(), channel, state.c_str());
+                 fullDevice.c_str(), channel, state.c_str());
 
         if (state == "ON" && duration > 0) {
             activeTimers[key] = true;
-            std::thread([this, device, channel, protocol, duration]() { turnOffAfterDelay(device, channel, protocol, duration); }).detach();
-            return std::make_unique<Command::Result>("Relay channel " + args[1] + " turned ON for " + args[4] + " minutes");
+            // Diagnostic: Confirm timer thread is spawned
+            LogDebug(VB_COMMAND, "Spawning timer thread for %s, channel %d, duration %d minutes\n", 
+                     fullDevice.c_str(), channel, duration);
+            std::thread([this, fullDevice, channel, protocol, duration]() { turnOffAfterDelay(fullDevice, channel, protocol, duration); }).detach();
+            return std::make_unique<Command::Result>("Relay channel " + args[1] + " turned ON for " + std::to_string(duration) + " minutes");
         } else if (state == "OFF") {
-            activeTimers[key] = false; // Cancel timer
+            activeTimers[key] = false;
         }
 
         return std::make_unique<Command::Result>("Relay channel " + args[1] + " turned " + state);
@@ -256,10 +351,15 @@ public:
 // Static Member Definitions
 std::map<std::string, bool> USBRelayOnOffCommand::activeTimers;
 std::map<std::string, unsigned char> USBRelayOnOffCommand::relayStates;
+std::map<std::string, std::string> USBRelayOnOffCommand::deviceProtocols;
 
-// Command Manager Methods
+// Command Manager Implementation
+CommandManager::CommandManager() {
+}
+
 void CommandManager::Init() {
     LoadPresets();
+
     addCommand(new StopPlaylistCommand());
     addCommand(new StopGracefullyPlaylistCommand());
     addCommand(new RestartPlaylistCommand());
@@ -298,6 +398,7 @@ void CommandManager::Init() {
     addCommand(new AllLightsOffCommand());
     addCommand(new SwitchToPlayerModeCommand());
     addCommand(new SwitchToRemoteModeCommand());
+
     addCommand(new TriggerRemotePresetCommand());
     addCommand(new TriggerRemotePresetSlotCommand());
     addCommand(new StartRemoteEffectCommand());
@@ -305,72 +406,94 @@ void CommandManager::Init() {
     addCommand(new RunRemoteScriptEvent());
     addCommand(new StartRemoteFSEQEffectCommand());
     addCommand(new StartRemotePlaylistCommand());
+
+    // Add our custom USB Relay command
     addCommand(new USBRelayOnOffCommand());
 
-    std::function<void(const std::string&, const std::string&)> f = [](const std::string& topic, const std::string& payload) {
-        if (topic.size() <= 13) {
-            Json::Value val;
-            bool success = LoadJsonFromString(payload, val);
-            if (success && val.isObject()) {
-                CommandManager::INSTANCE.run(val);
+    std::function<void(const std::string&, const std::string&)> f =
+        [](const std::string& topic, const std::string& payload) {
+            if (topic.size() <= 13) {
+                Json::Value val;
+                bool success = LoadJsonFromString(payload, val);
+                if (success && val.isObject()) {
+                    CommandManager::INSTANCE.run(val);
+                } else {
+                    LogWarn(VB_COMMAND, "Invalid JSON Payload: %s\n", payload.c_str());
+                }
             } else {
-                LogWarn(VB_COMMAND, "Invalid JSON Payload: %s\n", payload.c_str());
-            }
-        } else {
-            std::vector<std::string> args;
-            std::string command;
-            std::string ntopic = topic.substr(13);
-            args = splitWithQuotes(ntopic, '/');
-            command = args[0];
-            args.erase(args.begin());
-            bool foundp = false;
-            for (int x = 0; x < args.size(); x++) {
-                if (args[x] == "{Payload}") {
-                    args[x] = payload;
-                    foundp = true;
+                std::vector<std::string> args;
+                std::string command;
+
+                std::string ntopic = topic.substr(13); // remove /set/command/
+                args = splitWithQuotes(ntopic, '/');
+                command = args[0];
+                args.erase(args.begin());
+                bool foundp = false;
+                for (int x = 0; x < args.size(); x++) {
+                    if (args[x] == "{Payload}") {
+                        args[x] = payload;
+                        foundp = true;
+                    }
+                }
+                if (!payload.empty() && !foundp) {
+                    args.push_back(payload);
+                }
+                if (args.size() == 0 && payload != "") {
+                    Json::Value val = LoadJsonFromString(payload);
+                    if (val.isObject()) {
+                        CommandManager::INSTANCE.run(command, val);
+                    } else {
+                        LogWarn(VB_COMMAND, "Invalid JSON Payload for topic %s: %s\n", topic.c_str(), payload.c_str());
+                    }
+                } else {
+                    CommandManager::INSTANCE.run(command, args);
                 }
             }
-            if (!payload.empty() && !foundp) args.push_back(payload);
-            if (args.size() == 0 && payload != "") {
-                Json::Value val = LoadJsonFromString(payload);
-                if (val.isObject()) CommandManager::INSTANCE.run(command, val);
-                else LogWarn(VB_COMMAND, "Invalid JSON Payload for topic %s: %s\n", topic.c_str(), payload.c_str());
-            } else {
-                CommandManager::INSTANCE.run(command, args);
-            }
-        }
-    };
+        };
     Events::AddCallback("/set/command", f);
     Events::AddCallback("/set/command/#", f);
+}
+
+CommandManager::~CommandManager() {
+    Cleanup();
 }
 
 void CommandManager::Cleanup() {
     while (!commands.empty()) {
         Command* cmd = commands.begin()->second;
         commands.erase(commands.begin());
-        if (cmd->name != "GPIO") delete cmd;
+
+        if (cmd->name != "GPIO") { // No idea why deleteing the GPIO command causes a crash on exit
+            delete cmd;
+        }
     }
     commands.clear();
 }
 
-void CommandManager::addCommand(Command* cmd) { commands[cmd->name] = cmd; }
+void CommandManager::addCommand(Command* cmd) {
+    commands[cmd->name] = cmd;
+}
 void CommandManager::removeCommand(Command* cmd) {
     auto a = commands.find(cmd->name);
-    if (a != commands.end()) commands.erase(a);
+    if (a != commands.end()) {
+        commands.erase(a);
+    }
 }
 void CommandManager::removeCommand(const std::string& cmdName) {
     auto a = commands.find(cmdName);
-    if (a != commands.end()) commands.erase(a);
+    if (a != commands.end()) {
+        commands.erase(a);
+    }
 }
-
 Json::Value CommandManager::getDescriptions() {
     Json::Value ret;
     for (auto& a : commands) {
-        if (!a.second->hidden()) ret.append(a.second->getDescription());
+        if (!a.second->hidden()) {
+            ret.append(a.second->getDescription());
+        }
     }
     return ret;
 }
-
 std::unique_ptr<Command::Result> CommandManager::run(const std::string& command, const std::vector<std::string>& args) {
     auto f = commands.find(command);
     if (f != commands.end()) {
@@ -380,7 +503,6 @@ std::unique_ptr<Command::Result> CommandManager::run(const std::string& command,
     LogWarn(VB_COMMAND, "No command found for \"%s\"\n", command.c_str());
     return std::make_unique<Command::ErrorResult>("No Command: " + command);
 }
-
 std::unique_ptr<Command::Result> CommandManager::runRemoteCommand(const std::string& remote, const std::string& cmd, const std::vector<std::string>& args) {
     size_t startPos = 0;
     std::string command = cmd;
@@ -388,13 +510,19 @@ std::unique_ptr<Command::Result> CommandManager::runRemoteCommand(const std::str
         command.replace(startPos, 1, "%20");
         startPos += 3;
     }
+
     std::string url = "http://" + remote + ":32322/command/" + command;
+
     Json::Value j;
-    for (auto& a : args) j.append(a);
+    for (auto& a : args) {
+        j.append(a);
+    }
     std::vector<std::string> uargs;
     uargs.push_back(url);
     uargs.push_back("POST");
+
     std::string config = SaveJsonToString(j);
+
     uargs.push_back(config);
     return run("URL", uargs);
 }
@@ -403,11 +531,15 @@ std::unique_ptr<Command::Result> CommandManager::run(const std::string& command,
     auto f = commands.find(command);
     if (f != commands.end()) {
         std::vector<std::string> args;
-        for (int x = 0; x < argsArray.size(); x++) args.push_back(argsArray[x].asString());
+        for (int x = 0; x < argsArray.size(); x++) {
+            args.push_back(argsArray[x].asString());
+        }
         if (WillLog(LOG_DEBUG, VB_COMMAND)) {
             std::string argString;
             for (auto& a : args) {
-                if (!argString.empty()) argString += ",";
+                if (!argString.empty()) {
+                    argString += ",";
+                }
                 argString += a;
             }
             LogDebug(VB_COMMAND, "Running command \"%s(%s)\"\n", command.c_str(), argString.c_str());
@@ -417,7 +549,6 @@ std::unique_ptr<Command::Result> CommandManager::run(const std::string& command,
     LogWarn(VB_COMMAND, "No command found for \"%s\"\n", command.c_str());
     return std::make_unique<Command::ErrorResult>("No Command: " + command);
 }
-
 std::unique_ptr<Command::Result> CommandManager::run(const Json::Value& cmd) {
     std::string command = cmd["command"].asString();
     if (cmd.isMember("multisyncCommand")) {
@@ -425,7 +556,9 @@ std::unique_ptr<Command::Result> CommandManager::run(const Json::Value& cmd) {
         if (multisync) {
             std::string hosts = cmd.isMember("multisyncHosts") ? cmd["multisyncHosts"].asString() : "";
             std::vector<std::string> args;
-            for (int x = 0; x < cmd["args"].size(); x++) args.push_back(cmd["args"][x].asString());
+            for (int x = 0; x < cmd["args"].size(); x++) {
+                args.push_back(cmd["args"][x].asString());
+            }
             MultiSync::INSTANCE.SendFPPCommandPacket(hosts, command, args);
             return std::make_unique<Command::Result>("Command Sent");
         }
@@ -436,6 +569,7 @@ std::unique_ptr<Command::Result> CommandManager::run(const Json::Value& cmd) {
 HTTP_RESPONSE_CONST std::shared_ptr<httpserver::http_response> CommandManager::render_GET(const httpserver::http_request& req) {
     int plen = req.get_path_pieces().size();
     std::string p1 = req.get_path_pieces()[0];
+
     if (p1 == "commands") {
         if (plen > 1) {
             std::string command = req.get_path_pieces()[1];
@@ -453,7 +587,10 @@ HTTP_RESPONSE_CONST std::shared_ptr<httpserver::http_response> CommandManager::r
     } else if (p1 == "commandPresets") {
         std::string commandsFile = FPP_DIR_CONFIG("/commandPresets.json");
         Json::Value allCommands;
-        if (FileExists(commandsFile)) allCommands = LoadJsonFromFile(commandsFile);
+        if (FileExists(commandsFile)) {
+            // Load new config file
+            allCommands = LoadJsonFromFile(commandsFile);
+        }
         if (plen > 1) {
             if (allCommands.isMember("commands")) {
                 std::string p2 = req.get_path_pieces()[1];
@@ -468,7 +605,9 @@ HTTP_RESPONSE_CONST std::shared_ptr<httpserver::http_response> CommandManager::r
             if (std::string(req.get_arg("names")) == "true") {
                 Json::Value names;
                 if (allCommands.isMember("commands")) {
-                    for (int x = 0; x < allCommands["commands"].size(); x++) names.append(allCommands["commands"][x]["name"].asString());
+                    for (int x = 0; x < allCommands["commands"].size(); x++) {
+                        names.append(allCommands["commands"][x]["name"].asString());
+                    }
                 }
                 std::string resultStr = SaveJsonToString(names, "  ");
                 return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(resultStr, 200, "application/json"));
@@ -479,7 +618,9 @@ HTTP_RESPONSE_CONST std::shared_ptr<httpserver::http_response> CommandManager::r
     } else if (p1 == "command" && plen > 1) {
         std::string command = req.get_path_pieces()[1];
         std::vector<std::string> args;
-        for (int x = 2; x < plen; x++) args.push_back(req.get_path_pieces()[x]);
+        for (int x = 2; x < plen; x++) {
+            args.push_back(req.get_path_pieces()[x]);
+        }
         auto f = commands.find(command);
         if (f != commands.end()) {
             LogDebug(VB_COMMAND, "Running command \"%s\"\n", command.c_str());
@@ -490,7 +631,9 @@ HTTP_RESPONSE_CONST std::shared_ptr<httpserver::http_response> CommandManager::r
                 count++;
             }
             if (r->isDone()) {
-                if (r->isError()) return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(r->get(), 500, "text/plain"));
+                if (r->isError()) {
+                    return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(r->get(), 500, "text/plain"));
+                }
                 return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(r->get(), 200, "text/plain"));
             } else {
                 return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Timeout running command", 500, "text/plain"));
@@ -508,7 +651,9 @@ HTTP_RESPONSE_CONST std::shared_ptr<httpserver::http_response> CommandManager::r
             std::string command = req.get_path_pieces()[1];
             Json::Value val = LoadJsonFromString(std::string(req.get_content()));
             std::vector<std::string> args;
-            for (int x = 0; x < val.size(); x++) args.push_back(val[x].asString());
+            for (int x = 0; x < val.size(); x++) {
+                args.push_back(val[x].asString());
+            }
             auto f = commands.find(command);
             if (f != commands.end()) {
                 LogDebug(VB_COMMAND, "Running command \"%s\"\n", command.c_str());
@@ -519,7 +664,9 @@ HTTP_RESPONSE_CONST std::shared_ptr<httpserver::http_response> CommandManager::r
                     count++;
                 }
                 if (r->isDone()) {
-                    if (r->isError()) return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(r->get(), 500, r->contentType()));
+                    if (r->isError()) {
+                        return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(r->get(), 500, r->contentType()));
+                    }
                     return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(r->get(), 200, r->contentType()));
                 } else {
                     return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Timeout running command", 500, "text/plain"));
@@ -536,7 +683,9 @@ HTTP_RESPONSE_CONST std::shared_ptr<httpserver::http_response> CommandManager::r
                 count++;
             }
             if (r->isDone()) {
-                if (r->isError()) return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(r->get(), 500, r->contentType()));
+                if (r->isError()) {
+                    return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(r->get(), 500, r->contentType()));
+                }
                 return std::shared_ptr<httpserver::http_response>(new httpserver::string_response(r->get(), 200, r->contentType()));
             } else {
                 return std::shared_ptr<httpserver::http_response>(new httpserver::string_response("Timeout running command", 500, "text/plain"));
@@ -548,8 +697,15 @@ HTTP_RESPONSE_CONST std::shared_ptr<httpserver::http_response> CommandManager::r
 }
 
 Json::Value CommandManager::ReplaceCommandKeywords(Json::Value cmd, std::map<std::string, std::string>& keywords) {
-    if (!cmd.isMember("args")) return cmd;
-    for (int i = 0; i < cmd["args"].size(); i++) cmd["args"][i] = ReplaceKeywords(cmd["args"][i].asString(), keywords);
+    if (!cmd.isMember("args"))
+        return cmd;
+
+    for (int i = 0; i < cmd["args"].size(); i++) {
+        std::string arg = cmd["args"][i].asString();
+
+        cmd["args"][i] = ReplaceKeywords(cmd["args"][i].asString(), keywords);
+    }
+
     return cmd;
 }
 
@@ -562,56 +718,75 @@ int CommandManager::TriggerPreset(int slot, std::map<std::string, std::string>& 
             }
         }
     }
+
     return 1;
 }
 
 int CommandManager::TriggerPreset(int slot) {
     std::map<std::string, std::string> keywords;
+
     return TriggerPreset(slot, keywords);
 }
 
 int CommandManager::TriggerPreset(std::string name, std::map<std::string, std::string>& keywords) {
-    if (!presets.isMember(name)) return 0;
+    if (!presets.isMember(name))
+        return 0;
+
     for (int i = 0; i < presets[name].size(); i++) {
         Json::Value cmd = ReplaceCommandKeywords(presets[name][i], keywords);
         run(cmd);
     }
+
     return 1;
 }
 
 int CommandManager::TriggerPreset(std::string name) {
     std::map<std::string, std::string> keywords;
+
     return TriggerPreset(name, keywords);
 }
 
 void CommandManager::LoadPresets() {
     LogDebug(VB_COMMAND, "Loading Command Presets\n");
+
     char id[6];
     memset(id, 0, sizeof(id));
+
     std::string commandsFile = FPP_DIR_CONFIG("/commandPresets.json");
+
     Json::Value allCommands;
-    if (FileExists(commandsFile)) allCommands = LoadJsonFromFile(commandsFile);
-    else {
+
+    if (FileExists(commandsFile)) {
+        // Load new config file
+        allCommands = LoadJsonFromFile(commandsFile);
+    } else {
+        // Convert any old events to new format
         Json::Value commands(Json::arrayValue);
+
         for (int major = 1; major <= 25; major++) {
             for (int minor = 1; minor <= 25; minor++) {
                 snprintf(id, sizeof(id), "%02d_%02d", major, minor);
                 std::string filename = FPP_DIR_MEDIA(std::string("/events/") + id + ".fevt");
+
                 if (FileExists(filename)) {
                     LogDebug(VB_COMMAND, "Converting old %s event to a Command Preset\n", id);
+
                     Json::Value event;
                     if (LoadJsonFromFile(filename, event)) {
                         event.removeMember("majorId");
                         event.removeMember("minorId");
                         event["presetSlot"] = 0;
+
                         commands.append(event);
                     }
                 }
             }
         }
+
         allCommands["commands"] = commands;
         SaveJsonToFile(allCommands, commandsFile, "\t");
     }
+
     if (allCommands.isMember("commands")) {
         for (int i = 0; i < allCommands["commands"].size(); i++) {
             if (presets.isMember(allCommands["commands"][i]["name"].asString())) {

--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -6666,27 +6666,35 @@ function SetupSelectableTableRow (info) {
 }
 
 function DialogOK (title, message) {
-	DoModalDialog({
-		id: 'dialogOKPopup',
-		title: title,
-		body: message,
-		class: 'modal-sm',
-		keyboard: true,
-		backdrop: true,
-		buttons: {
-			Close: {
-				click: function () {
-					CloseModalDialog('dialogOKPopup');
-				},
-				class: 'btn-success'
-			}
-		}
-	});
+    DoModalDialog({
+        id: 'dialogOKPopup',
+        title: title,
+        body: message,
+        class: 'modal-sm',
+        keyboard: true,
+        backdrop: true,
+        buttons: {
+            Close: {
+                click: function () {
+                    CloseModalDialog('dialogOKPopup');
+                },
+                class: 'btn-success'
+            }
+        },
+        open: function() {
+            $('#dialogOKPopup').css('z-index', 1060);
+            $('.modal-backdrop').last().css('z-index', 1059);
+        },
+        close: function() {
+            $('.modal-backdrop').remove(); // Remove lingering backdrop
+            $('body').removeClass('modal-open').css('padding-right', ''); // Reset body state
+        }
+    });
 }
 
 // Simple wrapper for now, but we may highlight this somehow later
 function DialogError (title, message) {
-	DialogOK(title, message);
+    DialogOK(title, message);
 }
 
 // page visibility prefixing


### PR DESCRIPTION
Error Dialog Hidden Behind Other Modals

The error popup (dialogOKPopup) was getting stuck behind other modals because they all had the same z-index (1055).
Fix: Increased its z-index to 1060 so it always appears on top.
Backdrop Stuck After Closing the Modal

After closing the error popup, the screen stayed dimmed and unresponsive until a page refresh.
Fix: Updated the "Close" button to properly remove the modal, its backdrop, and restore the page’s normal state.
