### PR TITLE
[UX Enhancement] Update Available icon color on orange background is hard to see

### DIFF
--- a/www/common/menuHead.inc
+++ b/www/common/menuHead.inc
@@ -118,6 +118,14 @@ if (isset($settings['backgroundColor']) && $settings['backgroundColor'] != "") {
     .header {
         background-color: #<? echo $settings['backgroundColor'] ?>;
     }
+    /* DarkOrange and Orange header colors make the upgrade icon hard to see - change the color to the text color*/
+    <?php if (in_array($settings['backgroundColor'], ['FF8C00', 'FFA500'], true)) { ?>
+    #navbarUpdateAvail a {
+        color: rgb(152, 152, 152);
+        font-size: 1.5em;
+    }
+   <?php } ?>
+
 </style>
 <?
 }


### PR DESCRIPTION
On an either the "Orange" or "DarkOrange" background, the upgrade icon is really hard to say. QOL feature to change the icon color on those two backgrounds. 

Before:
<img width="322" height="63" alt="Screenshot 2026-01-09 at 1 56 23 PM" src="https://github.com/user-attachments/assets/3704f680-8388-4b57-83a2-2c20d9bc3bff" />
<img width="267" height="59" alt="Screenshot 2026-01-09 at 1 56 31 PM" src="https://github.com/user-attachments/assets/b7b14433-f554-495a-a1cf-1b41c737b9c6" />


After:
<img width="288" height="52" alt="Screenshot 2026-01-09 at 1 56 55 PM" src="https://github.com/user-attachments/assets/d7f65b2f-c368-43c5-8d3a-7e3878b6107f" />
<img width="299" height="55" alt="Screenshot 2026-01-09 at 1 56 47 PM" src="https://github.com/user-attachments/assets/a7aac433-c180-4042-a8d2-8cfb7e57fb0f" />
