### PR TITLE
Support pinned interfaces on ethtool output

### DIFF
--- a/www/troubleshoot-commands.json
+++ b/www/troubleshoot-commands.json
@@ -18,7 +18,7 @@
                 "Wired": {
                     "title": "Wired",
                     "description": "",
-                    "cmd": "for interface in $(ifconfig | grep -oP \"^\\w+(?=:)\" | grep \"eth\"); do echo \" \"; ethtool \"$interface\"; done;",
+                    "cmd": "for interface in $(ifconfig | grep -oP \"^\\w+(?=:)\" | egrep \"eth|enx\"); do echo \" \"; ethtool \"$interface\"; done;",
                     "platforms": [
                         "all"
                     ]
@@ -489,7 +489,9 @@
             "grpDisplayTitle": "GPIO",
             "grpDescription": "Set of tools for GPIO troubleshooting",
             "platforms": [
-                "Raspberry Pi", "BeagleBone Black", "BeagleBone 64"
+                "Raspberry Pi",
+                "BeagleBone Black",
+                "BeagleBone 64"
             ],
             "commands": {
                 "GPIO": {
@@ -497,7 +499,9 @@
                     "description": "Information about the GPIO chips on the system",
                     "cmd": "gpiodetect",
                     "platforms": [
-                        "Raspberry Pi", "BeagleBone Black", "BeagleBone 64"
+                        "Raspberry Pi",
+                        "BeagleBone Black",
+                        "BeagleBone 64"
                     ]
                 },
                 "GPIOInfo": {
@@ -505,7 +509,9 @@
                     "description": "Information about the GPIO lines on the system",
                     "cmd": "gpioinfo",
                     "platforms": [
-                        "Raspberry Pi", "BeagleBone Black", "BeagleBone 64"
+                        "Raspberry Pi",
+                        "BeagleBone Black",
+                        "BeagleBone 64"
                     ]
                 },
                 "pinctrl": {


### PR DESCRIPTION
Before this change only interfaces with the syntax of "eth?" were displayced in the ethtool output.  Changed this to included pinned interfaces.

Before
``` text
fpp@FPP-Center-Dormer:~ $ for interface in $(ifconfig | grep -oP "^\\w+(?=:)" | grep "eth"); do echo " "; ethtool "$interface"; done;
 
Settings for eth0:
        Supported ports: [ TP    MII ]
        Supported link modes:   10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Half 1000baseT/Full
        Supported pause frame use: Transmit-only
        Supports auto-negotiation: Yes
        Supported FEC modes: Not reported
        Advertised link modes:  10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Half 1000baseT/Full
        Advertised pause frame use: Transmit-only
        Advertised auto-negotiation: Yes
        Advertised FEC modes: Not reported
        Speed: Unknown!
        Duplex: Unknown! (255)
        Auto-negotiation: on
        master-slave cfg: preferred slave
        master-slave status: unknown
        Port: Twisted Pair
        PHYAD: 1
        Transceiver: external
        MDI-X: Unknown
netlink error: Operation not permitted
        Link detected: no
```

After
``` text
fpp@FPP-Center-Dormer:~ $ for interface in $(ifconfig | grep -oP "^\\w+(?=:)" | egrep "eth|enx"); do echo " "; ethtool "$interface"; done;
 
Settings for enx00e04c6804e0:
        Supported ports: [ TP    MII ]
        Supported link modes:   10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Half 1000baseT/Full
        Supported pause frame use: No
        Supports auto-negotiation: Yes
        Supported FEC modes: Not reported
        Advertised link modes:  10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
        Advertised pause frame use: No
        Advertised auto-negotiation: Yes
        Advertised FEC modes: Not reported
        Link partner advertised link modes:  10baseT/Half 10baseT/Full
                                             100baseT/Half 100baseT/Full
        Link partner advertised pause frame use: No
        Link partner advertised auto-negotiation: Yes
        Link partner advertised FEC modes: Not reported
        Speed: 100Mb/s
        Duplex: Full
        Auto-negotiation: on
        Port: MII
        PHYAD: 32
        Transceiver: internal
netlink error: Operation not permitted
        Current message level: 0x00007fff (32767)
                               drv probe link timer ifdown ifup rx_err tx_err tx_queued intr tx_done rx_status pktdata hw wol
        Link detected: yes
 
Settings for enx00e04c68426a:
        Supported ports: [ TP    MII ]
        Supported link modes:   10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Half 1000baseT/Full
        Supported pause frame use: No
        Supports auto-negotiation: Yes
        Supported FEC modes: Not reported
        Advertised link modes:  10baseT/Half 10baseT/Full
        Advertised pause frame use: No
        Advertised auto-negotiation: Yes
        Advertised FEC modes: Not reported
        Link partner advertised link modes:  10baseT/Half 10baseT/Full
                                             100baseT/Half 100baseT/Full
                                             1000baseT/Full
        Link partner advertised pause frame use: No
        Link partner advertised auto-negotiation: Yes
        Link partner advertised FEC modes: Not reported
        Speed: 10Mb/s
        Duplex: Full
        Auto-negotiation: on
        Port: MII
        PHYAD: 32
        Transceiver: internal
netlink error: Operation not permitted
        Current message level: 0x00007fff (32767)
                               drv probe link timer ifdown ifup rx_err tx_err tx_queued intr tx_done rx_status pktdata hw wol
        Link detected: yes
 
Settings for eth0:
        Supported ports: [ TP    MII ]
        Supported link modes:   10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Half 1000baseT/Full
        Supported pause frame use: Transmit-only
        Supports auto-negotiation: Yes
        Supported FEC modes: Not reported
        Advertised link modes:  10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Half 1000baseT/Full
        Advertised pause frame use: Transmit-only
        Advertised auto-negotiation: Yes
        Advertised FEC modes: Not reported
        Speed: Unknown!
        Duplex: Unknown! (255)
        Auto-negotiation: on
        master-slave cfg: preferred slave
        master-slave status: unknown
        Port: Twisted Pair
        PHYAD: 1
        Transceiver: external
        MDI-X: Unknown
netlink error: Operation not permitted
        Link detected: no
```