### PR TITLE
Add PHPUnit test framework and Centralize shell command execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ www/warnings.json
 www/warnings_full.json
 fppdLog.txt
 _notes
+.phpunit.result.cache

--- a/www/common.php
+++ b/www/common.php
@@ -1,5 +1,6 @@
 <?php
 require_once "config.php";
+require_once __DIR__ . '/lib/bootstrap.php';
 
 function check($var, $var_name = "", $function_name = "")
 {

--- a/www/cronjobs.php
+++ b/www/cronjobs.php
@@ -42,13 +42,13 @@
 
     static public function getJobs()
     {
-      $result = fpp()->command->run('crontab -l');
+      $result = fpp()->shell->run('crontab -l');
       return self::stringToArray((string) $result);
     }
 
     static public function saveJobs($jobs = array())
     {
-      return (string) fpp()->command
+      return (string) fpp()->shell
         ->run('echo "' . self::arrayToString($jobs) . '" | crontab -');
     }
 

--- a/www/cronjobs.php
+++ b/www/cronjobs.php
@@ -42,14 +42,14 @@
 
     static public function getJobs()
     {
-      $output = shell_exec('crontab -l');
-      return self::stringToArray($output);
+      $result = fpp()->command->run('crontab -l');
+      return self::stringToArray((string) $result);
     }
 
     static public function saveJobs($jobs = array())
     {
-      $output = shell_exec('echo "' . self::arrayToString($jobs) . '" | crontab -');
-      return $output;
+      return (string) fpp()->command
+        ->run('echo "' . self::arrayToString($jobs) . '" | crontab -');
     }
 
     static public function doesJobExist($job = '')

--- a/www/lib/Command/CommandExecutor.php
+++ b/www/lib/Command/CommandExecutor.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace FalconChristmas\Fpp\Command;
+
+/**
+ * Thin wrapper around exec() to keep shell interactions centralized/testable.
+ */
+class CommandExecutor
+{
+    /**
+     * @param string $command
+     * @param bool $redirectStdErr
+     * @return CommandResult
+     */
+    public function run(string $command, bool $redirectStdErr = true)
+    {
+        if ($redirectStdErr) {
+            $command .= ' 2>&1';
+        }
+
+        $output = [];
+        $exitCode = 0;
+        exec($command, $output, $exitCode);
+
+        return new CommandResult($command, $output, $exitCode);
+    }
+}

--- a/www/lib/Command/CommandResult.php
+++ b/www/lib/Command/CommandResult.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace FalconChristmas\Fpp\Command;
+
+class CommandResult
+{
+    private string $command;
+    private array $output;
+    private int $exitCode;
+
+    /**
+     * @param string $command
+     * @param array<int, string> $output
+     * @param int $exitCode
+     */
+    public function __construct(string $command, array $output, int $exitCode)
+    {
+        $this->command = $command;
+        $this->output = $output;
+        $this->exitCode = $exitCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCommand(): string
+    {
+        return $this->command;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getOutput(): array
+    {
+        return $this->output;
+    }
+
+    /**
+     * @return int
+     */
+    public function getExitCode(): int
+    {
+        return $this->exitCode;
+    }
+
+    /**
+     * @return bool
+     */
+    public function wasSuccessful(): bool
+    {
+        return $this->exitCode === 0;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return implode("\n", $this->output);
+    }
+}

--- a/www/lib/Container/Container.php
+++ b/www/lib/Container/Container.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace FalconChristmas\Fpp\Container;
+
+use FalconChristmas\Fpp\Command\CommandExecutor;
+use FalconChristmas\Fpp\Container\Exception\ContainerException;
+use FalconChristmas\Fpp\Container\Exception\NotFoundException;
+use Throwable;
+
+/**
+ * Minimal IoC container to centralize service access inside the web UI.
+ *
+ * @property CommandExecutor $command
+ */
+class Container
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private $bindings = [];
+
+    /**
+     * @var array<string, bool>
+     */
+    private $singletons = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    private $instances = [];
+
+    /**
+     * Register a service factory or instance.
+     *
+     * @param string $key
+     * @param mixed  $resolver
+     */
+    public function bind(string $key, mixed $resolver): void
+    {
+        $this->bindings[$key] = $resolver;
+        unset($this->singletons[$key], $this->instances[$key]);
+    }
+
+    /**
+     * Register a singleton factory or instance.
+     *
+     * @param string $key
+     * @param mixed  $resolver
+     */
+    public function singleton(string $key, mixed $resolver): void
+    {
+        $this->bindings[$key] = $resolver;
+        $this->singletons[$key] = true;
+        unset($this->instances[$key]);
+    }
+
+    /**
+     * Register an already instantiated singleton.
+     *
+     * @param string $key
+     * @param mixed  $instance
+     */
+    public function instance(string $key, mixed $instance): void
+    {
+        $this->instances[$key] = $instance;
+        $this->singletons[$key] = true;
+        unset($this->bindings[$key]);
+    }
+
+    /**
+     * Determine if a binding exists.
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->bindings) || array_key_exists($key, $this->instances);
+    }
+
+    /**
+     * Resolve a binding or singleton.
+     *
+     * @param string $key
+     * @return mixed
+     * @throws NotFoundException
+     * @throws ContainerException
+     */
+    public function make(string $key): mixed
+    {
+        if (array_key_exists($key, $this->instances)) {
+            return $this->instances[$key];
+        }
+
+        if (!array_key_exists($key, $this->bindings)) {
+            throw new NotFoundException("Service '{$key}' not registered in the container.");
+        }
+
+        $resolver = $this->bindings[$key];
+        try {
+            $instance = $this->resolve($resolver);
+        } catch (Throwable $e) {
+            throw new ContainerException("Error resolving service '{$key}'.", 0, $e);
+        }
+
+        if (isset($this->singletons[$key])) {
+            $this->instances[$key] = $instance;
+            unset($this->bindings[$key]);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * Remove a binding and its cached instance.
+     *
+     * @param string $key
+     */
+    public function forget(string $key): void
+    {
+        unset($this->bindings[$key], $this->instances[$key], $this->singletons[$key]);
+    }
+
+    /**
+     * Remove all bindings, singletons, and cached instances.
+     */
+    public function clear(): void
+    {
+        $this->bindings = [];
+        $this->singletons = [];
+        $this->instances = [];
+    }
+
+    /**
+     * Magic getter for syntactic sugar: $container->service
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function __get(string $key): mixed
+    {
+        return $this->make($key);
+    }
+
+    /**
+     * PSR-11 compatibility.
+     *
+     * @param string $id
+     * @return mixed
+     */
+    public function get(string $id): mixed
+    {
+        return $this->make($id);
+    }
+
+    /**
+     * Resolve the value for a binding.
+     *
+     * @param mixed $resolver
+     * @return mixed
+     */
+    private function resolve(mixed $resolver): mixed
+    {
+        if (is_callable($resolver)) {
+            return $resolver($this);
+        }
+
+        return $resolver;
+    }
+}

--- a/www/lib/Container/Container.php
+++ b/www/lib/Container/Container.php
@@ -2,7 +2,7 @@
 
 namespace FalconChristmas\Fpp\Container;
 
-use FalconChristmas\Fpp\Command\CommandExecutor;
+use FalconChristmas\Fpp\Shell\ShellExecutor;
 use FalconChristmas\Fpp\Container\Exception\ContainerException;
 use FalconChristmas\Fpp\Container\Exception\NotFoundException;
 use Throwable;
@@ -10,7 +10,7 @@ use Throwable;
 /**
  * Minimal IoC container to centralize service access inside the web UI.
  *
- * @property CommandExecutor $command
+ * @property ShellExecutor $shell
  */
 class Container
 {

--- a/www/lib/Container/Exception/ContainerException.php
+++ b/www/lib/Container/Exception/ContainerException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace FalconChristmas\Fpp\Container\Exception;
+
+use RuntimeException;
+
+class ContainerException extends RuntimeException
+{
+}

--- a/www/lib/Container/Exception/NotFoundException.php
+++ b/www/lib/Container/Exception/NotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace FalconChristmas\Fpp\Container\Exception;
+
+use RuntimeException;
+
+class NotFoundException extends RuntimeException
+{
+}

--- a/www/lib/Shell/ShellExecutor.php
+++ b/www/lib/Shell/ShellExecutor.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace FalconChristmas\Fpp\Command;
+namespace FalconChristmas\Fpp\Shell;
 
 /**
  * Thin wrapper around exec() to keep shell interactions centralized/testable.
  */
-class CommandExecutor
+class ShellExecutor
 {
     /**
      * @param string $command
      * @param bool $redirectStdErr
-     * @return CommandResult
+     * @return ShellResult
      */
-    public function run(string $command, bool $redirectStdErr = true)
+    public function run(string $command, bool $redirectStdErr = true): ShellResult
     {
         if ($redirectStdErr) {
             $command .= ' 2>&1';
@@ -22,6 +22,6 @@ class CommandExecutor
         $exitCode = 0;
         exec($command, $output, $exitCode);
 
-        return new CommandResult($command, $output, $exitCode);
+        return new ShellResult($command, $output, $exitCode);
     }
 }

--- a/www/lib/Shell/ShellResult.php
+++ b/www/lib/Shell/ShellResult.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace FalconChristmas\Fpp\Command;
+namespace FalconChristmas\Fpp\Shell;
 
-class CommandResult
+class ShellResult
 {
     private string $command;
     private array $output;

--- a/www/lib/bootstrap.php
+++ b/www/lib/bootstrap.php
@@ -1,0 +1,43 @@
+<?php
+
+use FalconChristmas\Fpp\Container\Container;
+use FalconChristmas\Fpp\Command\CommandExecutor;
+
+spl_autoload_register(function ($class) {
+    $prefix = 'FalconChristmas\\Fpp\\';
+    $baseDir = __DIR__ . '/';
+
+    if (!startsWith($class, $prefix)) {
+        return;
+    }
+
+    $relativeClass = substr($class, strlen($prefix));
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+if (!function_exists('fpp')) {
+    /**
+     * Global helper to access the shared service container.
+     *
+     * @return \FalconChristmas\Fpp\Container\Container
+     */
+    function fpp()
+    {
+        static $container = null;
+
+        if ($container === null) {
+            $container = new Container();
+
+            // Default service bindings; tests can override them as needed.
+            $container->singleton('command', function () {
+                return new CommandExecutor();
+            });
+        }
+
+        return $container;
+    }
+}

--- a/www/lib/bootstrap.php
+++ b/www/lib/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
 use FalconChristmas\Fpp\Container\Container;
-use FalconChristmas\Fpp\Command\CommandExecutor;
+use FalconChristmas\Fpp\Shell\ShellExecutor;
 
 spl_autoload_register(function ($class) {
     $prefix = 'FalconChristmas\\Fpp\\';
@@ -33,8 +33,8 @@ if (!function_exists('fpp')) {
             $container = new Container();
 
             // Default service bindings; tests can override them as needed.
-            $container->singleton('command', function () {
-                return new CommandExecutor();
+            $container->singleton('shell', function () {
+                return new ShellExecutor();
             });
         }
 

--- a/www/phpunit.xml
+++ b/www/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    backupGlobals="false"
+>
+    <testsuites>
+        <testsuite name="FPP Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/www/tests/Unit/CommandExecutorTest.php
+++ b/www/tests/Unit/CommandExecutorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use FalconChristmas\Fpp\Command\CommandExecutor;
+use FalconChristmas\Fpp\Command\CommandResult;
+use PHPUnit\Framework\TestCase;
+
+final class CommandExecutorTest extends TestCase
+{
+    public function testRunReturnsSuccessfulResult(): void
+    {
+        $executor = new CommandExecutor();
+        $result = $executor->run('echo success');
+
+        $this->assertInstanceOf(CommandResult::class, $result);
+        $this->assertSame('echo success 2>&1', $result->getCommand());
+        $this->assertSame(['success'], $result->getOutput());
+        $this->assertSame(0, $result->getExitCode());
+        $this->assertTrue($result->wasSuccessful());
+        $this->assertSame("success", (string) $result);
+    }
+
+    public function testRunWithoutRedirectStdErr(): void
+    {
+        $executor = new CommandExecutor();
+        $result = $executor->run('echo success', false);
+
+        $this->assertInstanceOf(CommandResult::class, $result);
+        $this->assertSame('echo success', $result->getCommand());
+        $this->assertSame(['success'], $result->getOutput());
+        $this->assertSame(0, $result->getExitCode());
+        $this->assertTrue($result->wasSuccessful());
+        $this->assertSame("success", (string) $result);
+    }
+
+    public function testRunCapturesFailureExitCode(): void
+    {
+        $executor = new CommandExecutor();
+        $result = $executor->run('php -r "exit(3);"');
+
+        $this->assertSame(3, $result->getExitCode());
+        $this->assertFalse($result->wasSuccessful());
+        $this->assertSame([], $result->getOutput());
+        $this->assertSame('', (string) $result);
+    }
+}

--- a/www/tests/Unit/ContainerTest.php
+++ b/www/tests/Unit/ContainerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use FalconChristmas\Fpp\Container\Container;
+use FalconChristmas\Fpp\Container\Exception\ContainerException;
+use FalconChristmas\Fpp\Container\Exception\NotFoundException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class ContainerTest extends TestCase
+{
+    public function testBindResolvesCallableEachTime(): void
+    {
+        $container = new Container();
+        $callCount = 0;
+
+        $container->bind(
+            'counter',
+            function () use (&$callCount) {
+                $callCount++;
+                return $callCount;
+            }
+        );
+
+        $this->assertSame(1, $container->make('counter'));
+        $this->assertSame(2, $container->make('counter'));
+        $this->assertTrue($container->has('counter'));
+    }
+
+    public function testSingletonCachesResolvedInstance(): void
+    {
+        $container = new Container();
+
+        $container->singleton('object', function () {
+            return new stdClass();
+        });
+
+        $first = $container->make('object');
+        $second = $container->make('object');
+
+        $this->assertSame($first, $second);
+        $this->assertTrue($container->has('object'));
+    }
+
+    public function testInstanceRegistersPreBuiltSingleton(): void
+    {
+        $container = new Container();
+        $instance = new stdClass();
+        $instance->value = 'preset';
+
+        $container->instance('preset', $instance);
+
+        $this->assertTrue($container->has('preset'));
+        $this->assertSame($instance, $container->make('preset'));
+    }
+
+    public function testForgetRemovesBindingsAndInstances(): void
+    {
+        $container = new Container();
+
+        $container->singleton('transient', function () {
+            return new stdClass();
+        });
+
+        $container->make('transient');
+        $this->assertTrue($container->has('transient'));
+
+        $container->forget('transient');
+        $this->assertFalse($container->has('transient'));
+
+        $this->expectException(NotFoundException::class);
+        $container->make('transient');
+    }
+
+    public function testMagicGetDelegatesToMake(): void
+    {
+        $container = new Container();
+        $container->bind('string', function () {
+            return 'value';
+        });
+
+        $this->assertSame('value', $container->string);
+    }
+
+    public function testMakeThrowsForUnknownBinding(): void
+    {
+        $container = new Container();
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage("Service 'missing' not registered in the container.");
+
+        $container->make('missing');
+    }
+
+    public function testCallableExceptionsAreWrappedInContainerException(): void
+    {
+        $container = new Container();
+        $container->bind('broken', function () {
+            throw new \LogicException('broken');
+        });
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage("Error resolving service 'broken'.");
+
+        $container->make('broken');
+    }
+
+    public function testClearRemovesAllEntries(): void
+    {
+        $container = new Container();
+        $container->singleton('one', function () {
+            return new stdClass();
+        });
+        $container->bind('two', function () {
+            return new stdClass();
+        });
+        $container->instance('three', new stdClass());
+
+        $container->make('one');
+        $container->make('two');
+
+        $container->clear();
+
+        $this->assertFalse($container->has('one'));
+        $this->assertFalse($container->has('two'));
+        $this->assertFalse($container->has('three'));
+
+        $this->expectException(NotFoundException::class);
+        $container->make('one');
+    }
+}

--- a/www/tests/Unit/CronjobsTest.php
+++ b/www/tests/Unit/CronjobsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use FalconChristmas\Fpp\Command\CommandResult;
+use FalconChristmas\Fpp\Shell\ShellResult;
 use PHPUnit\Framework\TestCase;
 
 final class CronjobsTest extends TestCase
@@ -37,18 +37,18 @@ final class CronjobsTest extends TestCase
             public array $nextOutput = [];
             public int $exitCode = 0;
 
-            public function run(string $command, bool $redirectStdErr = true): CommandResult
+            public function run(string $command, bool $redirectStdErr = true): ShellResult
             {
                 $this->lastCommand = $command;
 
-                return new CommandResult($command, $this->nextOutput, $this->exitCode);
+                return new ShellResult($command, $this->nextOutput, $this->exitCode);
             }
         };
 
         // Reset and swap the command executor.
         $container = fpp();
         $container->clear();
-        $container->instance('command', $this->fake);
+        $container->instance('shell', $this->fake);
     }
 
     public function testGetJobsRunsCrontabList(): void

--- a/www/tests/Unit/CronjobsTest.php
+++ b/www/tests/Unit/CronjobsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use FalconChristmas\Fpp\Command\CommandResult;
+use PHPUnit\Framework\TestCase;
+
+final class CronjobsTest extends TestCase
+{
+    private object $fake;
+    private static string $originalIncludePath;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$originalIncludePath = get_include_path();
+        set_include_path(__DIR__ . '/../stubs' . PATH_SEPARATOR . self::$originalIncludePath);
+
+        // cronjobs.php outputs HTML; buffer it while loading the Crontab class.
+        ob_start(function () {
+            return '';
+        });
+        require_once __DIR__ . '/../../cronjobs.php';
+        ob_end_clean();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        set_include_path(self::$originalIncludePath);
+    }
+
+    protected function setUp(): void
+    {
+        $this->fake = new class {
+            public string $lastCommand = '';
+            public array $nextOutput = [];
+            public int $exitCode = 0;
+
+            public function run(string $command, bool $redirectStdErr = true): CommandResult
+            {
+                $this->lastCommand = $command;
+
+                return new CommandResult($command, $this->nextOutput, $this->exitCode);
+            }
+        };
+
+        // Reset and swap the command executor.
+        $container = fpp();
+        $container->clear();
+        $container->instance('command', $this->fake);
+    }
+
+    public function testGetJobsRunsCrontabList(): void
+    {
+        $this->fake->nextOutput = ["job1\r\njob2\r\n"];
+
+        $jobs = \Crontab::getJobs();
+
+        $this->assertSame('crontab -l', $this->fake->lastCommand);
+        $this->assertSame(['job1', 'job2'], array_values($jobs));
+    }
+
+    public function testSaveJobsRunsCrontabWrite(): void
+    {
+        $jobs = ['* * * * * /bin/true', '0 1 * * * /usr/bin/backup'];
+
+        \Crontab::saveJobs($jobs);
+
+        $expected = 'echo "* * * * * /bin/true' . "\r\n" . '0 1 * * * /usr/bin/backup" | crontab -';
+        $this->assertSame($expected, $this->fake->lastCommand);
+    }
+}

--- a/www/tests/Unit/ShellExecutorTest.php
+++ b/www/tests/Unit/ShellExecutorTest.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use FalconChristmas\Fpp\Command\CommandExecutor;
-use FalconChristmas\Fpp\Command\CommandResult;
+use FalconChristmas\Fpp\Shell\ShellExecutor;
+use FalconChristmas\Fpp\Shell\ShellResult;
 use PHPUnit\Framework\TestCase;
 
-final class CommandExecutorTest extends TestCase
+final class ShellExecutorTest extends TestCase
 {
     public function testRunReturnsSuccessfulResult(): void
     {
-        $executor = new CommandExecutor();
+        $executor = new ShellExecutor();
         $result = $executor->run('echo success');
 
-        $this->assertInstanceOf(CommandResult::class, $result);
+        $this->assertInstanceOf(ShellResult::class, $result);
         $this->assertSame('echo success 2>&1', $result->getCommand());
         $this->assertSame(['success'], $result->getOutput());
         $this->assertSame(0, $result->getExitCode());
@@ -25,10 +25,10 @@ final class CommandExecutorTest extends TestCase
 
     public function testRunWithoutRedirectStdErr(): void
     {
-        $executor = new CommandExecutor();
+        $executor = new ShellExecutor();
         $result = $executor->run('echo success', false);
 
-        $this->assertInstanceOf(CommandResult::class, $result);
+        $this->assertInstanceOf(ShellResult::class, $result);
         $this->assertSame('echo success', $result->getCommand());
         $this->assertSame(['success'], $result->getOutput());
         $this->assertSame(0, $result->getExitCode());
@@ -38,7 +38,7 @@ final class CommandExecutorTest extends TestCase
 
     public function testRunCapturesFailureExitCode(): void
     {
-        $executor = new CommandExecutor();
+        $executor = new ShellExecutor();
         $result = $executor->run('php -r "exit(3);"');
 
         $this->assertSame(3, $result->getExitCode());

--- a/www/tests/bootstrap.php
+++ b/www/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/bootstrap.php';


### PR DESCRIPTION
This PR introduces a small, testable abstraction for shell command execution along with a lightweight service container.

## Key changes:
* Added `ShellExecutor` and `ShellResult` to centralize and abstract all shell interactions.
* Introduced a minimal IoC container and global `fpp()` helper for shared services.
* Refactored `cronjobs.php` to use the command executor instead of `shell_exec()`.
* Added PHPUnit configuration and initial unit tests covering the container, command execution, and cron job behavior.

## Why:
* Makes shell usage explicit, centralized, and mockable.
* Enables unit testing of code paths that previously required real system calls.
* Lays groundwork for future refactors without changing runtime behavior.

## Notes:
* No functional changes intended for production behavior.
* Further refactors (e.g. moving cronjobs to a dedicated class/file) intentionally left for follow-up PRs.