### PR TITLE
update filesystems troubleshooting command to show human readable and subdirectory sizes

### DIFF
--- a/www/troubleshoot-commands.json
+++ b/www/troubleshoot-commands.json
@@ -91,7 +91,7 @@
                 "Filesystems": {
                     "title": "Filesystems",
                     "description": "",
-                    "cmd": "df -k",
+                    "cmd": "df -h ; echo ''; du -sh /home/fpp/media/*/ | sort -h",
                     "platforms": [
                         "all"
                     ]


### PR DESCRIPTION
#2517

Simple update to the filesystems command which allow better troubleshooting of what is taking up all the space in the media directories.

<img width="562" height="714" alt="Screenshot 2025-12-27 at 4 36 14 PM" src="https://github.com/user-attachments/assets/75013e2f-cd52-42df-807f-8d12cdf03713" />
