### PR TITLE
fix command scheduler showing null and javascript error from undefined

### DIFF
--- a/www/scheduler.php
+++ b/www/scheduler.php
@@ -498,7 +498,7 @@ error_reporting(E_ALL);
 
         function GetScheduleEntryRowData(item) {
             var schType = $(item).find('.schType').val();
-            e = {};
+            var e = {};
             e.enabled = $(item).find('.schEnable').is(':checked') ? 1 : 0;
             e.sequence = 0;
 
@@ -525,10 +525,10 @@ error_reporting(E_ALL);
 
                 if (json == '') {
                     var cmd = {};
-                    cmd.command = command;
+                    cmd.command = $(item).find('.cmdTmplCommand').val() || '';
                     cmd.args = [];
                     json = JSON.stringify(cmd);
-                    $(row).find('.cmdTmplJSON').html(json);
+                    $(item).find('.cmdTmplJSON').html(json);
                 }
 
                 // Just in case, FPP Commands can't immediately repeat so disable
@@ -540,7 +540,7 @@ error_reporting(E_ALL);
 
                 var jdata = JSON.parse(json);
                 e.playlist = '';
-                e.command = $(item).find('.cmdTmplCommand').val();
+                e.command = $(item).find('.cmdTmplCommand').val() || '';
                 e.args = jdata.args;
 
                 if (jdata.hasOwnProperty('multisyncCommand')) {


### PR DESCRIPTION

## Test Core Problem
In scheduler.php:
To replicate before fix:
* Add row in Scheduler
* Select Schedule Type -> Command
* Save
* Refresh the page, a js error exists and you will now have "null unavailable" in your dropdown list.

After fix:
* Add row in Scheduler
* Select Schedule Type -> Command
* Save
* Refresh the page, NO js error exists and you will now have NOT have "null unavailable" in your dropdown list.

## Also fixes a global scoped variable (missing var).
```
// Before
e = {};
// After
var e = {};
```
