### PR TITLE
Fix asan flagging on json parsing

### DIFF
--- a/src/commands/Commands.h
+++ b/src/commands/Commands.h
@@ -15,6 +15,7 @@
 #include <httpserver.hpp>
 #include <list>
 #include <map>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -79,11 +80,18 @@ public:
             allowBlanks = ab;
             return *this;
         }
-        CommandArg& setContentList(const std::vector<std::string>& v) {
-            contentList = v;
+        CommandArg& setContentList(std::vector<std::string> v) {
+            contentList = std::move(v);
             return *this;
         }
-        CommandArg& setDefaultValue(const std::string& d) {
+        CommandArg& setContentListRange(std::span<const std::string_view> s) {
+            contentList.clear();
+            contentList.reserve(s.size());
+            for (auto& e : s)
+                contentList.emplace_back(e);
+            return *this;
+        }
+        CommandArg& setDefaultValue(std::string_view d) {
             defaultValue = d;
             return *this;
         }


### PR DESCRIPTION
Building and running with asan would lead to invalid reads in `RawWLEDEffect::fillVectors()`. This PR fixes that and refactors to use `string_view` for fewer heap allocations and temporary allocations.