### PR TITLE
add tail follow to filemanager logs and handle tail streaming output

### DIFF
--- a/www/api/index.php
+++ b/www/api/index.php
@@ -63,6 +63,8 @@ dispatch_get('/file/move/:fileName', 'MoveFile'); // keep above file/:DirName
 dispatch_get('/files/zip/:DirNames', 'GetZipDir');
 dispatch_post('/file/:DirName/copy/:source/:dest', 'files_copy');
 dispatch_post('/file/:DirName/rename/:source/:dest', 'files_rename');
+dispatch_get('/file/:DirName/tailfollow/**', 'TailFollowFile');
+dispatch_post('/file/:DirName/tailfollow/**', 'StopTailFollow');
 dispatch_get('/file/:DirName/**', 'GetFile');
 dispatch_delete('/file/:DirName/**', 'DeleteFile');
 dispatch_post('/file/:DirName', 'PatchFile');

--- a/www/filemanager.php
+++ b/www/filemanager.php
@@ -603,6 +603,9 @@
                                         <input onclick="ButtonHandler('Logs', 'tailFile');"
                                             class="disableButtons noDirButton singleLogsButton" type="button"
                                             value="Tail" />
+                                        <input onclick="ButtonHandler('Logs', 'tailFollow');"
+                                            class="disableButtons noDirButton singleLogsButton" type="button"
+                                            value="Tail Follow" />
                                         <input onclick="ButtonHandler('Logs', 'download');"
                                             class="disableButtons noDirButton singleLogsButton multiLogsButton"
                                             type="button" value="Download" />

--- a/www/js/fpp-filemanager.js
+++ b/www/js/fpp-filemanager.js
@@ -335,6 +335,15 @@ function ButtonHandler (table, button) {
 				'Error, unable to view multiple files at the same time.'
 			);
 		}
+	} else if (button == 'tailFollow') {
+		if (selectedCount == 1) {
+			TailFollowFile(table, filename);
+		} else {
+			DialogError(
+				'Error',
+				'Error, unable to tail follow multiple files at the same time.'
+			);
+		}
 	} else if (button == 'viewImage') {
 		if (selectedCount == 1) {
 			ViewImage(filename);


### PR DESCRIPTION
#2508 

Adds a "Tail Follow" button to the Logs tab in File Manager that provides real-time log streaming (`tail -f`).

I have tried to capture user states and make sure the process gets killed on start/stop, users presses X button on modal, user refreshes the page, user navigates away from the page.  As a safety net, tail processes will timeout in 300 seconds.

## API Tests
As the GET api endpoint won't work correctly on apihelp.php because of streaming output I did not include it.  A future enhancement on the apihelp would be to have an attribute for non-testable and disable buttons.

```bash
# Valid request with quick timeout
timeout 2 curl -N "http://localhost/api/file/Logs/tailfollow/fppd.log?lines=5"

# Invalid directory - return 403
curl -s -w "\nHTTP %{http_code}\n" "http://localhost/api/file/Uploads/tailfollow/test.txt"
# Expected: HTTP 403

# Non-existent file - return 403
curl -s -w "\nHTTP %{http_code}\n" "http://localhost/api/file/Logs/tailfollow/fakefile.log"
# Expected: HTTP 403
```
## Functional Tests

### Basic Functionality

As part of the tests have terminal to check process state:

```bash
ps -ef | grep tail
```

You should see something like:
```bash
fpp@FPP-test:~ $ ps -ef | grep tail
fpp       1473 23977  0 12:39 ?        00:00:00 sh -c timeout 300 tail -n 100 -f '/home/fpp/media/logs/fppd.log' 2>&1
fpp       1474  1473  0 12:39 ?        00:00:00 timeout 300 tail -n 100 -f /home/fpp/media/logs/fppd.log
fpp       1475  1474  0 12:39 ?        00:00:00 tail -n 100 -f /home/fpp/media/logs/fppd.log
```

| Test | Steps | Expected Result | Process State |
|------|-------|-----------------|------------|
| Button visibility | navigate to File Manager → Logs tab | "Tail Follow" button exists | not running |
| Start stream | select a log file -> Click "Tail Follow" | modal opens, shows last 100 lines, streaming begins | running |
| Live updates | generate log activity | new log lines appear in real-time | running |
| Stop stream | click "Stop" button in modal | button changes to "Start", streaming stops | tail process should exit |
| Resume stream | click "Start" button | streaming resumes | Running |
| Close modal | click "Close" or X button | modal closes, stream stops, no console errors | tail process should exit |
| Tail Follow any new file | refresh the page| page refreshes | Tail Process should Exit |
| Tail Follow any new file | click Back button until you navigate away from File Manager| on different page | tail process should exit 
| Tail Follow any new file | click stop -> close -> tail follow any new file | button states should be reset to "stop" | Running