### PR TITLE
Fix z-index conflict and backdrop cleanup in DialogOK

### DIFF
--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -6666,27 +6666,35 @@ function SetupSelectableTableRow (info) {
 }
 
 function DialogOK (title, message) {
-	DoModalDialog({
-		id: 'dialogOKPopup',
-		title: title,
-		body: message,
-		class: 'modal-sm',
-		keyboard: true,
-		backdrop: true,
-		buttons: {
-			Close: {
-				click: function () {
-					CloseModalDialog('dialogOKPopup');
-				},
-				class: 'btn-success'
-			}
-		}
-	});
+    DoModalDialog({
+        id: 'dialogOKPopup',
+        title: title,
+        body: message,
+        class: 'modal-sm',
+        keyboard: true,
+        backdrop: true,
+        buttons: {
+            Close: {
+                click: function () {
+                    CloseModalDialog('dialogOKPopup');
+                },
+                class: 'btn-success'
+            }
+        },
+        open: function() {
+            $('#dialogOKPopup').css('z-index', 1060);
+            $('.modal-backdrop').last().css('z-index', 1059);
+        },
+        close: function() {
+            $('.modal-backdrop').remove(); // Remove lingering backdrop
+            $('body').removeClass('modal-open').css('padding-right', ''); // Reset body state
+        }
+    });
 }
 
 // Simple wrapper for now, but we may highlight this somehow later
 function DialogError (title, message) {
-	DialogOK(title, message);
+    DialogOK(title, message);
 }
 
 // page visibility prefixing


### PR DESCRIPTION
Error Dialog Hidden Behind Other Modals

The error popup (dialogOKPopup) was getting stuck behind other modals because they all had the same z-index (1055). Fix: Increased its z-index to 1060 so it always appears on top. Backdrop Stuck After Closing the Modal

After closing the error popup, the screen stayed dimmed and unresponsive until a page refresh. Fix: Updated the "Close" button to properly remove the modal, its backdrop, and restore the page’s normal state.