### PR TITLE
fix: InitialSetup - browser autofill prevents saving when selecting No Password

### DIFF
--- a/www/initialSetup.php
+++ b/www/initialSetup.php
@@ -54,10 +54,21 @@
                 }
             <? } ?>
 
+            var osPasswordEnable = $('#osPasswordEnable').val();
+
             // Password verify fields are UI-only confirmation values.
+            // If UI/OS password auth is disabled, ignore password field writes even if
+            // browser autofill or prior UI events populated pendingSettings.
             var filteredSettings = {};
             $.each(pendingSettings, function (key, value) {
                 if (key !== 'passwordVerify' && key !== 'osPasswordVerify') {
+                    // Don't save the value if user does not want passwords enabled.
+                    if (key === 'password' && passwordEnable !== '1') {
+                        return;
+                    }
+                    if (key === 'osPassword' && osPasswordEnable !== '1') {
+                        return;
+                    }
                     filteredSettings[key] = value;
                 }
             });


### PR DESCRIPTION
fix: initialSetup - choosing "No Password" and Saving errors if the browser auto-fills the password boxes

<img width="535" height="271" alt="image" src="https://github.com/user-attachments/assets/ae50934f-c627-441c-a46d-8d9d8a8a82fa" />
