### PR TITLE
Remote FileCopy CSP Logic Fix

### DIFF
--- a/www/backup.php
+++ b/www/backup.php
@@ -205,32 +205,34 @@ function CSP_AllowRemoteSystems()
 	global $mediaDirectory, $fppDir;
 	$backupHosts = getKnownFPPSystems();
 	$http_backupHostsAdded = 0;
-	$csp_config_path = $mediaDirectory . '/config/csp_allowed_domains.json';
+	$csp_config_path = $mediaDirectory . "/config/csp_allowed_domains.json";
+	$apache_csp_update_script_path = $fppDir . "/scripts/ManageApacheContentPolicy.sh";
 
-	if (file_exists($csp_config_path)) {
-		$csp_allowed_domains = json_decode(file_get_contents($csp_config_path), true);
+	if (!file_exists($csp_config_path)) {
+		//Run the apache shell script and let it create a blank csp_allowed_domains.json file
+		shell_exec("sudo bash $apache_csp_update_script_path regenerate-norestart 2>&1");
+	}
 
-		//Insert known FPP systems into csp_config
-		foreach ($backupHosts as $csp_backupHost) {
-            $csp_hostToAdd = "http://" . $csp_backupHost;
-            
-			if (!in_array($csp_hostToAdd, $csp_allowed_domains['connect-src'])) {
-				$csp_allowed_domains['connect-src'][] = $csp_hostToAdd;
-				$http_backupHostsAdded++;
-			}
+	$csp_allowed_domains = json_decode(file_get_contents($csp_config_path), true);
+
+	//Insert known FPP systems into csp_config
+	foreach ($backupHosts as $csp_backupHost) {
+		$csp_hostToAdd = "http://" . $csp_backupHost;
+
+		if (!in_array($csp_hostToAdd, $csp_allowed_domains['connect-src'])) {
+			$csp_allowed_domains['connect-src'][] = $csp_hostToAdd;
+			$http_backupHostsAdded++;
 		}
+	}
 
-		//If we have hosts to add
-		if ($http_backupHostsAdded > 0) {
-			if (file_put_contents($csp_config_path, json_encode($csp_allowed_domains, JSON_PRETTY_PRINT)) !== false) {
-				//Regenerate CSP
-				$script_path = $fppDir . "/scripts/ManageApacheContentPolicy.sh";
-
-				// Make sure the script has execute permissions
-				if (shell_exec("sudo bash $script_path regenerate 2>&1") !== NULL) {
-					//Cause page refresh to get new content policy
-					echo "<script>location.reload();</script>";
-				}
+	//If we have hosts to add
+	if ($http_backupHostsAdded > 0) {
+		if (file_put_contents($csp_config_path, json_encode($csp_allowed_domains, JSON_PRETTY_PRINT)) !== false) {
+			//Regenerate CSP
+			// Make sure the script has execute permissions
+			if (shell_exec("sudo bash $apache_csp_update_script_path regenerate 2>&1") !== NULL) {
+				//Cause page refresh to get new content policy
+				echo "<script>location.reload();</script>";
 			}
 		}
 	}


### PR DESCRIPTION
If no csp_allowed_domains.json exists, generate a blank one using existing shell script, so hosts can actually be added