### PR TITLE
Enable websockets in FPP 9 Proxy

### DIFF
--- a/src/boot/FPPINIT.cpp
+++ b/src/boot/FPPINIT.cpp
@@ -571,6 +571,9 @@ static void setupNetwork(bool fullReload = false) {
             if (DHCPSERVER == 1) {
                 std::string address = interfaceSettings["ADDRESS"];
                 address = address.substr(0, address.find_last_of("."));
+                dhcpProxies += "RewriteCond %{HTTP:Upgrade}     \"websocket\" [NC]\n";
+                dhcpProxies += "RewriteCond %{HTTP:Connection}  \"Upgrade\" [NC]\n";
+                dhcpProxies += "RewriteRule ^" + address + ".([0-9:]*)/(.*)$  ws://" + address + ".$1/$2 [P,L]\n";
                 dhcpProxies += "RewriteRule ^" + address + ".([0-9:]*)$  http://" + address + ".$1/  [P,L]\n";
                 dhcpProxies += "RewriteRule ^" + address + ".([0-9:]*)/(.*)$  http://" + address + ".$1/$2  [P,L]\n\n";
             }

--- a/www/api/controllers/proxies.php
+++ b/www/api/controllers/proxies.php
@@ -132,6 +132,9 @@ function WriteProxyFile($proxies)
         $newht .= "RewriteRule ^" . $host . "$  " . $host . "/  [R,L]\n";
         $newht .= "RewriteRule ^" . $host . ":([0-9]*)$  http://" . $host . ":$1/  [P,L]\n";
         $newht .= "RewriteRule ^" . $host . ":([0-9]*)/(.*)$  http://" . $host . ":$1/$2  [P,L]\n";
+        $newht .= "RewriteCond %{HTTP:Upgrade}     \"websocket\" [NC]\n";
+        $newht .= "RewriteCond %{HTTP:Connection}  \"Upgrade\" [NC]\n";
+        $newht .= "RewriteRule ^" . $host . "/(.*)$  ws://" . $host . "/$1 [P,L]\n";
         $newht .= "RewriteRule ^" . $host . "/(.*)$  http://" . $host . "/$1  [P,L]\n\n";
     }
     file_put_contents("$mediaDirectory/config/proxy-config.conf", $newht);


### PR DESCRIPTION
FPP proxy doesn't currently work for boards that require websockets in their UI, such as the Baldrick series from ILightThat. 

These changes enable the proxying of websockets for all proxy targets.

Further details are available in the discussion of #2336 
For context, this PR is essentially a rework of the previously approved #1951 