### PR TITLE
fix mobile timepicker from wiping out holidays in scheduler

### DIFF
--- a/www/scheduler.php
+++ b/www/scheduler.php
@@ -336,7 +336,16 @@ error_reporting(E_ALL);
         function SetupDatePicker(item) {
             if (hasTouch && window.innerWidth < 601) {
                 //use native date picker for small touchscreens (datepicker widget is bad experience on mobile)
-                $(item).attr('type', 'date');
+                //but skip if field contains a holiday name
+                $(item).each(function() {
+                    var val = $(this).val();
+                    if (val && !val.match(/^\d{4}[-\/]\d{2}[-\/]\d{2}$/)) {
+                        // value is a holiday, don't convert to native date picker
+                        // as it would clear the holiday value
+                        return true;
+                    }
+                    $(this).attr('type', 'date');
+                });
             } else {
                 $(item).datepicker({
                     'changeMonth': true,
@@ -455,7 +464,19 @@ error_reporting(E_ALL);
             var val = $(item).val();
             var re = new RegExp(/^\d{4}[-/]\d{2}[-/]\d{2}$/i);
             if (!val.match(re)) {
-                $(item).val(MAXYEAR + "-12-31");
+                // check if value is a valid holiday name before replacing
+                var isHoliday = false;
+                if (settings['locale'] && settings['locale']['holidays']) {
+                    for (var i in settings['locale']['holidays']) {
+                        if (settings['locale']['holidays'][i]['shortName'] == val) {
+                            isHoliday = true;
+                            break;
+                        }
+                    }
+                }
+                if (!isHoliday) {
+                    $(item).val(MAXYEAR + "-12-31");
+                }
             }
         }
 


### PR DESCRIPTION
#2507

I was able to replicate this using the mobile time picker. The time picker was attempting to convert the holiday dates and inputs only accept YYYY-MM-DD causing them to blank out.