### PR TITLE
Use Rsync to copy EEPROM to remote host

### DIFF
--- a/scripts/copy_settings_to_storage.sh
+++ b/scripts/copy_settings_to_storage.sh
@@ -152,9 +152,14 @@ for action in $@; do
         fi
         if [ -f "$SOURCE/config/cape-eeprom.bin" ]
         then
-            cp -v $SOURCE/config/cape-eeprom.bin $DEST/config/  2>&1 | IgnoreWarnings
-            chown fpp:fpp $DEST/config/cape-eeprom.bin 2> /dev/null
-            chmod 664 $DEST/config/cape-eeprom.bin 2> /dev/null
+            if [ "$DIRECTION" == "FROMREMOTE" ] || [ "$DIRECTION" == "TOREMOTE" ]
+            then
+              rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/config/cape-eeprom.bin $DEST/config  2>&1 | IgnoreWarnings
+            else
+              cp -v $SOURCE/config/cape-eeprom.bin $DEST/config/  2>&1 | IgnoreWarnings
+              chown fpp:fpp $DEST/config/cape-eeprom.bin 2> /dev/null
+              chmod 664 $DEST/config/cape-eeprom.bin 2> /dev/null
+            fi
         else
             echo "$SOURCE/config/cape-eeprom.bin does not exist, nothing to copy."
         fi


### PR DESCRIPTION
Small tweak to use RSYNC to copy the EEPROM file if using Backup to Remote or Restore From Remote options

Fixes #2219
