### PR TITLE
JSON Setting Backup fixes for v8.5

### DIFF
--- a/www/api/controllers/backups.php
+++ b/www/api/controllers/backups.php
@@ -327,10 +327,15 @@ function process_jsonbackup_file_data_helper($json_config_backup_Data, $source_d
 
 		//Read the backup file so we can extract some metadata
 		$decoded_backup_data = json_decode(file_get_contents($backup_filepath . '/' . $backup_filename), true);
-		if (array_key_exists('backup_comment', $decoded_backup_data)) {
+		if (is_null($decoded_backup_data)) {
+			$decode_error_result = array('Status' => 'Error', 'Message' => 'Unable to decode JSON backup file (' . $backup_filepath . '/' . $backup_filename, 'IsReadable' => is_readable($backup_filepath . '/' . $backup_filename), 'FileContent' => file_get_contents($backup_filepath . '/' . $backup_filename));
+			error_log('process_jsonbackup_file_data_helper: ( ' . json_encode($decode_error_result) . ' )');
+		}
+
+		if (is_array($decoded_backup_data) && array_key_exists('backup_comment', $decoded_backup_data)) {
 			$backup_data_comment = $decoded_backup_data['backup_comment'];
 		}
-		if (array_key_exists('backup_trigger_source', $decoded_backup_data)) {
+		if (is_array($decoded_backup_data) && array_key_exists('backup_trigger_source', $decoded_backup_data)) {
 			$backup_data_trigger_source = $decoded_backup_data['backup_trigger_source'];
 		}
 

--- a/www/api/controllers/backups.php
+++ b/www/api/controllers/backups.php
@@ -77,44 +77,13 @@ function GetAvailableBackupsOnDevice()
 	$deviceName = params('DeviceName');
 	$dirs = array();
 
-//	// unmount just in case
-//	exec($SUDO . ' umount /mnt/tmp');
-//
-//	$unusable = CheckIfDeviceIsUsable($deviceName);
-//	if ($unusable != '') {
-//		array_push($dirs, $unusable);
-//		return json($dirs);
-//	}
-//
-//	exec($SUDO . ' mkdir -p /mnt/tmp');
-//
-//	$fsType = exec($SUDO . ' file -sL /dev/' . $deviceName, $output);
-//
-//	$mountCmd = '';
-//	// Same mount options used in scripts/copy_settings_to_storage.sh
-//	if (preg_match('/BTRFS/', $fsType)) {
-//		$mountCmd = "mount -t btrfs -o noatime,nodiratime,compress=zstd,nofail /dev/$deviceName /mnt/tmp";
-//	} else if ((preg_match('/FAT/', $fsType)) ||
-//		(preg_match('/DOS/', $fsType))) {
-//		$mountCmd = "mount -t auto -o noatime,nodiratime,exec,nofail,uid=500,gid=500 /dev/$deviceName /mnt/tmp";
-//	} else {
-//		// Default to ext4
-//		$mountCmd = "mount -t ext4 -o noatime,nodiratime,nofail /dev/$deviceName /mnt/tmp";
-//	}
-//
-//	exec($SUDO . ' ' . $mountCmd);
-//
-//	$dirs = GetAvailableBackupsFromDir('/mnt/tmp/');
-//
-//	exec($SUDO . ' umount /mnt/tmp');
-
 	$dirs = DriveMountHelper($deviceName, 'GetAvailableBackupsFromDir', array('/mnt/tmp/'));
 
 	return json($dirs);
 }
 
 /**
- * Handles mounting the specified device and performing
+ * Handles mounting the specified device and performing a task via the callback function (if specified)
  *
  * @param $deviceName string The device to be mounted
  * @param $usercallback_function string The function we should call once mounting is completed so we can do something in the directory
@@ -319,7 +288,7 @@ function GetAvailableJSONBackups(){
 		//$settings['jsonConfigBackupUSBLocation'] is the selected alternative drive to stop backups to
 		$json_config_backup_filenames_on_alternative = DriveMountHelper($settings['jsonConfigBackupUSBLocation'], 'read_directory_files', array($dir_jsonbackupsalternate, false, true, 'asc'));
 		//Process the backup files to extra some info about them
-		$json_config_backup_filenames_on_alternative = process_jsonbackup_file_data_helper($json_config_backup_filenames_on_alternative, $dir_jsonbackupsalternate);
+		$json_config_backup_filenames_on_alternative =  DriveMountHelper($settings['jsonConfigBackupUSBLocation'], 'process_jsonbackup_file_data_helper', array($json_config_backup_filenames_on_alternative, $dir_jsonbackupsalternate));
 	}
 	//Merge the results together, if the same backup name exists in the alternative backup location it will overwrite the record from the local cnfig directory
 	$json_config_backup_filenames_clean = array_merge($json_config_backup_filenames, $json_config_backup_filenames_on_alternative);

--- a/www/backup.php
+++ b/www/backup.php
@@ -1711,15 +1711,16 @@ function performBackup($area = "all", $allowDownload = true, $backupComment = "U
         //Create a copy of the areas array to manipulate
         $tmp_config_areas = $system_config_areas;
 
-        //Generate backup for selected area
+		//remove email as its in the general settings file and not a separate section (no actual file to backup)
+		unset($tmp_config_areas['settings']['file']['email']);
+
+		//Generate backup for selected area
         //AREA - ALL
         if (strtolower($area) == "all") {
             //combine all backup areas into a single file
 
             //remove the 'all' key and do some processing of areas array
             unset($tmp_config_areas['all']);
-            //remove email as its in the general settings file and not a separate section
-            unset($tmp_config_areas['settings']['file']['email']);
 
             //loop over the areas and process them
             foreach ($tmp_config_areas as $config_key => $config_data) {

--- a/www/backup.php
+++ b/www/backup.php
@@ -746,7 +746,7 @@ function processRestoreData($restore_area, $restore_area_data, $backup_version)
                         //otherwise existing (valid) config may be overwritten
                         if ($uploadData_IsProtected == false && $emailpass != "") {
                             WriteSettingToFile('emailpass', $emailpass);
-                            //Update the email config in the global settings array,  so can call the fuction that sets up and  writes out exim4 config
+                            //Update the email config in the global settings array,  so can call the function that sets up and  writes out exim4 config
                             $settings['emailserver'] = $restore_data['emailserver'];
                             if (array_key_exists('emailport', $restore_data)) {
                                 $settings['emailport'] = $restore_data['emailport'];
@@ -759,7 +759,6 @@ function processRestoreData($restore_area, $restore_area_data, $backup_version)
                             $settings['emailfromtext'] = $restore_data['emailfromtext'];
                             $settings['emailtoemail'] = $restore_data['emailtoemail'];
                             ApplyEmailConfig();
-                            $save_result = true;
                         }
                         $save_result = true;
                     }
@@ -781,12 +780,25 @@ function processRestoreData($restore_area, $restore_area_data, $backup_version)
                         }
 
                         if (!empty($data)) {
+                            //
                             $settings_restored[$restore_area_key][$restore_areas_idx]['ATTEMPT'] = true;
-                            //Timezone isn't stored in a seperate file anymore, it's now a setting
-                            WriteSettingToFile('TimeZone', $data);
-                            //Update the timezone on the system
-                            SetTimezone($data);
-                            $save_result = true;
+                            //Apply timezone settings via API
+							$url = 'http://localhost/api/settings/TimeZone';
+							//options for the request
+							$options = array(
+								'http' => array(
+									'header' => "Content-type: text/plain",
+									'method' => 'PUT',
+									'content' => $data,
+								),
+							);
+							$context = stream_context_create($options);
+
+							if (file_get_contents($url, false, $context) !== false) {
+								$save_result = true;
+							} else {
+								$save_result = true;
+							}
                         }
                     }
                 }


### PR DESCRIPTION
Collection of additional fixes to the JSON settings backup
Fixes HTTP 500 Error:
- When backing up up "System Settings" 
- If an the "Copy Backups to additional location" setting was used
- In some cases when trying to generate a backup  (added some logging to try understand the real cause, suspect it's probably just a corrupt backup)



Fix Timezone setting not being restored