### PR TITLE
Fix z-index conflict and backdrop cleanup in DialogOK

### DIFF
--- a/www/help.php
+++ b/www/help.php
@@ -1,114 +1,111 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-	<?php
-	include 'common/htmlMeta.inc';
-	require_once('config.php');
-	require_once('common.php');
+    <?php
+    include 'common/htmlMeta.inc';
+    require_once('config.php');
+    require_once('common.php');
 
-	$helpPages = array(
-		'help/pixeloverlaymodels.php' => 'Real-Time Pixel Overlay Models'
-	);
+    $helpPages = array(
+        'help/pixeloverlaymodels.php' => 'Real-Time Pixel Overlay Models'
+    );
 
-	include 'common/menuHead.inc'; ?>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<title><? echo $pageTitle; ?></title>
+    include 'common/menuHead.inc'; ?>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title><?php echo $pageTitle; ?></title>
+    <style>
+        /* Add minimal CSS for better spacing and separation */
+        .help-section {
+            padding: 15px;
+            margin-bottom: 20px;
+            background-color: #f8f9fa; /* Light background similar to the first image */
+            border-radius: 5px;
+        }
+        .help-section ul {
+            padding-left: 0;
+        }
+        .help-section li {
+            margin-bottom: 10px;
+        }
+        .help-section h3 {
+            margin-bottom: 15px;
+        }
+    </style>
 </head>
-
 <body>
-	<div id="bodyWrapper">
-		<?php
-		$activeParentMenuItem = 'help';
-		include 'menu.inc'; ?>
-		<div class="mainContainer">
+    <div id="bodyWrapper">
+        <?php
+        $activeParentMenuItem = 'help';
+        include 'menu.inc'; ?>
+        <div class="mainContainer">
+            <h1 class="title">Help</h1>
+            <div class="pageContent">
+                <h2>Get Help</h2>
+                <p>Need assistance with FPP? Explore the resources below.</p>
 
-			<h1 class="title">Help</h1>
-			<div class="pageContent">
-				<h2>Get Help</h2>
-				<div class="row">
-					<div class="col-sm-12 col-md-6 col-xl-4">
-						<h3>Places to get help</h3>
-						<ul class="no-bullets">
-							<li><a class="<?= $externalLinkClass ?> link-to-fpp-manual"
-									href="https://added-by-javascript.net" target="_blank" rel="noopener noreferrer"><i
-										class="fas fa-book"></i>
-									FPP has an extensive manual - FPP Manual <i
-										class="fas fa-external-link-alt external-link"></i></a></li>
-							<li><a class="<?= $externalLinkClass ?>"
-									href="https://www.facebook.com/groups/1554782254796752" target="_blank"
-									rel="noopener noreferrer"><i class="fas fa-comments"></i> Got a
-									question?
-									Join
-									the FPP Facebook group <i class="fas fa-external-link-alt external-link"></i></a>
-							</li>
-							<li><a class="<?= $externalLinkClass ?>" href="https://falconchristmas.com/forum"
-									target="_blank" rel="noopener noreferrer"><i class="fas fa-comments"></i> or the FPP
-									Forums <i class="fas fa-external-link-alt external-link"></i></a></li>
+                <div class="row">
+                    <div class="col-sm-12 col-md-6 col-xl-4">
+                        <div class="help-section">
+                            <h3>Places to Get Help</h3>
+                            <ul class="no-bullets">
+                                <li><a class="<?php echo $externalLinkClass; ?> link-to-fpp-manual"
+                                       href="https://added-by-javascript.net" target="_blank" rel="noopener noreferrer">
+                                       <i class="fas fa-book"></i> FPP has an extensive manual - FPP Manual
+                                       <i class="fas fa-external-link-alt external-link"></i></a></li>
+                                <li><a class="<?php echo $externalLinkClass; ?>"
+                                       href="https://www.facebook.com/groups/1554782254796752" target="_blank" rel="noopener noreferrer">
+                                       <i class="fas fa-comments"></i> Got a question? Join the FPP Facebook group
+                                       <i class="fas fa-external-link-alt external-link"></i></a></li>
+                                <li><a class="<?php echo $externalLinkClass; ?>" href="https://falconchristmas.com/forum" target="_blank" rel="noopener noreferrer">
+                                       <i class="fas fa-comments"></i> or the FPP Forums
+                                       <i class="fas fa-external-link-alt external-link"></i></a></li>
+                                <li><a class="<?php echo $externalLinkClass; ?>" href="https://xlights.org/zoom/" target="_blank" rel="noopener noreferrer">
+                                       <i class="fas fa-headphones"></i> Prefer to talk? Join the xLights Zoom room
+                                       <i class="fas fa-external-link-alt external-link"></i></a></li>
+                                <li><a class="<?php echo $externalLinkClass; ?>" href="https://github.com/FalconChristmas/fpp/issues" target="_blank" rel="noopener noreferrer">
+                                       <i class="fas fa-bug"></i> Need to log a bug? - Issue Tracker
+                                       <i class="fas fa-external-link-alt external-link"></i></a></li>
+                            </ul>
+                        </div>
+                    </div>
 
-							<li><a class="<?= $externalLinkClass ?>" href="https://xlights.org/zoom/" target="_blank"
-									rel="noopener noreferrer"><i class="fas fa-headphones"></i> Prefer to talk? Join the
-									xLights
-									Zoom room <i class="fas fa-external-link-alt external-link"></i></a></li>
+                    <div class="col-sm-12 col-md-6 col-xl-4">
+                        <div class="help-section">
+                            <h3>FPP API</h3>
+                            <ul class="no-bullets">
+                                <li><a class="dropdown-item" href="apihelp.php">
+                                       <i class="fas fa-plug"></i> REST API Help</a></li>
+                                <li><a class="dropdown-item" href="commandhelp.php">
+                                       <i class="fas fa-cubes"></i> FPP Commands Help</a></li>
+                            </ul>
+                        </div>
+                    </div>
 
-							<li><a class="<?= $externalLinkClass ?>"
-									href="https://github.com/FalconChristmas/fpp/issues" target="_blank"
-									rel="noopener noreferrer"><i class="fas fa-bug"></i> Need to log a bug?
-									-
-									Issue
-									Tracker <i class="fas fa-external-link-alt external-link"></i></a></li>
-
-						</ul>
-					</div>
-
-					<div class="col-sm-12 col-md-6 col-xl-4">
-						<h3>FPP API</h3>
-						<ul class="no-bullets">
-							<li>
-								<a class="dropdown-item" href="apihelp.php"><i class="fas fa-plug"></i> REST API
-									Help</a>
-							</li>
-							<li>
-								<a class="dropdown-item" href="commandhelp.php"><i class="fas fa-cubes"></i> FPP
-									Commands Help</a>
-							</li>
-
-						</ul>
-					</div>
-
-					<div class="col-sm-12 col-md-6 col-xl-4">
-						<h3>Specific Topics</h3>
-						<ul>
-							<li><a href='javascript:void(0);'
-									onClick="helpPage='help/backup.php'; DisplayHelp();">Backup &
-									Restore</a>
-							</li>
-							<li><a href='javascript:void(0);'
-									onClick="helpPage='help/channeloutputs.php'; DisplayHelp();">Channel
-									Outputs</a></li>
-							<li><a href='javascript:void(0);' onClick="helpPage='help/gpio.php'; DisplayHelp();">GPIO
-									Input Triggers</a>
-							</li>
-							<li><a href='javascript:void(0);'
-									onClick="helpPage='help/networkconfig.php'; DisplayHelp();">Network
-									Config</a></li>
-							<li><a href='javascript:void(0);'
-									onClick="helpPage='help/outputprocessors.php'; DisplayHelp();">Output
-									Processors</a></li>
-							<li><a href='javascript:void(0);'
-									onClick="helpPage='help/pixeloverlaymodels.php'; DisplayHelp();">Real-Time Pixel
-									Overlay Models</a></li>
-							<li><a href='javascript:void(0);'
-									onClick="helpPage='help/scriptbrowser.php'; DisplayHelp();">Script
-									Repository Browser</a></li>
-						</ul>
-					</div>
-				</div>
-			</div>
-		</div>
-		<?php include 'common/footer.inc'; ?>
-	</div>
-
+                    <div class="col-sm-12 col-md-6 col-xl-4">
+                        <div class="help-section">
+                            <h3>Specific Topics</h3>
+                            <ul class="no-bullets"> <!-- Changed to no-bullets for consistency -->
+                                <li><a href="javascript:void(0);" onclick="helpPage='help/backup.php'; DisplayHelp();">
+                                       <i class="fas fa-archive"></i> Backup & Restore</a></li>
+                                <li><a href="javascript:void(0);" onclick="helpPage='help/channeloutputs.php'; DisplayHelp();">
+                                       <i class="fas fa-broadcast-tower"></i> Channel Outputs</a></li>
+                                <li><a href="javascript:void(0);" onclick="helpPage='help/gpio.php'; DisplayHelp();">
+                                       <i class="fas fa-microchip"></i> GPIO Input Triggers</a></li>
+                                <li><a href="javascript:void(0);" onclick="helpPage='help/networkconfig.php'; DisplayHelp();">
+                                       <i class="fas fa-network-wired"></i> Network Config</a></li>
+                                <li><a href="javascript:void(0);" onclick="helpPage='help/outputprocessors.php'; DisplayHelp();">
+                                       <i class="fas fa-cogs"></i> Output Processors</a></li>
+                                <li><a href="javascript:void(0);" onclick="helpPage='help/pixeloverlaymodels.php'; DisplayHelp();">
+                                       <i class="fas fa-layer-group"></i> Real-Time Pixel Overlay Models</a></li>
+                                <li><a href="javascript:void(0);" onclick="helpPage='help/scriptbrowser.php'; DisplayHelp();">
+                                       <i class="fas fa-code"></i> Script Repository Browser</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <?php include 'common/footer.inc'; ?>
+    </div>
 </body>
-
 </html>

--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -6666,27 +6666,35 @@ function SetupSelectableTableRow (info) {
 }
 
 function DialogOK (title, message) {
-	DoModalDialog({
-		id: 'dialogOKPopup',
-		title: title,
-		body: message,
-		class: 'modal-sm',
-		keyboard: true,
-		backdrop: true,
-		buttons: {
-			Close: {
-				click: function () {
-					CloseModalDialog('dialogOKPopup');
-				},
-				class: 'btn-success'
-			}
-		}
-	});
+    DoModalDialog({
+        id: 'dialogOKPopup',
+        title: title,
+        body: message,
+        class: 'modal-sm',
+        keyboard: true,
+        backdrop: true,
+        buttons: {
+            Close: {
+                click: function () {
+                    CloseModalDialog('dialogOKPopup');
+                },
+                class: 'btn-success'
+            }
+        },
+        open: function() {
+            $('#dialogOKPopup').css('z-index', 1060);
+            $('.modal-backdrop').last().css('z-index', 1059);
+        },
+        close: function() {
+            $('.modal-backdrop').remove(); // Remove lingering backdrop
+            $('body').removeClass('modal-open').css('padding-right', ''); // Reset body state
+        }
+    });
 }
 
 // Simple wrapper for now, but we may highlight this somehow later
 function DialogError (title, message) {
-	DialogOK(title, message);
+    DialogOK(title, message);
 }
 
 // page visibility prefixing


### PR DESCRIPTION
{one day i will figure this git stuff out, sorry for open/close pulls.}

Error Dialog Hidden Behind Other Modals

The error popup (dialogOKPopup) was getting stuck behind other modals because they all had the same z-index (1055).
Fix: Increased its z-index to 1060 so it always appears on top.
Backdrop Stuck After Closing the Modal

After closing the error popup, the screen stayed dimmed and unresponsive until a page refresh.
Fix: Updated the "Close" button to properly remove the modal, its backdrop, and restore the page’s normal state.
