### PR TITLE
fix scheduler: scheduled playlist never taking over from manual playlist because of priority issue

### DIFF
--- a/src/Player.h
+++ b/src/Player.h
@@ -24,9 +24,10 @@ public:
 
     void Init();
 
+    // manualPriority: Lower = higher importance. Default allows scheduled playlists to take priority.
     int StartPlaylist(const std::string& name, const int repeat = -1,
                       const int startPosition = -1, const int endPosition = -1,
-                      const int manualPriority = -1);
+                      const int manualPriority = 10000);
     int StartScheduledPlaylist(const std::string& name, const int position,
                                const int repeat, const int scheduleEntry, const int scheduledPriority,
                                const time_t sTime, const time_t eTime, const int method);

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -522,13 +522,19 @@ bool Scheduler::doScheduledPlaylist(const std::time_t& now, const std::time_t& i
 
         if (!Player::INSTANCE.WasScheduled()) {
             // Manually started playlist is running, check priority
+            // Lower priority number = higher importance
+            // Manual playlists default to priority 10000, scheduled use entry index (0-99 typical)
             if (Player::INSTANCE.GetPriority() > item->priority) {
-                // Scheduled playlist has higher priority, stop the manual one
+                // Scheduled playlist has higher priority (lower number), stop the manual one
+                LogDebug(VB_SCHEDULE, "Stopping manual playlist (priority %d) for scheduled item (priority %d)\n",
+                         Player::INSTANCE.GetPriority(), item->priority);
                 while (Player::INSTANCE.GetStatus() != FPP_STATUS_IDLE) {
                     Player::INSTANCE.StopNow(1);
                 }
             } else {
                 // Manual playlist has higher or equal priority, let it continue
+                LogDebug(VB_SCHEDULE, "Manual playlist (priority %d) blocking scheduled item (priority %d)\n",
+                         Player::INSTANCE.GetPriority(), item->priority);
                 return false;
             }
         } else if (Player::INSTANCE.GetPriority() > item->priority) {


### PR DESCRIPTION
I worked with a user on Facebook why their scheduler was never starting.  After some debugging and back and forth they would have a manual playlist running and the scheduled playlist would just dump log entries over and over (after turning on higher level logging):

```bash
2025-12-30T18:02:01.007887-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:01:55.009 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:489: Checking scheduled 'Start Playlist'
2025-12-30T18:02:01.007923-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:01:55.009 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 18:00:00 2025: 10 'Start Playlist' - '"Christmas Music Show - All Ages - 2025" "true" "false" '
2025-12-30T18:02:01.007964-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:01:56.008 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:489: Checking scheduled 'Start Playlist'
2025-12-30T18:02:01.008010-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:01:56.008 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 18:00:00 2025: 10 'Start Playlist' - '"Christmas Music Show - All Ages - 2025" "true" "false" '
2025-12-30T18:02:01.008046-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:01:57.008 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:489: Checking scheduled 'Start Playlist'
2025-12-30T18:02:01.008090-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:01:57.008 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 18:00:00 2025: 10 'Start Playlist' - '"Christmas Music Show - All Ages - 2025" "true" "false" '
2025-12-30T18:02:01.008126-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:01:58.007 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:489: Checking scheduled 'Start Playlist'
2025-12-30T18:02:01.008162-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:01:58.007 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 18:00:00 2025: 10 'Start Playlist' - '"Christmas Music Show - All Ages - 2025" "true" "false" '
2025-12-30T18:02:01.008194-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:01:59.007 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:489: Checking scheduled 'Start Playlist'
2025-12-30T18:02:01.008232-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:01:59.007 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 18:00:00 2025: 10 'Start Playlist' - '"Christmas Music Show - All Ages - 2025" "true" "false" '
2025-12-30T18:02:01.008269-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:02:00.007 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:489: Checking scheduled 'Start Playlist'
2025-12-30T18:02:01.008301-05:00 FPP-BareMetal-Primary fppd[1423]: 2025-12-30 18:02:00.007 (1423) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 18:00:00 2025: 10 'Start Playlist' - '"Christmas Music Show - All Ages - 2025" "true" "false" '
```

# Root Cause

Commit 7dc79622 added priority checking but used a value that would make manual playlists always take precedence over scheduled playlists. 

Manual playlists were set to -1 while scheduled playlists use entry index (0-99). Since -1 is lower (higher priority), scheduled playlists could never take priority over manual ones.  

I have set the default value to an artifically high level to overcome. I have also added some debug logging to make what is happening more clear in logs.  


# To replicate on Master
- Turn on Schedule Logging to Excessive
- Start a Manual Playlist
- Schedule a Playlist to start
- Schedule playlist will never start until Manual Playlist completes
- You will see logging like the users above

# After Fix
- Turn on Schedule Logging to Excessive
- Start a Manual Playlist
- Schedule a Playlist to start
- Scheduled playlist will take over immediately on scheduled time.
- You will see logging like below

```bash
2025-12-30T19:06:10.388636-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:56.006 (15420) [Command] /opt/fpp/src/commands/Commands.cpp:537: No preset found for name "PLAYLIST_START_TMINUS_004"
2025-12-30T19:06:10.388663-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:56.006 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 19:03:00 2025:  0 'Start Playlist' - '"test" "true" "false" '
2025-12-30T19:06:10.388690-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:57.110 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:452: Scheduled Item running in 3 seconds:
2025-12-30T19:06:10.388716-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:57.110 (15420) [Command] /opt/fpp/src/commands/Commands.cpp:537: No preset found for name "PLAYLIST_START_TMINUS_003"
2025-12-30T19:06:10.388745-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:57.110 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 19:03:00 2025:  0 'Start Playlist' - '"test" "true" "false" '
2025-12-30T19:06:10.388771-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:58.009 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:452: Scheduled Item running in 2 seconds:
2025-12-30T19:06:10.388796-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:58.009 (15420) [Command] /opt/fpp/src/commands/Commands.cpp:537: No preset found for name "PLAYLIST_START_TMINUS_002"
2025-12-30T19:06:10.388821-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:58.009 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 19:03:00 2025:  0 'Start Playlist' - '"test" "true" "false" '
2025-12-30T19:06:10.388869-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:59.011 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:452: Scheduled Item running in 1 second:
2025-12-30T19:06:10.388895-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:59.011 (15420) [Command] /opt/fpp/src/commands/Commands.cpp:537: No preset found for name "PLAYLIST_START_TMINUS_001"
2025-12-30T19:06:10.388921-06:00 FPP-test fppd[15420]: 2025-12-30 19:02:59.011 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 19:03:00 2025:  0 'Start Playlist' - '"test" "true" "false" '
2025-12-30T19:06:10.388946-06:00 FPP-test fppd[15420]: 2025-12-30 19:03:00.012 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:489: Checking scheduled 'Start Playlist'
2025-12-30T19:06:10.388979-06:00 FPP-test fppd[15420]: 2025-12-30 19:03:00.012 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 19:03:00 2025:  0 'Start Playlist' - '"test" "true" "false" '
2025-12-30T19:06:10.389005-06:00 FPP-test fppd[15420]: 2025-12-30 19:03:00.012 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:529: Stopping manual playlist (priority 1000000) for scheduled item (priority 0)
2025-12-30T19:06:10.389030-06:00 FPP-test fppd[15420]: 2025-12-30 19:03:00.208 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:586: Starting Scheduled Playlist:
2025-12-30T19:06:10.389058-06:00 FPP-test fppd[15420]: 2025-12-30 19:03:00.208 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:421: Tue Dec 30 19:03:00 2025:  0 'Start Playlist' - '"test" "true" "false" '
2025-12-30T19:06:10.389109-06:00 FPP-test fppd[15420]: 2025-12-30 19:05:00.008 (15420) [Schedule] /opt/fpp/src/Scheduler.cpp:452: Scheduled Items running in 17700 seconds:
```