### PR TITLE
Playlist sorting for ASC and DESC

### DIFF
--- a/src/commands/Commands.h
+++ b/src/commands/Commands.h
@@ -15,6 +15,7 @@
 #include <httpserver.hpp>
 #include <list>
 #include <map>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -79,11 +80,18 @@ public:
             allowBlanks = ab;
             return *this;
         }
-        CommandArg& setContentList(const std::vector<std::string>& v) {
-            contentList = v;
+        CommandArg& setContentList(std::vector<std::string> v) {
+            contentList = std::move(v);
             return *this;
         }
-        CommandArg& setDefaultValue(const std::string& d) {
+        CommandArg& setContentListRange(std::span<const std::string_view> s) {
+            contentList.clear();
+            contentList.reserve(s.size());
+            for (auto& e : s)
+                contentList.emplace_back(e);
+            return *this;
+        }
+        CommandArg& setDefaultValue(std::string_view d) {
             defaultValue = d;
             return *this;
         }

--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -6925,8 +6925,8 @@ function TailFollowFile (dir, file, lines = 50) {
 	var options = {
 		id: 'tailFollowDialog',
 		title: 'Tail Follow: ' + file,
-		body: "<pre id='tailFollowText' class='fileText' style='margin: 0; padding: 10px; background: #000; color: #0f0; max-height: 600px; overflow-y: auto; font-family: monospace; white-space: pre-wrap; word-wrap: break-word;'></pre>",
-		class: 'modal-dialog-scrollable modal-xl',
+		body: "<pre id='tailFollowText' class='fileText' style='margin: 0; padding: 10px; background: #000; color: #0f0; max-height: 65vh; overflow-y: auto; font-family: monospace; white-space: pre-wrap; word-wrap: break-word;'></pre>",
+		class: 'modal-xl',
 		keyboard: false,
 		backdrop: 'static',
 		buttons: {


### PR DESCRIPTION
#2277

I find this useful and have been manually doing this for my RF playlist.  User that submitted the enhancement request explains the downsides of trying to do this exclusively in RF.

Note: There is an existing issue with the playlists page in master that does not allow the buttons to be interactive for up to several seconds in multiple browsers that I've noticed with large playlists.  I've poked at the issue but haven't found a fix.  I will create a separate issue for this but would also love your opinion and whether you've looked at this @OnlineDynamic so I don't waste time.

## Enhancement Added
This will ASC or DESC sort Lead In, Main Playlist and Lead Out lists independently for all entry types.  

I have changed the randomizeBuffer to playlistBuffer so it's reusable and follows the same pattern and not needing a secondary span for another buffer.

## Testing

1. Load up a playlist with various entries including a subsection like Lead In
2. Click Playlist Actions -> Sort Playlist ASC | DESC
3. Playlist is sorted correctly
4. Save Playlist
5. Reload Playlist
