### PR TITLE
Refactor CSS for dark mode and improve tokenization

### DIFF
--- a/www/about.php
+++ b/www/about.php
@@ -432,64 +432,6 @@ $freeSpace = disk_free_space($uploadDirectory);
     <title>
         <? echo $pageTitle; ?>
     </title>
-    <style>
-        .no-close .ui-dialog-titlebar-close {
-            display: none
-        }
-
-        .clear {
-            clear: both;
-        }
-
-        .items {
-            width: 40%;
-            background: rgb#FFF;
-            float: right;
-            margin: 0, auto;
-        }
-
-        .selectedEntry {
-            background: #CCC;
-        }
-
-        .pl_title {
-            font-size: larger;
-        }
-
-        h4,
-        h3 {
-            padding: 0;
-            margin: 0;
-        }
-
-        .tblheader {
-            background-color: #CCC;
-            text-align: center;
-        }
-
-        tr.rowScheduleDetails {
-            border: thin solid;
-            border-color: #CCC;
-        }
-
-        tr.rowScheduleDetails td {
-            padding: 1px 5px;
-        }
-
-        #tblSchedule {
-            border: thin;
-            border-color: #333;
-            border-collapse: collapse;
-        }
-
-        .time {
-            width: 100%;
-        }
-
-        .center {
-            text-align: center;
-        }
-    </style>
 </head>
 
 <body>

--- a/www/co-ledPanels.php
+++ b/www/co-ledPanels.php
@@ -2737,7 +2737,7 @@
             // Show warning banner
             if ($('.configUpgradeWarning').length === 0) {
                 const warningHtml = `
-                    <div class="alert alert-warning alert-dismissible fade show configUpgradeWarning" role="alert" style="margin: 10px 0; color: #856404; background-color: #fff3cd; border-color: #ffeaa7;">
+                    <div class="alert alert-warning alert-dismissible fade show configUpgradeWarning" role="alert" style="margin: 10px 0;">
                         <strong><i class="fas fa-exclamation-triangle"></i> Configuration Upgrade Required:</strong> 
                         ${message}
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>

--- a/www/common/htmlMeta.inc
+++ b/www/common/htmlMeta.inc
@@ -1,4 +1,13 @@
 <!-- HTML META SECTION -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta charset="utf-8">
-<meta name="color-scheme" content="light">
+<meta name="color-scheme" content="light dark">
+<script>
+  (function () {
+    var mq = window.matchMedia('(prefers-color-scheme: dark)');
+    document.documentElement.setAttribute('data-bs-theme', mq.matches ? 'dark' : 'light');
+    mq.addEventListener('change', function (e) {
+      document.documentElement.setAttribute('data-bs-theme', e.matches ? 'dark' : 'light');
+    });
+  })();
+</script>

--- a/www/common/menuHead.inc
+++ b/www/common/menuHead.inc
@@ -51,9 +51,10 @@ if ((!isset($settings['disableUIPopoverAlerts'])) || ($settings['disableUIPopove
     customElements.define('zero-md', class extends ZeroMd {
         async load() {
             await super.load()
+            const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
             this.template = `
 <style>:host { display: block; }</style>
-<link rel="stylesheet" href="/js/zero-md/css/github-markdown-light.min.css">
+<link rel="stylesheet" href="/js/zero-md/css/${isDark ? 'github-markdown-dark' : 'github-markdown-light'}.min.css">
 <link rel="stylesheet" href="/js/zero-md/css/github-markdown.min.css">
 <link rel="stylesheet" href="/js/zero-md/css/katex.min.css">`
             //this.template = STYLES.preset('light') // or STYLES.preset('dark')
@@ -80,6 +81,7 @@ if (isset($themeInfo["preFPPStyleSheet"])) {
 <link rel="stylesheet"
     href="css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css?ref=<?php echo filemtime('css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css'); ?>">
 <link rel="stylesheet" href="css/fpp.css?ref=<?php echo filemtime('css/fpp.css'); ?>">
+<link rel="stylesheet" href="css/fpp-dark.css?ref=<?php echo filemtime('css/fpp-dark.css'); ?>">
 
 <?
 if (isset($themeInfo["postFPPStyleSheet"])) {

--- a/www/components.html
+++ b/www/components.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en" data-theme="light" data-bs-theme="light">
+<html lang="en">
 	<head>
 		<meta charset="utf-8" />
 
@@ -32,7 +32,7 @@
 								<div class="ajax-file-upload-filename">
 									1). file.png (2.71 KB)
 								</div>
-								<div class="ajax-file-upload-progress" style="">
+								<div class="ajax-file-upload-progress">
 									<div class="ajax-file-upload-bar" style="width: 50%"></div>
 								</div>
 								<div

--- a/www/css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css
+++ b/www/css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css
@@ -34,17 +34,6 @@
   --bs-dark: #343a40;
   --bs-graceful: #6f42c1;
   --bs-pleasant: #6B95EC;
-  --bs-primary-rgb: 23, 23, 32;
-  --bs-secondary-rgb: 108, 117, 125;
-  --bs-tertiary-rgb: 206, 212, 218;
-  --bs-success-rgb: 86, 183, 96;
-  --bs-info-rgb: 23, 162, 184;
-  --bs-warning-rgb: 242, 188, 95;
-  --bs-danger-rgb: 246, 57, 57;
-  --bs-light-rgb: 242, 246, 246;
-  --bs-dark-rgb: 52, 58, 64;
-  --bs-graceful-rgb: 111, 66, 193;
-  --bs-pleasant-rgb: 107, 149, 236;
   --bs-primary-text-emphasis: rgb(9.2, 9.2, 12.8);
   --bs-secondary-text-emphasis: rgb(43.2, 46.8, 50);
   --bs-success-text-emphasis: rgb(34.4, 73.2, 38.4);
@@ -69,8 +58,6 @@
   --bs-danger-border-subtle: rgb(251.4, 175.8, 175.8);
   --bs-light-border-subtle: #e3ebec;
   --bs-dark-border-subtle: #adb5bd;
-  --bs-white-rgb: 255, 255, 255;
-  --bs-black-rgb: 23, 23, 32;
   --bs-font-sans-serif: "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --bs-font-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
@@ -79,25 +66,16 @@
   --bs-body-font-weight: 400;
   --bs-body-line-height: 1.5;
   --bs-body-color: #171720;
-  --bs-body-color-rgb: 23, 23, 32;
   --bs-body-bg: #fff;
-  --bs-body-bg-rgb: 255, 255, 255;
   --bs-emphasis-color: #171720;
-  --bs-emphasis-color-rgb: 23, 23, 32;
   --bs-secondary-color: rgba(23, 23, 32, 0.75);
-  --bs-secondary-color-rgb: 23, 23, 32;
   --bs-secondary-bg: #e3ebec;
-  --bs-secondary-bg-rgb: 227, 235, 236;
   --bs-tertiary-color: rgba(23, 23, 32, 0.5);
-  --bs-tertiary-color-rgb: 23, 23, 32;
   --bs-tertiary-bg: #f2f6f6;
-  --bs-tertiary-bg-rgb: 242, 246, 246;
   --bs-heading-color: inherit;
   --bs-link-color: #495057;
-  --bs-link-color-rgb: 73, 80, 87;
   --bs-link-decoration: underline;
   --bs-link-hover-color: rgb(38.096875, 41.75, 45.403125);
-  --bs-link-hover-color-rgb: 38, 42, 45;
   --bs-link-hover-decoration: none;
   --bs-code-color: #d63384;
   --bs-highlight-color: #171720;
@@ -128,20 +106,46 @@
 
 [data-bs-theme=dark] {
   color-scheme: dark;
+  --bs-blue: #8fb1f2;
+  --bs-indigo: #8c68f6;
+  --bs-purple: #8e63cf;
+  --bs-pink: #e06aa2;
+  --bs-red: #f87171;
+  --bs-orange: #ff944d;
+  --bs-yellow: #f4c97d;
+  --bs-green: #6fc879;
+  --bs-teal: #4dd4ad;
+  --bs-cyan: #4fc3d7;
+  --bs-white: #fff;
+  --bs-gray: #adb5bd;
+  --bs-gray-dark: #dee2e6;
+  --bs-gray-100: #212529;
+  --bs-gray-200: #343a40;
+  --bs-gray-300: #495057;
+  --bs-gray-400: #6c757d;
+  --bs-gray-500: #adb5bd;
+  --bs-gray-600: #ced4da;
+  --bs-gray-700: #dee2e6;
+  --bs-gray-800: #e9ecef;
+  --bs-gray-900: #f2f6f6;
+  --bs-primary: #dee2e6;
+  --bs-secondary: #a6acb2;
+  --bs-tertiary: #6c757d;
+  --bs-success: #6fc879;
+  --bs-info: #4fc3d7;
+  --bs-warning: #f4c97d;
+  --bs-danger: #f87171;
+  --bs-light: #f2f6f6;
+  --bs-dark: #343a40;
+  --bs-graceful: #8e63cf;
+  --bs-pleasant: #8fb1f2;
   --bs-body-color: #dee2e6;
-  --bs-body-color-rgb: 222, 226, 230;
   --bs-body-bg: #212529;
-  --bs-body-bg-rgb: 33, 37, 41;
   --bs-emphasis-color: #fff;
-  --bs-emphasis-color-rgb: 255, 255, 255;
   --bs-secondary-color: rgba(222, 226, 230, 0.75);
-  --bs-secondary-color-rgb: 222, 226, 230;
   --bs-secondary-bg: #343a40;
-  --bs-secondary-bg-rgb: 52, 58, 64;
   --bs-tertiary-color: rgba(222, 226, 230, 0.5);
-  --bs-tertiary-color-rgb: 222, 226, 230;
   --bs-tertiary-bg: rgb(42.5, 47.5, 52.5);
-  --bs-tertiary-bg-rgb: 43, 48, 53;
   --bs-primary-text-emphasis: rgb(115.8, 115.8, 121.2);
   --bs-secondary-text-emphasis: rgb(166.8, 172.2, 177);
   --bs-success-text-emphasis: rgb(153.6, 211.8, 159.6);
@@ -166,16 +170,39 @@
   --bs-danger-border-subtle: rgb(147.6, 34.2, 34.2);
   --bs-light-border-subtle: #495057;
   --bs-dark-border-subtle: #343a40;
+  --bs-font-sans-serif: "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --bs-font-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0));
+  --bs-body-font-family: "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --bs-body-font-size: 0.95rem;
+  --bs-body-font-weight: 400;
+  --bs-body-line-height: 1.5;
   --bs-heading-color: inherit;
   --bs-link-color: rgb(115.8, 115.8, 121.2);
+  --bs-link-decoration: underline;
   --bs-link-hover-color: rgb(143.64, 143.64, 147.96);
-  --bs-link-color-rgb: 116, 116, 121;
-  --bs-link-hover-color-rgb: 144, 144, 148;
+  --bs-link-hover-decoration: none;
   --bs-code-color: rgb(230.4, 132.6, 181.2);
   --bs-highlight-color: #dee2e6;
   --bs-highlight-bg: rgb(96.8, 75.2, 38);
+  --bs-border-width: 1px;
+  --bs-border-style: solid;
   --bs-border-color: #495057;
   --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
+  --bs-border-radius: 0.25rem;
+  --bs-border-radius-sm: 0.2rem;
+  --bs-border-radius-lg: 0.3rem;
+  --bs-border-radius-xl: 1rem;
+  --bs-border-radius-xxl: 2rem;
+  --bs-border-radius-2xl: var(--bs-border-radius-xxl);
+  --bs-border-radius-pill: 50rem;
+  --bs-box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.35);
+  --bs-box-shadow-sm: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.2);
+  --bs-box-shadow-lg: 0 1rem 3rem rgba(0, 0, 0, 0.45);
+  --bs-box-shadow-inset: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+  --bs-focus-ring-width: 0.25rem;
+  --bs-focus-ring-opacity: 0.25;
+  --bs-focus-ring-color: rgba(222, 226, 230, 0.25);
   --bs-form-valid-color: rgb(153.6, 211.8, 159.6);
   --bs-form-valid-border-color: rgb(153.6, 211.8, 159.6);
   --bs-form-invalid-color: rgb(249.6, 136.2, 136.2);
@@ -247,7 +274,8 @@
   --bs-btn-hover-border-color: transparent;
   --bs-btn-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 1px 1px rgba(23, 23, 32, 0.075);
   --bs-btn-disabled-opacity: 0.65;
-  --bs-btn-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-btn-focus-shadow-rgb), .5);
+  --bs-btn-focus-shadow-color: var(--bs-body-color);
+  --bs-btn-focus-box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--bs-btn-focus-shadow-color) 50%, transparent);
   display: inline-block;
   padding: var(--bs-btn-padding-y) var(--bs-btn-padding-x);
   font-family: var(--bs-btn-font-family);
@@ -320,7 +348,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: rgb(19.55, 19.55, 27.2);
   --bs-btn-hover-border-color: rgb(18.4, 18.4, 25.6);
-  --bs-btn-focus-shadow-rgb: 58, 58, 65;
+  --bs-btn-focus-shadow-color: var(--bs-primary);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: rgb(18.4, 18.4, 25.6);
   --bs-btn-active-border-color: rgb(17.25, 17.25, 24);
@@ -337,7 +365,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: rgb(91.8, 99.45, 106.25);
   --bs-btn-hover-border-color: rgb(86.4, 93.6, 100);
-  --bs-btn-focus-shadow-rgb: 130, 138, 145;
+  --bs-btn-focus-shadow-color: var(--bs-secondary);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: rgb(86.4, 93.6, 100);
   --bs-btn-active-border-color: rgb(81, 87.75, 93.75);
@@ -354,7 +382,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(213.35, 218.45, 223.55);
   --bs-btn-hover-border-color: rgb(210.9, 216.3, 221.7);
-  --bs-btn-focus-shadow-rgb: 179, 184, 190;
+  --bs-btn-focus-shadow-color: var(--bs-tertiary);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(215.8, 220.6, 225.4);
   --bs-btn-active-border-color: rgb(210.9, 216.3, 221.7);
@@ -371,7 +399,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(111.35, 193.8, 119.85);
   --bs-btn-hover-border-color: rgb(102.9, 190.2, 111.9);
-  --bs-btn-focus-shadow-rgb: 77, 159, 86;
+  --bs-btn-focus-shadow-color: var(--bs-success);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(119.8, 197.4, 127.8);
   --bs-btn-active-border-color: rgb(102.9, 190.2, 111.9);
@@ -388,7 +416,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(57.8, 175.95, 194.65);
   --bs-btn-hover-border-color: rgb(46.2, 171.3, 191.1);
-  --bs-btn-focus-shadow-rgb: 23, 141, 161;
+  --bs-btn-focus-shadow-color: var(--bs-info);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(69.4, 180.6, 198.2);
   --bs-btn-active-border-color: rgb(46.2, 171.3, 191.1);
@@ -405,7 +433,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(243.95, 198.05, 119);
   --bs-btn-hover-border-color: rgb(243.3, 194.7, 111);
-  --bs-btn-focus-shadow-rgb: 209, 163, 86;
+  --bs-btn-focus-shadow-color: var(--bs-warning);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(244.6, 201.4, 127);
   --bs-btn-active-border-color: rgb(243.3, 194.7, 111);
@@ -422,7 +450,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(247.35, 86.7, 86.7);
   --bs-btn-hover-border-color: rgb(246.9, 76.8, 76.8);
-  --bs-btn-focus-shadow-rgb: 213, 52, 53;
+  --bs-btn-focus-shadow-color: var(--bs-danger);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(247.8, 96.6, 96.6);
   --bs-btn-active-border-color: rgb(246.9, 76.8, 76.8);
@@ -439,7 +467,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(205.7, 209.1, 209.1);
   --bs-btn-hover-border-color: rgb(193.6, 196.8, 196.8);
-  --bs-btn-focus-shadow-rgb: 209, 213, 214;
+  --bs-btn-focus-shadow-color: var(--bs-light);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(193.6, 196.8, 196.8);
   --bs-btn-active-border-color: rgb(181.5, 184.5, 184.5);
@@ -456,7 +484,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: rgb(82.45, 87.55, 92.65);
   --bs-btn-hover-border-color: rgb(72.3, 77.7, 83.1);
-  --bs-btn-focus-shadow-rgb: 82, 88, 93;
+  --bs-btn-focus-shadow-color: var(--bs-dark);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: rgb(92.6, 97.4, 102.2);
   --bs-btn-active-border-color: rgb(72.3, 77.7, 83.1);
@@ -473,7 +501,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: rgb(94.35, 56.1, 164.05);
   --bs-btn-hover-border-color: rgb(88.8, 52.8, 154.4);
-  --bs-btn-focus-shadow-rgb: 133, 94, 202;
+  --bs-btn-focus-shadow-color: var(--bs-graceful);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: rgb(88.8, 52.8, 154.4);
   --bs-btn-active-border-color: rgb(83.25, 49.5, 144.75);
@@ -490,7 +518,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(129.2, 164.9, 238.85);
   --bs-btn-hover-border-color: rgb(121.8, 159.6, 237.9);
-  --bs-btn-focus-shadow-rgb: 94, 130, 205;
+  --bs-btn-focus-shadow-color: var(--bs-pleasant);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(136.6, 170.2, 239.8);
   --bs-btn-active-border-color: rgb(121.8, 159.6, 237.9);
@@ -506,7 +534,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #171720;
   --bs-btn-hover-border-color: #171720;
-  --bs-btn-focus-shadow-rgb: 23, 23, 32;
+  --bs-btn-focus-shadow-color: var(--bs-primary);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #171720;
   --bs-btn-active-border-color: #171720;
@@ -523,7 +551,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #6c757d;
   --bs-btn-hover-border-color: #6c757d;
-  --bs-btn-focus-shadow-rgb: 108, 117, 125;
+  --bs-btn-focus-shadow-color: var(--bs-secondary);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #6c757d;
   --bs-btn-active-border-color: #6c757d;
@@ -540,7 +568,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #ced4da;
   --bs-btn-hover-border-color: #ced4da;
-  --bs-btn-focus-shadow-rgb: 206, 212, 218;
+  --bs-btn-focus-shadow-color: var(--bs-tertiary);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #ced4da;
   --bs-btn-active-border-color: #ced4da;
@@ -557,7 +585,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #56B760;
   --bs-btn-hover-border-color: #56B760;
-  --bs-btn-focus-shadow-rgb: 86, 183, 96;
+  --bs-btn-focus-shadow-color: var(--bs-success);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #56B760;
   --bs-btn-active-border-color: #56B760;
@@ -574,7 +602,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #17a2b8;
   --bs-btn-hover-border-color: #17a2b8;
-  --bs-btn-focus-shadow-rgb: 23, 162, 184;
+  --bs-btn-focus-shadow-color: var(--bs-info);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #17a2b8;
   --bs-btn-active-border-color: #17a2b8;
@@ -591,7 +619,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #F2BC5F;
   --bs-btn-hover-border-color: #F2BC5F;
-  --bs-btn-focus-shadow-rgb: 242, 188, 95;
+  --bs-btn-focus-shadow-color: var(--bs-warning);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #F2BC5F;
   --bs-btn-active-border-color: #F2BC5F;
@@ -608,7 +636,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #F63939;
   --bs-btn-hover-border-color: #F63939;
-  --bs-btn-focus-shadow-rgb: 246, 57, 57;
+  --bs-btn-focus-shadow-color: var(--bs-danger);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #F63939;
   --bs-btn-active-border-color: #F63939;
@@ -625,7 +653,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #f2f6f6;
   --bs-btn-hover-border-color: #f2f6f6;
-  --bs-btn-focus-shadow-rgb: 242, 246, 246;
+  --bs-btn-focus-shadow-color: var(--bs-light);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #f2f6f6;
   --bs-btn-active-border-color: #f2f6f6;
@@ -642,7 +670,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #343a40;
   --bs-btn-hover-border-color: #343a40;
-  --bs-btn-focus-shadow-rgb: 52, 58, 64;
+  --bs-btn-focus-shadow-color: var(--bs-dark);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #343a40;
   --bs-btn-active-border-color: #343a40;
@@ -659,7 +687,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #6f42c1;
   --bs-btn-hover-border-color: #6f42c1;
-  --bs-btn-focus-shadow-rgb: 111, 66, 193;
+  --bs-btn-focus-shadow-color: var(--bs-graceful);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #6f42c1;
   --bs-btn-active-border-color: #6f42c1;
@@ -676,7 +704,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #6B95EC;
   --bs-btn-hover-border-color: #6B95EC;
-  --bs-btn-focus-shadow-rgb: 107, 149, 236;
+  --bs-btn-focus-shadow-color: var(--bs-pleasant);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #6B95EC;
   --bs-btn-active-border-color: #6B95EC;
@@ -699,7 +727,7 @@
   --bs-btn-disabled-color: #6c757d;
   --bs-btn-disabled-border-color: transparent;
   --bs-btn-box-shadow: 0 0 0 #000;
-  --bs-btn-focus-shadow-rgb: 100, 106, 112;
+  --bs-btn-focus-shadow-color: var(--bs-link-color);
   text-decoration: underline;
 }
 .btn-link:hover, .btn-link:focus-visible {
@@ -1547,7 +1575,7 @@ textarea.form-control-lg {
   height: 100%;
   padding: 1rem 0.65rem;
   overflow: hidden;
-  color: rgba(var(--bs-body-color-rgb), 0.65);
+  color: color-mix(in srgb, var(--bs-body-color) 65%, transparent);
   text-align: start;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1783,7 +1811,7 @@ textarea.form-control-lg {
 }
 .was-validated .form-control:valid:focus, .was-validated #settingsManagerTabsContent input[type=text]:valid:focus, #settingsManagerTabsContent .was-validated input[type=text]:valid:focus, .was-validated input[type=checkbox]:valid:focus, .form-control.is-valid:focus, #settingsManagerTabsContent input.is-valid[type=text]:focus, input.is-valid[type=checkbox]:focus {
   border-color: var(--bs-form-valid-border-color);
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+  box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--bs-success) 25%, transparent);
 }
 
 .was-validated textarea.form-control:valid, textarea.form-control.is-valid {
@@ -1802,7 +1830,7 @@ textarea.form-control-lg {
 }
 .was-validated .form-select:valid:focus, .form-select.is-valid:focus {
   border-color: var(--bs-form-valid-border-color);
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+  box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--bs-success) 25%, transparent);
 }
 
 .was-validated .form-control-color:valid, .form-control-color.is-valid {
@@ -1816,7 +1844,7 @@ textarea.form-control-lg {
   background-color: var(--bs-form-valid-color);
 }
 .was-validated .form-check-input:valid:focus, .form-check-input.is-valid:focus {
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+  box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--bs-success) 25%, transparent);
 }
 .was-validated .form-check-input:valid ~ .form-check-label, .form-check-input.is-valid ~ .form-check-label {
   color: var(--bs-form-valid-color);
@@ -1873,7 +1901,7 @@ textarea.form-control-lg {
 }
 .was-validated .form-control:invalid:focus, .was-validated #settingsManagerTabsContent input[type=text]:invalid:focus, #settingsManagerTabsContent .was-validated input[type=text]:invalid:focus, .was-validated input[type=checkbox]:invalid:focus, .form-control.is-invalid:focus, #settingsManagerTabsContent input.is-invalid[type=text]:focus, input.is-invalid[type=checkbox]:focus {
   border-color: var(--bs-form-invalid-border-color);
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+  box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--bs-danger) 25%, transparent);
 }
 
 .was-validated textarea.form-control:invalid, textarea.form-control.is-invalid {
@@ -1892,7 +1920,7 @@ textarea.form-control-lg {
 }
 .was-validated .form-select:invalid:focus, .form-select.is-invalid:focus {
   border-color: var(--bs-form-invalid-border-color);
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+  box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--bs-danger) 25%, transparent);
 }
 
 .was-validated .form-control-color:invalid, .form-control-color.is-invalid {
@@ -1906,7 +1934,7 @@ textarea.form-control-lg {
   background-color: var(--bs-form-invalid-color);
 }
 .was-validated .form-check-input:invalid:focus, .form-check-input.is-invalid:focus {
-  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+  box-shadow: 0 0 0 0.25rem color-mix(in srgb, var(--bs-danger) 25%, transparent);
 }
 .was-validated .form-check-input:invalid ~ .form-check-label, .form-check-input.is-invalid ~ .form-check-label {
   color: var(--bs-form-invalid-color);
@@ -2457,11 +2485,11 @@ sup {
 }
 
 a {
-  color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+  color: color-mix(in srgb, var(--bs-link-color) calc(var(--bs-link-opacity, 1) * 100%), transparent);
   text-decoration: underline;
 }
 a:hover {
-  --bs-link-color-rgb: var(--bs-link-hover-color-rgb);
+  color: color-mix(in srgb, var(--bs-link-hover-color) calc(var(--bs-link-opacity, 1) * 100%), transparent);
   text-decoration: none;
 }
 
@@ -4500,62 +4528,62 @@ progress {
 
 .text-bg-primary {
   color: #fff !important;
-  background-color: RGBA(var(--bs-primary-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-bg-secondary {
   color: #fff !important;
-  background-color: RGBA(var(--bs-secondary-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-bg-tertiary {
   color: #171720 !important;
-  background-color: RGBA(var(--bs-tertiary-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-bg-success {
   color: #171720 !important;
-  background-color: RGBA(var(--bs-success-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-bg-info {
   color: #171720 !important;
-  background-color: RGBA(var(--bs-info-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-bg-warning {
   color: #171720 !important;
-  background-color: RGBA(var(--bs-warning-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-bg-danger {
   color: #171720 !important;
-  background-color: RGBA(var(--bs-danger-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-bg-light {
   color: #171720 !important;
-  background-color: RGBA(var(--bs-light-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-bg-dark {
   color: #fff !important;
-  background-color: RGBA(var(--bs-dark-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-bg-graceful {
   color: #fff !important;
-  background-color: RGBA(var(--bs-graceful-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-bg-pleasant {
   color: #171720 !important;
-  background-color: RGBA(var(--bs-pleasant-rgb), var(--bs-bg-opacity, 1)) !important;
+  background-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-primary {
-  color: RGBA(var(--bs-primary-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-primary-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-primary:hover, .link-primary:focus {
   color: RGBA(18, 18, 26, var(--bs-link-opacity, 1)) !important;
@@ -4563,8 +4591,8 @@ progress {
 }
 
 .link-secondary {
-  color: RGBA(var(--bs-secondary-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-secondary-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-secondary:hover, .link-secondary:focus {
   color: RGBA(86, 94, 100, var(--bs-link-opacity, 1)) !important;
@@ -4572,8 +4600,8 @@ progress {
 }
 
 .link-tertiary {
-  color: RGBA(var(--bs-tertiary-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-tertiary-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-tertiary:hover, .link-tertiary:focus {
   color: RGBA(216, 221, 225, var(--bs-link-opacity, 1)) !important;
@@ -4581,8 +4609,8 @@ progress {
 }
 
 .link-success {
-  color: RGBA(var(--bs-success-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-success-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-success) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-success:hover, .link-success:focus {
   color: RGBA(120, 197, 128, var(--bs-link-opacity, 1)) !important;
@@ -4590,8 +4618,8 @@ progress {
 }
 
 .link-info {
-  color: RGBA(var(--bs-info-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-info-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-info) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-info:hover, .link-info:focus {
   color: RGBA(69, 181, 198, var(--bs-link-opacity, 1)) !important;
@@ -4599,8 +4627,8 @@ progress {
 }
 
 .link-warning {
-  color: RGBA(var(--bs-warning-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-warning-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-warning:hover, .link-warning:focus {
   color: RGBA(245, 201, 127, var(--bs-link-opacity, 1)) !important;
@@ -4608,8 +4636,8 @@ progress {
 }
 
 .link-danger {
-  color: RGBA(var(--bs-danger-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-danger-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-danger:hover, .link-danger:focus {
   color: RGBA(248, 97, 97, var(--bs-link-opacity, 1)) !important;
@@ -4617,8 +4645,8 @@ progress {
 }
 
 .link-light {
-  color: RGBA(var(--bs-light-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-light-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-light) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-light:hover, .link-light:focus {
   color: RGBA(245, 248, 248, var(--bs-link-opacity, 1)) !important;
@@ -4626,8 +4654,8 @@ progress {
 }
 
 .link-dark {
-  color: RGBA(var(--bs-dark-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-dark-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-dark:hover, .link-dark:focus {
   color: RGBA(42, 46, 51, var(--bs-link-opacity, 1)) !important;
@@ -4635,8 +4663,8 @@ progress {
 }
 
 .link-graceful {
-  color: RGBA(var(--bs-graceful-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-graceful-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-graceful:hover, .link-graceful:focus {
   color: RGBA(89, 53, 154, var(--bs-link-opacity, 1)) !important;
@@ -4644,8 +4672,8 @@ progress {
 }
 
 .link-pleasant {
-  color: RGBA(var(--bs-pleasant-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-pleasant-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-pleasant:hover, .link-pleasant:focus {
   color: RGBA(137, 170, 240, var(--bs-link-opacity, 1)) !important;
@@ -4653,12 +4681,12 @@ progress {
 }
 
 .link-body-emphasis {
-  color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, var(--bs-emphasis-color) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-emphasis-color) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-body-emphasis:hover, .link-body-emphasis:focus {
-  color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-opacity, 0.75)) !important;
-  text-decoration-color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-underline-opacity, 0.75)) !important;
+  color: color-mix(in srgb, var(--bs-emphasis-color) calc(var(--bs-link-opacity, 0.75) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-emphasis-color) calc(var(--bs-link-underline-opacity, 0.75) * 100%), transparent) !important;
 }
 
 .focus-ring:focus {
@@ -4670,7 +4698,7 @@ progress {
   display: inline-flex;
   gap: 0.375rem;
   align-items: center;
-  text-decoration-color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 0.5));
+  text-decoration-color: color-mix(in srgb, var(--bs-link-color) calc(var(--bs-link-opacity, 0.5) * 100%), transparent);
   text-underline-offset: 0.25em;
   backface-visibility: hidden;
 }
@@ -5045,21 +5073,21 @@ progress {
 .navbar {
   --bs-navbar-padding-x: 0;
   --bs-navbar-padding-y: 0.75rem;
-  --bs-navbar-color: rgba(var(--bs-emphasis-color-rgb), 0.65);
-  --bs-navbar-hover-color: rgba(var(--bs-emphasis-color-rgb), 0.8);
-  --bs-navbar-disabled-color: rgba(var(--bs-emphasis-color-rgb), 0.3);
-  --bs-navbar-active-color: rgba(var(--bs-emphasis-color-rgb), 1);
+  --bs-navbar-color: color-mix(in srgb, var(--bs-emphasis-color) 65%, transparent);
+  --bs-navbar-hover-color: color-mix(in srgb, var(--bs-emphasis-color) 80%, transparent);
+  --bs-navbar-disabled-color: color-mix(in srgb, var(--bs-emphasis-color) 30%, transparent);
+  --bs-navbar-active-color: color-mix(in srgb, var(--bs-emphasis-color) 100%, transparent);
   --bs-navbar-brand-padding-y: 0.621875rem;
   --bs-navbar-brand-margin-end: 1rem;
   --bs-navbar-brand-font-size: 1.1875rem;
-  --bs-navbar-brand-color: rgba(var(--bs-emphasis-color-rgb), 1);
-  --bs-navbar-brand-hover-color: rgba(var(--bs-emphasis-color-rgb), 1);
+  --bs-navbar-brand-color: color-mix(in srgb, var(--bs-emphasis-color) 100%, transparent);
+  --bs-navbar-brand-hover-color: color-mix(in srgb, var(--bs-emphasis-color) 100%, transparent);
   --bs-navbar-nav-link-padding-x: 0.5rem;
   --bs-navbar-toggler-padding-y: 0.25rem;
   --bs-navbar-toggler-padding-x: 0.75rem;
   --bs-navbar-toggler-font-size: 1.1875rem;
   --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2823, 23, 32, 0.75%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-  --bs-navbar-toggler-border-color: rgba(var(--bs-emphasis-color-rgb), 0.15);
+  --bs-navbar-toggler-border-color: color-mix(in srgb, var(--bs-emphasis-color) 15%, transparent);
   --bs-navbar-toggler-border-radius: var(--bs-border-radius);
   --bs-navbar-toggler-focus-width: 0.25rem;
   --bs-navbar-toggler-transition: box-shadow 0.15s ease-in-out;
@@ -6141,7 +6169,7 @@ progress {
   --bs-card-inner-border-radius: calc(10px - (var(--bs-border-width)));
   --bs-card-cap-padding-y: 0.75rem;
   --bs-card-cap-padding-x: 1.5rem;
-  --bs-card-cap-bg: rgba(var(--bs-body-color-rgb), 0.03);
+  --bs-card-cap-bg: color-mix(in srgb, var(--bs-body-color) 3%, transparent);
   --bs-card-cap-color: ;
   --bs-card-height: ;
   --bs-card-color: ;
@@ -6631,47 +6659,47 @@ progress {
 }
 
 .focus-ring-primary {
-  --bs-focus-ring-color: rgba(var(--bs-primary-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .focus-ring-secondary {
-  --bs-focus-ring-color: rgba(var(--bs-secondary-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .focus-ring-tertiary {
-  --bs-focus-ring-color: rgba(var(--bs-tertiary-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .focus-ring-success {
-  --bs-focus-ring-color: rgba(var(--bs-success-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .focus-ring-info {
-  --bs-focus-ring-color: rgba(var(--bs-info-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .focus-ring-warning {
-  --bs-focus-ring-color: rgba(var(--bs-warning-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .focus-ring-danger {
-  --bs-focus-ring-color: rgba(var(--bs-danger-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .focus-ring-light {
-  --bs-focus-ring-color: rgba(var(--bs-light-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .focus-ring-dark {
-  --bs-focus-ring-color: rgba(var(--bs-dark-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .focus-ring-graceful {
-  --bs-focus-ring-color: rgba(var(--bs-graceful-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .focus-ring-pleasant {
-  --bs-focus-ring-color: rgba(var(--bs-pleasant-rgb), var(--bs-focus-ring-opacity));
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
 }
 
 .position-static {
@@ -6796,67 +6824,67 @@ progress {
 
 .border-primary {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-primary-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-secondary {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-secondary-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-tertiary {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-tertiary-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-success {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-success-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-info {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-info-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-warning {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-warning-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-danger {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-danger-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-light {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-light-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-dark {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-dark-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-graceful {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-graceful-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-pleasant {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-pleasant-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-black {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-black-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, #171720 calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-white {
   --bs-border-opacity: 1;
-  border-color: rgba(var(--bs-white-rgb), var(--bs-border-opacity)) !important;
+  border-color: color-mix(in srgb, #fff calc(var(--bs-border-opacity) * 100%), transparent) !important;
 }
 
 .border-primary-subtle {
@@ -7916,74 +7944,72 @@ progress {
 }
 
 /* rtl:end:remove */
-.text-primary {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-primary-rgb), var(--bs-text-opacity)) !important;
-}
 
+.text-primary {
+    color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
+}
 .text-secondary {
-  --bs-text-opacity: 1;
-  color: rgba(var(--bs-secondary-rgb), var(--bs-text-opacity)) !important;
+    color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-tertiary {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-tertiary-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-success {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-success-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, var(--bs-success) calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-info {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-info-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, var(--bs-info) calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-warning {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-warning-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-danger {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-danger-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-light {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-light-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, var(--bs-light) calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-dark {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-dark-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-graceful {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-graceful-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-pleasant {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-pleasant-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-black {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-black-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, #171720 calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-white {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-white-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, #fff calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-body {
   --bs-text-opacity: 1;
-  color: rgba(var(--bs-body-color-rgb), var(--bs-text-opacity)) !important;
+  color: color-mix(in srgb, var(--bs-body-color) calc(var(--bs-text-opacity) * 100%), transparent) !important;
 }
 
 .text-muted {
@@ -8135,62 +8161,62 @@ progress {
 
 .link-underline-primary {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-primary-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline-secondary {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-secondary-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline-tertiary {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-tertiary-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline-success {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-success-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline-info {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-info-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline-warning {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-warning-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline-danger {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-danger-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline-light {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-light-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline-dark {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-dark-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline-graceful {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-graceful-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline-pleasant {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-pleasant-rgb), var(--bs-link-underline-opacity)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
 }
 
 .link-underline {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: rgba(var(--bs-link-color-rgb), var(--bs-link-underline-opacity, 1)) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-link-color) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-opacity-0 {
@@ -8243,72 +8269,72 @@ progress {
 
 .bg-primary {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-primary-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-secondary {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-secondary-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-tertiary {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-tertiary-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-success {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-success-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-info {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-info-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-warning {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-warning-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-danger {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-danger-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-light {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-light-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-dark {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-dark-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-graceful {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-graceful-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-pleasant {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-pleasant-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-black {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-black-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, #171720 calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-white {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-white-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, #fff calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-body {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-body-bg-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-body-bg) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-transparent {
@@ -8318,12 +8344,12 @@ progress {
 
 .bg-body-secondary {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-secondary-bg-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-secondary-bg) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-body-tertiary {
   --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-tertiary-bg-rgb), var(--bs-bg-opacity)) !important;
+  background-color: color-mix(in srgb, var(--bs-tertiary-bg) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
 }
 
 .bg-opacity-10 {

--- a/www/css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css
+++ b/www/css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css
@@ -348,7 +348,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: rgb(19.55, 19.55, 27.2);
   --bs-btn-hover-border-color: rgb(18.4, 18.4, 25.6);
-  --bs-btn-focus-shadow-color: var(--bs-primary);
+  --bs-btn-focus-shadow-color: rgb(57.8, 57.8, 65.45);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: rgb(18.4, 18.4, 25.6);
   --bs-btn-active-border-color: rgb(17.25, 17.25, 24);
@@ -365,7 +365,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: rgb(91.8, 99.45, 106.25);
   --bs-btn-hover-border-color: rgb(86.4, 93.6, 100);
-  --bs-btn-focus-shadow-color: var(--bs-secondary);
+  --bs-btn-focus-shadow-color: rgb(130.05, 137.7, 144.5);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: rgb(86.4, 93.6, 100);
   --bs-btn-active-border-color: rgb(81, 87.75, 93.75);
@@ -382,7 +382,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(213.35, 218.45, 223.55);
   --bs-btn-hover-border-color: rgb(210.9, 216.3, 221.7);
-  --bs-btn-focus-shadow-color: var(--bs-tertiary);
+  --bs-btn-focus-shadow-color: rgb(178.55, 183.65, 190.1);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(215.8, 220.6, 225.4);
   --bs-btn-active-border-color: rgb(210.9, 216.3, 221.7);
@@ -399,7 +399,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(111.35, 193.8, 119.85);
   --bs-btn-hover-border-color: rgb(102.9, 190.2, 111.9);
-  --bs-btn-focus-shadow-color: var(--bs-success);
+  --bs-btn-focus-shadow-color: rgb(76.55, 159, 86.4);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(119.8, 197.4, 127.8);
   --bs-btn-active-border-color: rgb(102.9, 190.2, 111.9);
@@ -416,7 +416,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(57.8, 175.95, 194.65);
   --bs-btn-hover-border-color: rgb(46.2, 171.3, 191.1);
-  --bs-btn-focus-shadow-color: var(--bs-info);
+  --bs-btn-focus-shadow-color: rgb(23, 141.15, 161.2);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(69.4, 180.6, 198.2);
   --bs-btn-active-border-color: rgb(46.2, 171.3, 191.1);
@@ -433,7 +433,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(243.95, 198.05, 119);
   --bs-btn-hover-border-color: rgb(243.3, 194.7, 111);
-  --bs-btn-focus-shadow-color: var(--bs-warning);
+  --bs-btn-focus-shadow-color: rgb(209.15, 163.25, 85.55);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(244.6, 201.4, 127);
   --bs-btn-active-border-color: rgb(243.3, 194.7, 111);
@@ -450,7 +450,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(247.35, 86.7, 86.7);
   --bs-btn-hover-border-color: rgb(246.9, 76.8, 76.8);
-  --bs-btn-focus-shadow-color: var(--bs-danger);
+  --bs-btn-focus-shadow-color: rgb(212.55, 51.9, 53.25);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(247.8, 96.6, 96.6);
   --bs-btn-active-border-color: rgb(246.9, 76.8, 76.8);
@@ -467,7 +467,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(205.7, 209.1, 209.1);
   --bs-btn-hover-border-color: rgb(193.6, 196.8, 196.8);
-  --bs-btn-focus-shadow-color: var(--bs-light);
+  --bs-btn-focus-shadow-color: rgb(209.15, 212.55, 213.9);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(193.6, 196.8, 196.8);
   --bs-btn-active-border-color: rgb(181.5, 184.5, 184.5);
@@ -484,7 +484,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: rgb(82.45, 87.55, 92.65);
   --bs-btn-hover-border-color: rgb(72.3, 77.7, 83.1);
-  --bs-btn-focus-shadow-color: var(--bs-dark);
+  --bs-btn-focus-shadow-color: rgb(82.45, 87.55, 92.65);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: rgb(92.6, 97.4, 102.2);
   --bs-btn-active-border-color: rgb(72.3, 77.7, 83.1);
@@ -501,7 +501,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: rgb(94.35, 56.1, 164.05);
   --bs-btn-hover-border-color: rgb(88.8, 52.8, 154.4);
-  --bs-btn-focus-shadow-color: var(--bs-graceful);
+  --bs-btn-focus-shadow-color: rgb(132.6, 94.35, 202.3);
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: rgb(88.8, 52.8, 154.4);
   --bs-btn-active-border-color: rgb(83.25, 49.5, 144.75);
@@ -518,7 +518,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: rgb(129.2, 164.9, 238.85);
   --bs-btn-hover-border-color: rgb(121.8, 159.6, 237.9);
-  --bs-btn-focus-shadow-color: var(--bs-pleasant);
+  --bs-btn-focus-shadow-color: rgb(94.4, 130.1, 205.4);
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: rgb(136.6, 170.2, 239.8);
   --bs-btn-active-border-color: rgb(121.8, 159.6, 237.9);
@@ -534,7 +534,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #171720;
   --bs-btn-hover-border-color: #171720;
-  --bs-btn-focus-shadow-color: var(--bs-primary);
+  --bs-btn-focus-shadow-color: #171720;
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #171720;
   --bs-btn-active-border-color: #171720;
@@ -551,7 +551,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #6c757d;
   --bs-btn-hover-border-color: #6c757d;
-  --bs-btn-focus-shadow-color: var(--bs-secondary);
+  --bs-btn-focus-shadow-color: #6c757d;
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #6c757d;
   --bs-btn-active-border-color: #6c757d;
@@ -568,7 +568,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #ced4da;
   --bs-btn-hover-border-color: #ced4da;
-  --bs-btn-focus-shadow-color: var(--bs-tertiary);
+  --bs-btn-focus-shadow-color: #ced4da;
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #ced4da;
   --bs-btn-active-border-color: #ced4da;
@@ -585,7 +585,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #56B760;
   --bs-btn-hover-border-color: #56B760;
-  --bs-btn-focus-shadow-color: var(--bs-success);
+  --bs-btn-focus-shadow-color: #56B760;
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #56B760;
   --bs-btn-active-border-color: #56B760;
@@ -602,7 +602,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #17a2b8;
   --bs-btn-hover-border-color: #17a2b8;
-  --bs-btn-focus-shadow-color: var(--bs-info);
+  --bs-btn-focus-shadow-color: #17a2b8;
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #17a2b8;
   --bs-btn-active-border-color: #17a2b8;
@@ -619,7 +619,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #F2BC5F;
   --bs-btn-hover-border-color: #F2BC5F;
-  --bs-btn-focus-shadow-color: var(--bs-warning);
+  --bs-btn-focus-shadow-color: #F2BC5F;
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #F2BC5F;
   --bs-btn-active-border-color: #F2BC5F;
@@ -636,7 +636,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #F63939;
   --bs-btn-hover-border-color: #F63939;
-  --bs-btn-focus-shadow-color: var(--bs-danger);
+  --bs-btn-focus-shadow-color: #F63939;
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #F63939;
   --bs-btn-active-border-color: #F63939;
@@ -653,7 +653,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #f2f6f6;
   --bs-btn-hover-border-color: #f2f6f6;
-  --bs-btn-focus-shadow-color: var(--bs-light);
+  --bs-btn-focus-shadow-color: #f2f6f6;
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #f2f6f6;
   --bs-btn-active-border-color: #f2f6f6;
@@ -670,7 +670,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #343a40;
   --bs-btn-hover-border-color: #343a40;
-  --bs-btn-focus-shadow-color: var(--bs-dark);
+  --bs-btn-focus-shadow-color: #343a40;
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #343a40;
   --bs-btn-active-border-color: #343a40;
@@ -687,7 +687,7 @@
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #6f42c1;
   --bs-btn-hover-border-color: #6f42c1;
-  --bs-btn-focus-shadow-color: var(--bs-graceful);
+  --bs-btn-focus-shadow-color: #6f42c1;
   --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #6f42c1;
   --bs-btn-active-border-color: #6f42c1;
@@ -704,7 +704,7 @@
   --bs-btn-hover-color: #171720;
   --bs-btn-hover-bg: #6B95EC;
   --bs-btn-hover-border-color: #6B95EC;
-  --bs-btn-focus-shadow-color: var(--bs-pleasant);
+  --bs-btn-focus-shadow-color: #6B95EC;
   --bs-btn-active-color: #171720;
   --bs-btn-active-bg: #6B95EC;
   --bs-btn-active-border-color: #6B95EC;
@@ -727,7 +727,7 @@
   --bs-btn-disabled-color: #6c757d;
   --bs-btn-disabled-border-color: transparent;
   --bs-btn-box-shadow: 0 0 0 #000;
-  --bs-btn-focus-shadow-color: var(--bs-link-color);
+  --bs-btn-focus-shadow-color: rgb(100.3, 106.25, 112.2);
   text-decoration: underline;
 }
 .btn-link:hover, .btn-link:focus-visible {
@@ -4586,8 +4586,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-primary:hover, .link-primary:focus {
-  color: RGBA(18, 18, 26, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(18, 18, 26, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(18.4, 18.4, 25.6) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(18.4, 18.4, 25.6) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-secondary {
@@ -4595,8 +4595,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-secondary:hover, .link-secondary:focus {
-  color: RGBA(86, 94, 100, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(86, 94, 100, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(86.4, 93.6, 100) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(86.4, 93.6, 100) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-tertiary {
@@ -4604,8 +4604,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-tertiary:hover, .link-tertiary:focus {
-  color: RGBA(216, 221, 225, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(216, 221, 225, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(215.8, 220.6, 225.4) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(215.8, 220.6, 225.4) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-success {
@@ -4613,8 +4613,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-success:hover, .link-success:focus {
-  color: RGBA(120, 197, 128, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(120, 197, 128, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(119.8, 197.4, 127.8) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(119.8, 197.4, 127.8) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-info {
@@ -4622,8 +4622,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-info:hover, .link-info:focus {
-  color: RGBA(69, 181, 198, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(69, 181, 198, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(69.4, 180.6, 198.2) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(69.4, 180.6, 198.2) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-warning {
@@ -4631,8 +4631,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-warning:hover, .link-warning:focus {
-  color: RGBA(245, 201, 127, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(245, 201, 127, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(244.6, 201.4, 127) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(244.6, 201.4, 127) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-danger {
@@ -4640,8 +4640,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-danger:hover, .link-danger:focus {
-  color: RGBA(248, 97, 97, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(248, 97, 97, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(247.8, 96.6, 96.6) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(247.8, 96.6, 96.6) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-light {
@@ -4649,8 +4649,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-light:hover, .link-light:focus {
-  color: RGBA(245, 248, 248, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(245, 248, 248, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(244.6, 247.8, 247.8) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(244.6, 247.8, 247.8) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-dark {
@@ -4658,8 +4658,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-dark:hover, .link-dark:focus {
-  color: RGBA(42, 46, 51, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(42, 46, 51, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(41.6, 46.4, 51.2) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(41.6, 46.4, 51.2) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-graceful {
@@ -4667,8 +4667,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-graceful:hover, .link-graceful:focus {
-  color: RGBA(89, 53, 154, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(89, 53, 154, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(88.8, 52.8, 154.4) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(88.8, 52.8, 154.4) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-pleasant {
@@ -4676,8 +4676,8 @@ progress {
   text-decoration-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 .link-pleasant:hover, .link-pleasant:focus {
-  color: RGBA(137, 170, 240, var(--bs-link-opacity, 1)) !important;
-  text-decoration-color: RGBA(137, 170, 240, var(--bs-link-underline-opacity, 1)) !important;
+  color: color-mix(in srgb, rgb(136.6, 170.2, 239.8) calc(var(--bs-link-opacity, 1) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, rgb(136.6, 170.2, 239.8) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-body-emphasis {
@@ -6659,47 +6659,47 @@ progress {
 }
 
 .focus-ring-primary {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .focus-ring-secondary {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .focus-ring-tertiary {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .focus-ring-success {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .focus-ring-info {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .focus-ring-warning {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .focus-ring-danger {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .focus-ring-light {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .focus-ring-dark {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .focus-ring-graceful {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .focus-ring-pleasant {
-  --bs-focus-ring-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-focus-ring-opacity) * 100%), transparent);
+  --bs-focus-ring-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-focus-ring-opacity, 1) * 100%), transparent);
 }
 
 .position-static {
@@ -6824,67 +6824,67 @@ progress {
 
 .border-primary {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-secondary {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-tertiary {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-success {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-info {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-warning {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-danger {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-light {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-dark {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-graceful {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-pleasant {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-black {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, #171720 calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, #171720 calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-white {
   --bs-border-opacity: 1;
-  border-color: color-mix(in srgb, #fff calc(var(--bs-border-opacity) * 100%), transparent) !important;
+  border-color: color-mix(in srgb, #fff calc(var(--bs-border-opacity, 1) * 100%), transparent) !important;
 }
 
 .border-primary-subtle {
@@ -7944,72 +7944,74 @@ progress {
 }
 
 /* rtl:end:remove */
-
 .text-primary {
-    color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
+  --bs-text-opacity: 1;
+  color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
+
 .text-secondary {
-    color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
+  --bs-text-opacity: 1;
+  color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-tertiary {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-success {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, var(--bs-success) calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, var(--bs-success) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-info {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, var(--bs-info) calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, var(--bs-info) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-warning {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-danger {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-light {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, var(--bs-light) calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, var(--bs-light) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-dark {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-graceful {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-pleasant {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-black {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, #171720 calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, #171720 calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-white {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, #fff calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, #fff calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-body {
   --bs-text-opacity: 1;
-  color: color-mix(in srgb, var(--bs-body-color) calc(var(--bs-text-opacity) * 100%), transparent) !important;
+  color: color-mix(in srgb, var(--bs-body-color) calc(var(--bs-text-opacity, 1) * 100%), transparent) !important;
 }
 
 .text-muted {
@@ -8161,57 +8163,57 @@ progress {
 
 .link-underline-primary {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-secondary {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-tertiary {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-success {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-info {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-warning {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-danger {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-light {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-dark {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-graceful {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline-pleasant {
   --bs-link-underline-opacity: 1;
-  text-decoration-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-link-underline-opacity) * 100%), transparent) !important;
+  text-decoration-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-link-underline-opacity, 1) * 100%), transparent) !important;
 }
 
 .link-underline {
@@ -8269,72 +8271,72 @@ progress {
 
 .bg-primary {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-primary) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-secondary {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-secondary) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-tertiary {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-tertiary) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-success {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-success) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-info {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-info) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-warning {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-warning) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-danger {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-danger) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-light {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-light) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-dark {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-dark) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-graceful {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-graceful) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-pleasant {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-pleasant) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-black {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, #171720 calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, #171720 calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-white {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, #fff calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, #fff calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-body {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-body-bg) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-body-bg) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-transparent {
@@ -8344,12 +8346,12 @@ progress {
 
 .bg-body-secondary {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-secondary-bg) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-secondary-bg) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-body-tertiary {
   --bs-bg-opacity: 1;
-  background-color: color-mix(in srgb, var(--bs-tertiary-bg) calc(var(--bs-bg-opacity) * 100%), transparent) !important;
+  background-color: color-mix(in srgb, var(--bs-tertiary-bg) calc(var(--bs-bg-opacity, 1) * 100%), transparent) !important;
 }
 
 .bg-opacity-10 {

--- a/www/css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css
+++ b/www/css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css
@@ -14110,21 +14110,21 @@ progress {
   }
 }
 .buttons, .ui-dialog-buttonset button {
-  color: #171720;
+  color: var(--bs-body-color);
   background-color: transparent;
   background-image: none;
-  border-color: #171720;
+  border-color: var(--bs-body-color);
 }
 .buttons:hover, .ui-dialog-buttonset button:hover {
-  color: #fff;
-  background-color: #171720;
-  border-color: #171720;
+  color: var(--bs-body-bg);
+  background-color: var(--bs-body-color);
+  border-color: var(--bs-body-color);
 }
 .buttons:focus, .ui-dialog-buttonset button:focus, .buttons.focus, .ui-dialog-buttonset button.focus {
-  box-shadow: 0 0 0 0.25rem rgba(23, 23, 32, 0.5);
+  box-shadow: 0 0 0 0.25rem rgba(0, 0, 0, 0.25);
 }
 .buttons.disabled, .ui-dialog-buttonset button.disabled, .pageContent .buttons.disableButtons, .pageContent .ui-dialog-buttonset button.disableButtons, .ui-dialog-buttonset .pageContent button.disableButtons, .ui-dialog .buttons.disableButtons, .ui-dialog .ui-dialog-buttonset button.disableButtons, .ui-dialog-buttonset .ui-dialog button.disableButtons, .modal .buttons.disableButtons, .modal .ui-dialog-buttonset button.disableButtons, .ui-dialog-buttonset .modal button.disableButtons, .buttons:disabled, .ui-dialog-buttonset button:disabled {
-  color: #171720;
+  color: var(--bs-body-color);
   background-color: transparent;
 }
 .fppTableContents .buttons, .fppTableContents .ui-dialog-buttonset button, .ui-dialog-buttonset .fppTableContents button {
@@ -17840,7 +17840,7 @@ body.mobile-menu-open .hamburger--spin .hamburger-inner::after {
   }
 }
 .ajax-file-upload-statusbar {
-  background-color: #F5F5F5;
+  background-color: var(--bs-secondary-bg);
   border-radius: 12px;
 }
 .ajax-file-upload-statusbar .backdrop, .ajax-file-upload-statusbar .backdrop-disabled, .ajax-file-upload-statusbar .backdrop-success, .ajax-file-upload-statusbar .backdrop-dark {
@@ -18161,13 +18161,13 @@ hr {
   font-size: 1.425rem;
   font-weight: 700;
   line-height: 1;
-  color: #171720;
-  text-shadow: 0 1px 0 #fff;
+  color: var(--bs-body-color);
+  text-shadow: none;
   opacity: 0.5;
 }
 
 .close:hover {
-  color: #171720;
+  color: var(--bs-body-color);
   text-decoration: none;
 }
 
@@ -18182,9 +18182,9 @@ button.close {
 }
 
 .tooltip-inner {
-  background-color: #fff;
-  color: #171720;
-  border-color: #171720;
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  border-color: var(--bs-body-color);
   border-width: 1px;
   border-style: solid;
 }
@@ -18289,7 +18289,7 @@ button.close {
 
 .custom-radio .custom-control-input:checked ~ .custom-control-label::before {
   border-color: #6B95EC;
-  background-color: #fff;
+  background-color: var(--bs-body-bg);
 }
 
 .custom-radio .custom-control-input:checked ~ .custom-control-label::after {
@@ -18318,8 +18318,8 @@ input[type=text]::placeholder, input[type=number]::placeholder, input[type=passw
   opacity: 1;
 }
 input[type=text], input[type=number], input[type=password], input[type=email], input[type=date], input[type=search], select {
-  border: 1px solid #D2D2D2;
-  color: #171720;
+  border: 1px solid var(--bs-border-color);
+  color: var(--bs-body-color);
   -webkit-appearance: none;
      -moz-appearance: none;
           appearance: none;
@@ -18356,7 +18356,8 @@ input[type=date]::-webkit-calendar-picker-indicator {
 }
 
 .pageContent select, .ui-dialog select, .modal select {
-  background: #fff url(../../../images/redesign/chevron-down-grey.svg) no-repeat;
+  background-image: url(../../../images/redesign/chevron-down-grey.svg);
+  background-repeat: no-repeat;
   background-position: right 9px center;
   background-size: 15px;
   padding-right: 1.8em;
@@ -18365,6 +18366,10 @@ input[type=date]::-webkit-calendar-picker-indicator {
 }
 .pageContent select.form-control-lg, .ui-dialog select.form-control-lg, .modal select.form-control-lg {
   background-position: right 20px center;
+}
+
+[data-bs-theme=dark] .pageContent select, [data-bs-theme=dark] .ui-dialog select, [data-bs-theme=dark] .modal select {
+  background-image: url(../../../images/redesign/chevron-down-white.svg);
 }
 
 textarea {
@@ -18378,7 +18383,7 @@ input[type=checkbox], .form-inline input[type=checkbox] {
   cursor: pointer;
   box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.1);
   border-radius: 1.5em;
-  border: 1px solid #D2D2D2;
+  border: 1px solid var(--bs-border-color);
   display: inline-block;
   border-radius: 3px;
   width: 33px;
@@ -18424,8 +18429,8 @@ input[type=checkbox][disabled=""]:checked {
 }
 
 .pageContent .nav-link {
-  border: 1px solid #DADADA;
-  color: #171720;
+  border: 1px solid var(--bs-border-color);
+  color: var(--bs-body-color);
   font-weight: bold;
   transition: 0.2s all ease-in-out;
 }
@@ -18457,7 +18462,7 @@ input[type=checkbox][disabled=""]:checked {
 }
 
 .badge-light {
-  background-color: #ECECEC;
+  background-color: var(--bs-secondary-bg);
 }
 
 .alert {
@@ -18678,7 +18683,7 @@ input[type=checkbox][disabled=""]:checked {
 }
 .or-v span {
   transform: translateX(-50%);
-  background-color: #fff;
+  background-color: var(--bs-body-bg);
   display: inline-block;
   padding: 0.2em;
 }
@@ -18692,7 +18697,7 @@ input[type=checkbox][disabled=""]:checked {
 }
 
 .backdrop, .backdrop-disabled, .backdrop-success, .backdrop-dark {
-  background-color: #F5F5F5;
+  background-color: var(--bs-secondary-bg);
   border-radius: 12px;
 }
 .backdrop .backdrop, .backdrop-disabled .backdrop, .backdrop .backdrop-disabled, .backdrop-disabled .backdrop-disabled, .backdrop-success .backdrop, .backdrop-success .backdrop-disabled, .backdrop .backdrop-success, .backdrop-disabled .backdrop-success, .backdrop-success .backdrop-success, .backdrop-dark .backdrop, .backdrop-dark .backdrop-disabled, .backdrop-dark .backdrop-success, .backdrop .backdrop-dark, .backdrop-disabled .backdrop-dark, .backdrop-success .backdrop-dark, .backdrop-dark .backdrop-dark {
@@ -18709,7 +18714,7 @@ input[type=checkbox][disabled=""]:checked {
 }
 
 .backdrop-dark {
-  background-color: #ECECEC;
+  background-color: var(--bs-tertiary-bg);
 }
 
 .backdrop-success {
@@ -18797,9 +18802,9 @@ table.settingsTable div.th {
 }
 
 [role=region][aria-labelledby][tabindex] {
-  background: linear-gradient(to right, #fff 30%, rgba(255, 255, 255, 0)), linear-gradient(to right, rgba(255, 255, 255, 0), #fff 70%) 0 100%, radial-gradient(farthest-side at 0% 50%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)), radial-gradient(farthest-side at 100% 50%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+  background: linear-gradient(to right, var(--bs-body-bg) 30%, rgba(0, 0, 0, 0)), linear-gradient(to right, rgba(0, 0, 0, 0), var(--bs-body-bg) 70%) 0 100%, radial-gradient(farthest-side at 0% 50%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)), radial-gradient(farthest-side at 100% 50%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
   background-repeat: no-repeat;
-  background-color: #fff;
+  background-color: var(--bs-body-bg);
   background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
   background-position: 0 0, 100%, 0 0, 100%;
   background-attachment: local, local, scroll, scroll;
@@ -18812,11 +18817,12 @@ table.settingsTable div.th {
 }
 
 .backdrop [role=region][aria-labelledby][tabindex], .backdrop-dark [role=region][aria-labelledby][tabindex], .backdrop-success [role=region][aria-labelledby][tabindex], .backdrop-disabled [role=region][aria-labelledby][tabindex] {
-  background: linear-gradient(to right, #F5F5F5 30%, rgba(255, 255, 255, 0)), linear-gradient(to right, rgba(255, 255, 255, 0), #F5F5F5 70%) 0 100%, radial-gradient(farthest-side at 0% 50%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)), radial-gradient(farthest-side at 100% 50%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+  background: linear-gradient(to right, var(--bs-secondary-bg) 30%, rgba(0, 0, 0, 0)), linear-gradient(to right, rgba(0, 0, 0, 0), var(--bs-secondary-bg) 70%) 0 100%, radial-gradient(farthest-side at 0% 50%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)), radial-gradient(farthest-side at 100% 50%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+  background-color: var(--bs-secondary-bg);
 }
 
 [role=region][aria-labelledby][tabindex] > table {
-  mix-blend-mode: multiply;
+  mix-blend-mode: normal;
 }
 
 [role=region][aria-labelledby][tabindex]:focus {
@@ -18846,12 +18852,12 @@ table.settingsTable div.th {
 .fppSelectableRowTable > tbody > tr > td {
   padding-top: 0.25em;
   padding-bottom: 0.25em;
-  background-color: #F5F5F5;
-  border-bottom: 1px solid #d5d7da;
+  background-color: var(--bs-tertiary-bg);
+  border-bottom: 1px solid var(--bs-border-color);
 }
 
 .fppSelectableRowTable > tbody > tr:first-child {
-  border-top-color: lightgray;
+  border-top-color: var(--bs-border-color);
   border-top-style: inherit;
   border-top-width: 0.15em;
 }
@@ -18879,7 +18885,7 @@ table.settingsTable div.th {
 
 .fppSelectableRowTable > tbody > tr:first-child > td:last-child, #tblSchedule > tbody > tr:first-child > td:nth-last-child(2) {
   border-top-right-radius: 8px;
-  border-top-color: lightgray;
+  border-top-color: var(--bs-border-color);
   border-top-style: inherit;
   border-top-width: 0.15em;
 }
@@ -18905,7 +18911,7 @@ table.settingsTable div.th {
 }
 
 .fppSelectableRowTable > tbody > tr > th {
-  border-bottom: 1px solid #dee2e6;
+  border-bottom: 1px solid var(--bs-border-color);
 }
 
 .fppSelectableRowTable > tbody > tr.selectedEntry > td,
@@ -18926,8 +18932,8 @@ table.settingsTable div.th {
 .fppActionTable > tbody > tr > td {
   padding-top: 0.6em;
   padding-bottom: 0.6em;
-  background-color: #F5F5F5;
-  border-bottom: 1px solid #dee2e6;
+  background-color: var(--bs-tertiary-bg);
+  border-bottom: 1px solid var(--bs-border-color);
 }
 
 .fppActionTable.fppActionTable-success > tbody > tr > td {
@@ -18937,7 +18943,7 @@ table.settingsTable div.th {
 }
 
 .fppActionTable > tbody > tr:hover > td {
-  background-color: #ECECEC;
+  background-color: var(--bs-secondary-bg);
 }
 
 .fppActionTable.fppActionTable-success > tbody > tr:hover > td {
@@ -19046,10 +19052,9 @@ table.settingsTable div.th {
 }
 
 input[type=file]::file-selector-button {
-  color: #171720;
-  border-color: #171720;
+  color: var(--bs-body-color);
+  border-color: var(--bs-border-color);
   background-color: transparent;
-  border-color: #171720;
   padding-top: 0.33rem;
   padding-bottom: 0.33rem;
   padding-left: 0.65rem;
@@ -19058,14 +19063,14 @@ input[type=file]::file-selector-button {
   font-weight: bold;
   line-height: 1.5;
   border-radius: 0.25rem;
-  border: 1px solid;
+  border: 1px solid var(--bs-border-color);
 }
 
 input[type=file]::file-selector-button:hover {
-  background-color: #171720;
-  color: #FFFFFF;
+  background-color: var(--bs-secondary-bg);
+  color: var(--bs-body-color);
 }
 
 .form-select {
   display: inline-block;
-}/*# sourceMappingURL=fpp-bootstrap-5-3.css.map */
+}

--- a/www/css/fpp-bootstrap/src/_buttons.scss
+++ b/www/css/fpp-bootstrap/src/_buttons.scss
@@ -2,7 +2,26 @@
 
 .buttons {
   @extend .btn;
-  @include fpp-btn-outline-variant($black);
+  color: var(--bs-body-color);
+  background-color: transparent;
+  background-image: none;
+  border-color: var(--bs-body-color);
+
+  &:hover {
+    color: var(--bs-body-bg);
+    background-color: var(--bs-body-color);
+    border-color: var(--bs-body-color);
+  }
+
+  &:focus, &.focus {
+    box-shadow: 0 0 0 $btn-focus-width rgba(0,0,0,.25);
+  }
+
+  &.disabled, &:disabled {
+    color: var(--bs-body-color);
+    background-color: transparent;
+  }
+
   .fppTableContents &{
     padding-top: $btn-padding-y-sm;
     padding-bottom: $btn-padding-y-sm;

--- a/www/css/fpp-bootstrap/src/_mixins.scss
+++ b/www/css/fpp-bootstrap/src/_mixins.scss
@@ -1,12 +1,12 @@
 @mixin backdrop(){
-    background-color: $gray-lighter;
+    background-color: var(--bs-secondary-bg);
     border-radius: 12px;
     .backdrop{
         border-radius: 8px;
     }
 }
 @mixin backdrop-dark(){
-    background-color: $gray-light;
+    background-color: var(--bs-tertiary-bg);
     border-radius: 8px;
 }
 @function img($filename) {

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/_buttons.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/_buttons.scss
@@ -18,7 +18,8 @@
   --#{$prefix}btn-hover-border-color: transparent;
   --#{$prefix}btn-box-shadow: #{$btn-box-shadow};
   --#{$prefix}btn-disabled-opacity: #{$btn-disabled-opacity};
-  --#{$prefix}btn-focus-box-shadow: 0 0 0 #{$btn-focus-width} rgba(var(--#{$prefix}btn-focus-shadow-rgb), .5);
+  --#{$prefix}btn-focus-shadow-color: var(--#{$prefix}body-color);
+  --#{$prefix}btn-focus-box-shadow: 0 0 0 #{$btn-focus-width} color-mix(in srgb, var(--#{$prefix}btn-focus-shadow-color) 50%, transparent);
   // scss-docs-end btn-css-vars
 
   display: inline-block;
@@ -179,7 +180,7 @@
   --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
   --#{$prefix}btn-disabled-border-color: transparent;
   --#{$prefix}btn-box-shadow: 0 0 0 #000; // Can't use `none` as keyword negates all values when used with multiple shadows
-  --#{$prefix}btn-focus-shadow-rgb: #{$btn-link-focus-shadow-rgb};
+  --#{$prefix}btn-focus-shadow-color: #{$btn-link-focus-shadow-color};
 
   text-decoration: $link-decoration;
   @if $enable-gradients {

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/_functions.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/_functions.scss
@@ -37,15 +37,16 @@
   @return red($value), green($value), blue($value);
 }
 
-// stylelint-disable scss/dollar-variable-pattern
-@function rgba-css-var($identifier, $target) {
-  @if $identifier == "body" and $target == "bg" {
-    @return rgba(var(--#{$prefix}#{$identifier}-bg-rgb), var(--#{$prefix}#{$target}-opacity));
-  } @if $identifier == "body" and $target == "text" {
-    @return rgba(var(--#{$prefix}#{$identifier}-color-rgb), var(--#{$prefix}#{$target}-opacity));
-  } @else {
-    @return rgba(var(--#{$prefix}#{$identifier}-rgb), var(--#{$prefix}#{$target}-opacity));
-  }
+@function css-var($identifier) {
+  @return unquote("var(--#{$prefix}#{$identifier})");
+}
+
+@function css-color-mix($color, $opacity-variable, $fallback: 1) {
+  @return unquote("color-mix(in srgb, #{$color} calc(var(--#{$prefix}#{$opacity-variable}, #{$fallback}) * 100%), transparent)");
+}
+
+@function css-color-mix-static($color, $opacity) {
+  @return unquote("color-mix(in srgb, #{$color} #{percentage($opacity)}, transparent)");
 }
 
 @function map-loop($map, $func, $args...) {
@@ -63,8 +64,6 @@
 
   @return $_map;
 }
-// stylelint-enable scss/dollar-variable-pattern
-
 @function varify($list) {
   $result: null;
   @each $entry in $list {

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/_maps.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/_maps.scss
@@ -2,10 +2,6 @@
 //
 // Placed here so that others can override the default Sass maps and see automatic updates to utilities and more.
 
-// scss-docs-start theme-colors-rgb
-$theme-colors-rgb: map-loop($theme-colors, to-rgb, "$value") !default;
-// scss-docs-end theme-colors-rgb
-
 // scss-docs-start theme-text-map
 $theme-colors-text: (
   "primary": $primary-text-emphasis,
@@ -96,19 +92,19 @@ $theme-colors-border-subtle-dark: null !default;
 
 // Come v6, we'll de-dupe these variables. Until then, for backward compatibility, we keep them to reassign.
 // scss-docs-start utilities-colors
-$utilities-colors: $theme-colors-rgb !default;
+$utilities-colors: map-loop($theme-colors, css-var, "$key") !default;
 // scss-docs-end utilities-colors
 
 // scss-docs-start utilities-text-colors
 $utilities-text: map-merge(
   $utilities-colors,
   (
-    "black": to-rgb($black),
-    "white": to-rgb($white),
-    "body": to-rgb($body-color)
+    "black": $black,
+    "white": $white,
+    "body": css-var("body-color")
   )
 ) !default;
-$utilities-text-colors: map-loop($utilities-text, rgba-css-var, "$key", "text") !default;
+$utilities-text-colors: map-loop($utilities-text, css-color-mix, "$value", "text-opacity", 1) !default;
 
 $utilities-text-emphasis-colors: (
   "primary-emphasis": var(--#{$prefix}primary-text-emphasis),
@@ -126,12 +122,12 @@ $utilities-text-emphasis-colors: (
 $utilities-bg: map-merge(
   $utilities-colors,
   (
-    "black": to-rgb($black),
-    "white": to-rgb($white),
-    "body": to-rgb($body-bg)
+    "black": $black,
+    "white": $white,
+    "body": css-var("body-bg")
   )
 ) !default;
-$utilities-bg-colors: map-loop($utilities-bg, rgba-css-var, "$key", "bg") !default;
+$utilities-bg-colors: map-loop($utilities-bg, css-color-mix, "$value", "bg-opacity", 1) !default;
 
 $utilities-bg-subtle: (
   "primary-subtle": var(--#{$prefix}primary-bg-subtle),
@@ -149,11 +145,11 @@ $utilities-bg-subtle: (
 $utilities-border: map-merge(
   $utilities-colors,
   (
-    "black": to-rgb($black),
-    "white": to-rgb($white)
+    "black": $black,
+    "white": $white
   )
 ) !default;
-$utilities-border-colors: map-loop($utilities-border, rgba-css-var, "$key", "border") !default;
+$utilities-border-colors: map-loop($utilities-border, css-color-mix, "$value", "border-opacity", 1) !default;
 
 $utilities-border-subtle: (
   "primary-subtle": var(--#{$prefix}primary-border-subtle),
@@ -167,7 +163,7 @@ $utilities-border-subtle: (
 ) !default;
 // scss-docs-end utilities-border-colors
 
-$utilities-links-underline: map-loop($utilities-colors, rgba-css-var, "$key", "link-underline") !default;
+$utilities-links-underline: map-loop($utilities-colors, css-color-mix, "$value", "link-underline-opacity", 1) !default;
 
 $negative-spacers: if($enable-negative-margins, negativify-map($spacers), null) !default;
 

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/_reboot.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/_reboot.scss
@@ -242,11 +242,11 @@ sup { top: -.5em; }
 // Links
 
 a {
-  color: rgba(var(--#{$prefix}link-color-rgb), var(--#{$prefix}link-opacity, 1));
+  color: css-color-mix(var(--#{$prefix}link-color), "link-opacity", 1);
   text-decoration: $link-decoration;
 
   &:hover {
-    --#{$prefix}link-color-rgb: var(--#{$prefix}link-hover-color-rgb);
+    color: css-color-mix(var(--#{$prefix}link-hover-color), "link-opacity", 1);
     text-decoration: $link-hover-decoration;
   }
 }

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/_root.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/_root.scss
@@ -18,10 +18,6 @@
     --#{$prefix}#{$color}: #{$value};
   }
 
-  @each $color, $value in $theme-colors-rgb {
-    --#{$prefix}#{$color}-rgb: #{$value};
-  }
-
   @each $color, $value in $theme-colors-text {
     --#{$prefix}#{$color}-text-emphasis: #{$value};
   }
@@ -33,9 +29,6 @@
   @each $color, $value in $theme-colors-border-subtle {
     --#{$prefix}#{$color}-border-subtle: #{$value};
   }
-
-  --#{$prefix}white-rgb: #{to-rgb($white)};
-  --#{$prefix}black-rgb: #{to-rgb($black)};
 
   // Fonts
 
@@ -59,33 +52,23 @@
   }
 
   --#{$prefix}body-color: #{$body-color};
-  --#{$prefix}body-color-rgb: #{to-rgb($body-color)};
   --#{$prefix}body-bg: #{$body-bg};
-  --#{$prefix}body-bg-rgb: #{to-rgb($body-bg)};
 
   --#{$prefix}emphasis-color: #{$body-emphasis-color};
-  --#{$prefix}emphasis-color-rgb: #{to-rgb($body-emphasis-color)};
 
   --#{$prefix}secondary-color: #{$body-secondary-color};
-  --#{$prefix}secondary-color-rgb: #{to-rgb($body-secondary-color)};
   --#{$prefix}secondary-bg: #{$body-secondary-bg};
-  --#{$prefix}secondary-bg-rgb: #{to-rgb($body-secondary-bg)};
 
   --#{$prefix}tertiary-color: #{$body-tertiary-color};
-  --#{$prefix}tertiary-color-rgb: #{to-rgb($body-tertiary-color)};
   --#{$prefix}tertiary-bg: #{$body-tertiary-bg};
-  --#{$prefix}tertiary-bg-rgb: #{to-rgb($body-tertiary-bg)};
   // scss-docs-end root-body-variables
 
   --#{$prefix}heading-color: #{$headings-color};
 
   --#{$prefix}link-color: #{$link-color};
-  --#{$prefix}link-color-rgb: #{to-rgb($link-color)};
   --#{$prefix}link-decoration: #{$link-decoration};
 
   --#{$prefix}link-hover-color: #{$link-hover-color};
-  --#{$prefix}link-hover-color-rgb: #{to-rgb($link-hover-color)};
-
   @if $link-hover-decoration != null {
     --#{$prefix}link-hover-decoration: #{$link-hover-decoration};
   }
@@ -133,24 +116,51 @@
   @include color-mode(dark, true) {
     color-scheme: dark;
 
+    --#{$prefix}blue: #8fb1f2;
+    --#{$prefix}indigo: #8c68f6;
+    --#{$prefix}purple: #8e63cf;
+    --#{$prefix}pink: #e06aa2;
+    --#{$prefix}red: #f87171;
+    --#{$prefix}orange: #ff944d;
+    --#{$prefix}yellow: #f4c97d;
+    --#{$prefix}green: #6fc879;
+    --#{$prefix}teal: #4dd4ad;
+    --#{$prefix}cyan: #4fc3d7;
+    --#{$prefix}white: #fff;
+    --#{$prefix}gray: #adb5bd;
+    --#{$prefix}gray-dark: #dee2e6;
+    --#{$prefix}gray-100: #212529;
+    --#{$prefix}gray-200: #343a40;
+    --#{$prefix}gray-300: #495057;
+    --#{$prefix}gray-400: #6c757d;
+    --#{$prefix}gray-500: #adb5bd;
+    --#{$prefix}gray-600: #ced4da;
+    --#{$prefix}gray-700: #dee2e6;
+    --#{$prefix}gray-800: #e9ecef;
+    --#{$prefix}gray-900: #f2f6f6;
+    --#{$prefix}primary: #dee2e6;
+    --#{$prefix}secondary: #a6acb2;
+    --#{$prefix}tertiary: #6c757d;
+    --#{$prefix}success: #6fc879;
+    --#{$prefix}info: #4fc3d7;
+    --#{$prefix}warning: #f4c97d;
+    --#{$prefix}danger: #f87171;
+    --#{$prefix}light: #f2f6f6;
+    --#{$prefix}dark: #343a40;
+    --#{$prefix}graceful: #8e63cf;
+    --#{$prefix}pleasant: #8fb1f2;
+
     // scss-docs-start root-dark-mode-vars
     --#{$prefix}body-color: #{$body-color-dark};
-    --#{$prefix}body-color-rgb: #{to-rgb($body-color-dark)};
     --#{$prefix}body-bg: #{$body-bg-dark};
-    --#{$prefix}body-bg-rgb: #{to-rgb($body-bg-dark)};
 
     --#{$prefix}emphasis-color: #{$body-emphasis-color-dark};
-    --#{$prefix}emphasis-color-rgb: #{to-rgb($body-emphasis-color-dark)};
 
     --#{$prefix}secondary-color: #{$body-secondary-color-dark};
-    --#{$prefix}secondary-color-rgb: #{to-rgb($body-secondary-color-dark)};
     --#{$prefix}secondary-bg: #{$body-secondary-bg-dark};
-    --#{$prefix}secondary-bg-rgb: #{to-rgb($body-secondary-bg-dark)};
 
     --#{$prefix}tertiary-color: #{$body-tertiary-color-dark};
-    --#{$prefix}tertiary-color-rgb: #{to-rgb($body-tertiary-color-dark)};
     --#{$prefix}tertiary-bg: #{$body-tertiary-bg-dark};
-    --#{$prefix}tertiary-bg-rgb: #{to-rgb($body-tertiary-bg-dark)};
 
     @each $color, $value in $theme-colors-text-dark {
       --#{$prefix}#{$color}-text-emphasis: #{$value};
@@ -164,19 +174,51 @@
       --#{$prefix}#{$color}-border-subtle: #{$value};
     }
 
+    --#{$prefix}font-sans-serif: #{inspect($font-family-sans-serif)};
+    --#{$prefix}font-monospace: #{inspect($font-family-monospace)};
+    --#{$prefix}gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0));
+    @if $font-size-root != null {
+      --#{$prefix}root-font-size: #{$font-size-root};
+    }
+    --#{$prefix}body-font-family: #{inspect($font-family-base)};
+    @include rfs($font-size-base, --#{$prefix}body-font-size);
+    --#{$prefix}body-font-weight: #{$font-weight-base};
+    --#{$prefix}body-line-height: #{$line-height-base};
+    @if $body-text-align != null {
+      --#{$prefix}body-text-align: #{$body-text-align};
+    }
+
     --#{$prefix}heading-color: #{$headings-color-dark};
 
     --#{$prefix}link-color: #{$link-color-dark};
+    --#{$prefix}link-decoration: #{$link-decoration};
     --#{$prefix}link-hover-color: #{$link-hover-color-dark};
-    --#{$prefix}link-color-rgb: #{to-rgb($link-color-dark)};
-    --#{$prefix}link-hover-color-rgb: #{to-rgb($link-hover-color-dark)};
+    @if $link-hover-decoration != null {
+      --#{$prefix}link-hover-decoration: #{$link-hover-decoration};
+    }
 
     --#{$prefix}code-color: #{$code-color-dark};
     --#{$prefix}highlight-color: #{$mark-color-dark};
     --#{$prefix}highlight-bg: #{$mark-bg-dark};
 
+    --#{$prefix}border-width: #{$border-width};
+    --#{$prefix}border-style: #{$border-style};
     --#{$prefix}border-color: #{$border-color-dark};
     --#{$prefix}border-color-translucent: #{$border-color-translucent-dark};
+    --#{$prefix}border-radius: #{$border-radius};
+    --#{$prefix}border-radius-sm: #{$border-radius-sm};
+    --#{$prefix}border-radius-lg: #{$border-radius-lg};
+    --#{$prefix}border-radius-xl: #{$border-radius-xl};
+    --#{$prefix}border-radius-xxl: #{$border-radius-xxl};
+    --#{$prefix}border-radius-2xl: var(--#{$prefix}border-radius-xxl);
+    --#{$prefix}border-radius-pill: #{$border-radius-pill};
+    --#{$prefix}box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.35);
+    --#{$prefix}box-shadow-sm: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.2);
+    --#{$prefix}box-shadow-lg: 0 1rem 3rem rgba(0, 0, 0, 0.45);
+    --#{$prefix}box-shadow-inset: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    --#{$prefix}focus-ring-width: #{$focus-ring-width};
+    --#{$prefix}focus-ring-opacity: #{$focus-ring-opacity};
+    --#{$prefix}focus-ring-color: rgba(222, 226, 230, 0.25);
 
     --#{$prefix}form-valid-color: #{$form-valid-color-dark};
     --#{$prefix}form-valid-border-color: #{$form-valid-border-color-dark};

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/_utilities.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/_utilities.scss
@@ -89,7 +89,7 @@ $utilities: map-merge(
       css-var: true,
       css-variable-name: focus-ring-color,
       class: focus-ring,
-      values: map-loop($theme-colors-rgb, rgba-css-var, "$key", "focus-ring")
+      values: map-loop($utilities-colors, css-color-mix, "$value", "focus-ring-opacity", 1)
     ),
     // scss-docs-end utils-focus-ring
     // scss-docs-start utils-position
@@ -640,7 +640,7 @@ $utilities: map-merge(
       values: map-merge(
         $utilities-links-underline,
         (
-          null: rgba(var(--#{$prefix}link-color-rgb), var(--#{$prefix}link-underline-opacity, 1)),
+          null: css-color-mix(var(--#{$prefix}link-color), "link-underline-opacity", 1),
         )
       )
     ),
@@ -669,8 +669,8 @@ $utilities: map-merge(
         $utilities-bg-colors,
         (
           "transparent": transparent,
-          "body-secondary": rgba(var(--#{$prefix}secondary-bg-rgb), var(--#{$prefix}bg-opacity)),
-          "body-tertiary": rgba(var(--#{$prefix}tertiary-bg-rgb), var(--#{$prefix}bg-opacity)),
+          "body-secondary": css-color-mix(var(--#{$prefix}secondary-bg), "bg-opacity", 1),
+          "body-tertiary": css-color-mix(var(--#{$prefix}tertiary-bg), "bg-opacity", 1),
         )
       )
     ),

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/_variables.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/_variables.scss
@@ -743,15 +743,15 @@ $table-th-font-weight:        null !default;
 
 $table-striped-color:         $table-color !default;
 $table-striped-bg-factor:     .05 !default;
-$table-striped-bg:            rgba(var(--#{$prefix}emphasis-color-rgb), $table-striped-bg-factor) !default;
+$table-striped-bg:            css-color-mix-static(var(--#{$prefix}emphasis-color), $table-striped-bg-factor) !default;
 
 $table-active-color:          $table-color !default;
 $table-active-bg-factor:      .1 !default;
-$table-active-bg:             rgba(var(--#{$prefix}emphasis-color-rgb), $table-active-bg-factor) !default;
+$table-active-bg:             css-color-mix-static(var(--#{$prefix}emphasis-color), $table-active-bg-factor) !default;
 
 $table-hover-color:           $table-color !default;
 $table-hover-bg-factor:       .075 !default;
-$table-hover-bg:              rgba(var(--#{$prefix}emphasis-color-rgb), $table-hover-bg-factor) !default;
+$table-hover-bg:              css-color-mix-static(var(--#{$prefix}emphasis-color), $table-hover-bg-factor) !default;
 
 $table-border-factor:         .2 !default;
 $table-border-width:          var(--#{$prefix}border-width) !default;
@@ -843,7 +843,7 @@ $btn-active-box-shadow:       inset 0 3px 5px rgba($black, .125) !default;
 $btn-link-color:              var(--#{$prefix}link-color) !default;
 $btn-link-hover-color:        var(--#{$prefix}link-hover-color) !default;
 $btn-link-disabled-color:     $gray-600 !default;
-$btn-link-focus-shadow-rgb:   to-rgb(mix(color-contrast($link-color), $link-color, 15%)) !default;
+$btn-link-focus-shadow-color: mix(color-contrast($link-color), $link-color, 15%) !default;
 
 // Allows for customizing button radius independently from global border radius
 $btn-border-radius:           var(--#{$prefix}border-radius) !default;
@@ -1110,7 +1110,7 @@ $form-validation-states: (
     "icon": $form-feedback-icon-valid,
     "tooltip-color": #fff,
     "tooltip-bg-color": var(--#{$prefix}success),
-    "focus-box-shadow": 0 0 $input-btn-focus-blur $input-focus-width rgba(var(--#{$prefix}success-rgb), $input-btn-focus-color-opacity),
+    "focus-box-shadow": 0 0 $input-btn-focus-blur $input-focus-width #{css-color-mix-static(var(--#{$prefix}success), $input-btn-focus-color-opacity)},
     "border-color": var(--#{$prefix}form-valid-border-color),
   ),
   "invalid": (
@@ -1118,7 +1118,7 @@ $form-validation-states: (
     "icon": $form-feedback-icon-invalid,
     "tooltip-color": #fff,
     "tooltip-bg-color": var(--#{$prefix}danger),
-    "focus-box-shadow": 0 0 $input-btn-focus-blur $input-focus-width rgba(var(--#{$prefix}danger-rgb), $input-btn-focus-color-opacity),
+    "focus-box-shadow": 0 0 $input-btn-focus-blur $input-focus-width #{css-color-mix-static(var(--#{$prefix}danger), $input-btn-focus-color-opacity)},
     "border-color": var(--#{$prefix}form-invalid-border-color),
   )
 ) !default;
@@ -1206,13 +1206,13 @@ $navbar-toggler-border-radius:      $btn-border-radius !default;
 $navbar-toggler-focus-width:        $btn-focus-width !default;
 $navbar-toggler-transition:         box-shadow .15s ease-in-out !default;
 
-$navbar-light-color:                rgba(var(--#{$prefix}emphasis-color-rgb), .65) !default;
-$navbar-light-hover-color:          rgba(var(--#{$prefix}emphasis-color-rgb), .8) !default;
-$navbar-light-active-color:         rgba(var(--#{$prefix}emphasis-color-rgb), 1) !default;
-$navbar-light-disabled-color:       rgba(var(--#{$prefix}emphasis-color-rgb), .3) !default;
+$navbar-light-color:                css-color-mix-static(var(--#{$prefix}emphasis-color), .65) !default;
+$navbar-light-hover-color:          css-color-mix-static(var(--#{$prefix}emphasis-color), .8) !default;
+$navbar-light-active-color:         css-color-mix-static(var(--#{$prefix}emphasis-color), 1) !default;
+$navbar-light-disabled-color:       css-color-mix-static(var(--#{$prefix}emphasis-color), .3) !default;
 $navbar-light-icon-color:           rgba($body-color, .75) !default;
 $navbar-light-toggler-icon-bg:      url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='#{$navbar-light-icon-color}' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>") !default;
-$navbar-light-toggler-border-color: rgba(var(--#{$prefix}emphasis-color-rgb), .15) !default;
+$navbar-light-toggler-border-color: css-color-mix-static(var(--#{$prefix}emphasis-color), .15) !default;
 $navbar-light-brand-color:          $navbar-light-active-color !default;
 $navbar-light-brand-hover-color:    $navbar-light-active-color !default;
 // scss-docs-end navbar-variables
@@ -1351,7 +1351,7 @@ $card-box-shadow:                   null !default;
 $card-inner-border-radius:          subtract($card-border-radius, $card-border-width) !default;
 $card-cap-padding-y:                $card-spacer-y * .5 !default;
 $card-cap-padding-x:                $card-spacer-x !default;
-$card-cap-bg:                       rgba(var(--#{$prefix}body-color-rgb), .03) !default;
+$card-cap-bg:                       css-color-mix-static(var(--#{$prefix}body-color), .03) !default;
 $card-cap-color:                    null !default;
 $card-height:                       null !default;
 $card-color:                        null !default;
@@ -1470,7 +1470,7 @@ $toast-padding-x:                   .75rem !default;
 $toast-padding-y:                   .5rem !default;
 $toast-font-size:                   .875rem !default;
 $toast-color:                       null !default;
-$toast-background-color:            rgba(var(--#{$prefix}body-bg-rgb), .85) !default;
+$toast-background-color:            css-color-mix-static(var(--#{$prefix}body-bg), .85) !default;
 $toast-border-width:                var(--#{$prefix}border-width) !default;
 $toast-border-color:                var(--#{$prefix}border-color-translucent) !default;
 $toast-border-radius:               var(--#{$prefix}border-radius) !default;
@@ -1478,7 +1478,7 @@ $toast-box-shadow:                  var(--#{$prefix}box-shadow) !default;
 $toast-spacing:                     $container-padding-x !default;
 
 $toast-header-color:                var(--#{$prefix}secondary-color) !default;
-$toast-header-background-color:     rgba(var(--#{$prefix}body-bg-rgb), .85) !default;
+$toast-header-background-color:     css-color-mix-static(var(--#{$prefix}body-bg), .85) !default;
 $toast-header-border-color:         $toast-border-color !default;
 // scss-docs-end toast-variables
 

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/forms/_floating-labels.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/forms/_floating-labels.scss
@@ -18,7 +18,7 @@
     height: 100%; // allow textareas
     padding: $form-floating-padding-y $form-floating-padding-x;
     overflow: hidden;
-    color: rgba(var(--#{$prefix}body-color-rgb), #{$form-floating-label-opacity});
+    color: css-color-mix-static(var(--#{$prefix}body-color), $form-floating-label-opacity);
     text-align: start;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/helpers/_color-bg.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/helpers/_color-bg.scss
@@ -2,6 +2,6 @@
 @each $color, $value in $theme-colors {
   .text-bg-#{$color} {
     color: color-contrast($value) if($enable-important-utilities, !important, null);
-    background-color: RGBA(var(--#{$prefix}#{$color}-rgb), var(--#{$prefix}bg-opacity, 1)) if($enable-important-utilities, !important, null);
+    background-color: css-color-mix(var(--#{$prefix}#{$color}), "bg-opacity", 1) if($enable-important-utilities, !important, null);
   }
 }

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/helpers/_colored-links.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/helpers/_colored-links.scss
@@ -1,15 +1,14 @@
-// All-caps `RGBA()` function used because of this Sass bug: https://github.com/sass/node-sass/issues/2251
 @each $color, $value in $theme-colors {
   .link-#{$color} {
-    color: RGBA(var(--#{$prefix}#{$color}-rgb), var(--#{$prefix}link-opacity, 1)) if($enable-important-utilities, !important, null);
-    text-decoration-color: RGBA(var(--#{$prefix}#{$color}-rgb), var(--#{$prefix}link-underline-opacity, 1)) if($enable-important-utilities, !important, null);
+    color: css-color-mix(var(--#{$prefix}#{$color}), "link-opacity", 1) if($enable-important-utilities, !important, null);
+    text-decoration-color: css-color-mix(var(--#{$prefix}#{$color}), "link-underline-opacity", 1) if($enable-important-utilities, !important, null);
 
     @if $link-shade-percentage != 0 {
       &:hover,
       &:focus {
         $hover-color: if(color-contrast($value) == $color-contrast-light, shade-color($value, $link-shade-percentage), tint-color($value, $link-shade-percentage));
-        color: RGBA(#{to-rgb($hover-color)}, var(--#{$prefix}link-opacity, 1)) if($enable-important-utilities, !important, null);
-        text-decoration-color: RGBA(to-rgb($hover-color), var(--#{$prefix}link-underline-opacity, 1)) if($enable-important-utilities, !important, null);
+        color: css-color-mix($hover-color, "link-opacity", 1) if($enable-important-utilities, !important, null);
+        text-decoration-color: css-color-mix($hover-color, "link-underline-opacity", 1) if($enable-important-utilities, !important, null);
       }
     }
   }
@@ -17,14 +16,14 @@
 
 // One-off special link helper as a bridge until v6
 .link-body-emphasis {
-  color: RGBA(var(--#{$prefix}emphasis-color-rgb), var(--#{$prefix}link-opacity, 1)) if($enable-important-utilities, !important, null);
-  text-decoration-color: RGBA(var(--#{$prefix}emphasis-color-rgb), var(--#{$prefix}link-underline-opacity, 1)) if($enable-important-utilities, !important, null);
+  color: css-color-mix(var(--#{$prefix}emphasis-color), "link-opacity", 1) if($enable-important-utilities, !important, null);
+  text-decoration-color: css-color-mix(var(--#{$prefix}emphasis-color), "link-underline-opacity", 1) if($enable-important-utilities, !important, null);
 
   @if $link-shade-percentage != 0 {
     &:hover,
     &:focus {
-      color: RGBA(var(--#{$prefix}emphasis-color-rgb), var(--#{$prefix}link-opacity, .75)) if($enable-important-utilities, !important, null);
-      text-decoration-color: RGBA(var(--#{$prefix}emphasis-color-rgb), var(--#{$prefix}link-underline-opacity, .75)) if($enable-important-utilities, !important, null);
+      color: css-color-mix(var(--#{$prefix}emphasis-color), "link-opacity", .75) if($enable-important-utilities, !important, null);
+      text-decoration-color: css-color-mix(var(--#{$prefix}emphasis-color), "link-underline-opacity", .75) if($enable-important-utilities, !important, null);
     }
   }
 }

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/helpers/_icon-link.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/helpers/_icon-link.scss
@@ -2,7 +2,7 @@
   display: inline-flex;
   gap: $icon-link-gap;
   align-items: center;
-  text-decoration-color: rgba(var(--#{$prefix}link-color-rgb), var(--#{$prefix}link-opacity, .5));
+  text-decoration-color: css-color-mix(var(--#{$prefix}link-color), "link-opacity", .5);
   text-underline-offset: $icon-link-underline-offset;
   backface-visibility: hidden;
 

--- a/www/css/fpp-bootstrap/src/bootstrap-scss-src/mixins/_buttons.scss
+++ b/www/css/fpp-bootstrap/src/bootstrap-scss-src/mixins/_buttons.scss
@@ -24,7 +24,7 @@
   --#{$prefix}btn-hover-color: #{$hover-color};
   --#{$prefix}btn-hover-bg: #{$hover-background};
   --#{$prefix}btn-hover-border-color: #{$hover-border};
-  --#{$prefix}btn-focus-shadow-rgb: #{to-rgb(mix($color, $border, 15%))};
+  --#{$prefix}btn-focus-shadow-color: #{mix($color, $border, 15%)};
   --#{$prefix}btn-active-color: #{$active-color};
   --#{$prefix}btn-active-bg: #{$active-background};
   --#{$prefix}btn-active-border-color: #{$active-border};
@@ -48,7 +48,7 @@
   --#{$prefix}btn-hover-color: #{$color-hover};
   --#{$prefix}btn-hover-bg: #{$active-background};
   --#{$prefix}btn-hover-border-color: #{$active-border};
-  --#{$prefix}btn-focus-shadow-rgb: #{to-rgb($color)};
+  --#{$prefix}btn-focus-shadow-color: #{$color};
   --#{$prefix}btn-active-color: #{$active-color};
   --#{$prefix}btn-active-bg: #{$active-background};
   --#{$prefix}btn-active-border-color: #{$active-border};

--- a/www/css/fpp-bootstrap/src/fpp-bootstrap-5-3.scss
+++ b/www/css/fpp-bootstrap/src/fpp-bootstrap-5-3.scss
@@ -105,11 +105,11 @@ hr {
   font-size: 1.425rem;
   font-weight: 700;
   line-height: 1;
-  color: #171720;
-  text-shadow: 0 1px 0 #fff;
+  color: var(--bs-body-color);
+  text-shadow: none;
   opacity: .5; }
   .close:hover {
-    color: #171720;
+    color: var(--bs-body-color);
     text-decoration: none; }
   .close:not(:disabled):not(.disabled):hover, .close:not(:disabled):not(.disabled):focus {
     opacity: .75;
@@ -121,9 +121,9 @@ button.close {
 }
 
 .tooltip-inner {
-    background-color: $white;
-    color: $black;
-    border-color: $black;
+    background-color: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    border-color: var(--bs-body-color);
     border-width: 1px;
     border-style: solid;
 }
@@ -214,8 +214,8 @@ button.close {
 }
 .custom-radio .custom-control-input:checked ~ .custom-control-label::before {
     border-color:$blue;
-    background-color: #fff;
-    
+    background-color: var(--bs-body-bg);
+
 }
 .custom-radio .custom-control-input:checked ~ .custom-control-label::after {
     background: radial-gradient(circle, $blue 35%, rgba($blue,0) 35%);
@@ -237,8 +237,8 @@ input[type=text], input[type=number], input[type=password], input[type=email], i
       opacity: 1;
     }
 
-	border: 1px solid #D2D2D2;
-	color:$black;
+	border: 1px solid var(--bs-border-color);
+	color: var(--bs-body-color);
 	appearance: none;
 	font-weight: normal;
     vertical-align: middle;
@@ -275,7 +275,8 @@ input[type=date]{
     }
 }   
 .pageContent select, .ui-dialog select, .modal select{
-	background: #fff url(../../../images/redesign/chevron-down-grey.svg) no-repeat;
+	background-image: url(../../../images/redesign/chevron-down-grey.svg);
+	background-repeat: no-repeat;
 	background-position: right 9px center;
     background-size: 15px;
     padding-right:1.8em;
@@ -283,6 +284,11 @@ input[type=date]{
     vertical-align: middle;
     &.form-control-lg{
         background-position: right 20px center;
+    }
+}
+[data-bs-theme="dark"] {
+    .pageContent select, .ui-dialog select, .modal select {
+        background-image: url(../../../images/redesign/chevron-down-white.svg);
     }
 }
 
@@ -295,7 +301,7 @@ input[type=checkbox], .form-inline input[type=checkbox]{
 	cursor: pointer;
 	box-shadow: 3px 3px 8px rgba(0,0,0,0.1) ;
 	border-radius:1.5em;
-	border:1px solid #D2D2D2;
+	border: 1px solid var(--bs-border-color);
     display: inline-block;
 	border-radius:3px;
 	width: $checkbox-size;
@@ -341,8 +347,8 @@ input[type=checkbox][disabled=""]:checked {
 
 }
 .pageContent .nav-link{
-    border:1px solid #DADADA;
-    color:$black;
+    border: 1px solid var(--bs-border-color);
+    color: var(--bs-body-color);
     font-weight: bold;
     transition: 0.2s all ease-in-out;
     &:hover{
@@ -371,7 +377,7 @@ input[type=checkbox][disabled=""]:checked {
     }
 }
 .badge-light {
-    background-color: #ECECEC;
+    background-color: var(--bs-secondary-bg);
 }
 .alert{
     color:$white;
@@ -568,7 +574,7 @@ background: linear-gradient(90deg, $gray-100 0%, $gray-300 39%, $gray-300 57%, $
     margin-right: 0.5em;
     span{
         transform: translateX(-50%);
-        background-color: $white;
+        background-color: var(--bs-body-bg);
         display: inline-block;
         padding:0.2em;
     }
@@ -590,7 +596,7 @@ background: linear-gradient(90deg, $gray-100 0%, $gray-300 39%, $gray-300 57%, $
 }
 .backdrop-dark{
     @extend .backdrop;
-    background-color: $gray-light;
+    background-color: var(--bs-tertiary-bg);
 }
 .backdrop-success{
     @extend .backdrop;
@@ -678,46 +684,47 @@ table.settingsTable div.th{
 
 
 [role="region"][aria-labelledby][tabindex] {
-    background: linear-gradient(to right, #fff 30%, rgba(255, 255, 255, 0)),
-      linear-gradient(to right, rgba(255, 255, 255, 0), #fff 70%) 0 100%,
-      radial-gradient(
-        farthest-side at 0% 50%,
-        rgba(0, 0, 0, 0.2),
-        rgba(0, 0, 0, 0)
-      ),
-      radial-gradient(
-          farthest-side at 100% 50%,
-          rgba(0, 0, 0, 0.2),
-          rgba(0, 0, 0, 0)
-        )
-        0 100%;
+    background:
+        linear-gradient(to right, var(--bs-body-bg) 30%, rgba(0, 0, 0, 0)),
+        linear-gradient(to right, rgba(0, 0, 0, 0), var(--bs-body-bg) 70%) 0 100%,
+        radial-gradient(
+            farthest-side at 0% 50%,
+            rgba(0, 0, 0, 0.2),
+            rgba(0, 0, 0, 0)
+        ),
+        radial-gradient(
+            farthest-side at 100% 50%,
+            rgba(0, 0, 0, 0.2),
+            rgba(0, 0, 0, 0)
+        ) 0 100%;
     background-repeat: no-repeat;
-    background-color: #fff;
+    background-color: var(--bs-body-bg);
     background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
     background-position: 0 0, 100%, 0 0, 100%;
     background-attachment: local, local, scroll, scroll;
     overflow: auto;
-    @include media-breakpoint-down(md) { 
+    @include media-breakpoint-down(md) {
         margin-right: -1.2em;
     }
 }
 .backdrop [role="region"][aria-labelledby][tabindex] {
-    background: linear-gradient(to right, $gray-lighter 30%, rgba(255, 255, 255, 0)),
-      linear-gradient(to right, rgba(255, 255, 255, 0), $gray-lighter 70%) 0 100%,
-      radial-gradient(
-        farthest-side at 0% 50%,
-        rgba(0, 0, 0, 0.2),
-        rgba(0, 0, 0, 0)
-      ),
-      radial-gradient(
-          farthest-side at 100% 50%,
-          rgba(0, 0, 0, 0.2),
-          rgba(0, 0, 0, 0)
-        )
-        0 100%;
+    background:
+        linear-gradient(to right, var(--bs-secondary-bg) 30%, rgba(0, 0, 0, 0)),
+        linear-gradient(to right, rgba(0, 0, 0, 0), var(--bs-secondary-bg) 70%) 0 100%,
+        radial-gradient(
+            farthest-side at 0% 50%,
+            rgba(0, 0, 0, 0.2),
+            rgba(0, 0, 0, 0)
+        ),
+        radial-gradient(
+            farthest-side at 100% 50%,
+            rgba(0, 0, 0, 0.2),
+            rgba(0, 0, 0, 0)
+        ) 0 100%;
+    background-color: var(--bs-secondary-bg);
 }
 [role="region"][aria-labelledby][tabindex]>table{
-    mix-blend-mode: multiply;
+    mix-blend-mode: normal;
 }
 [role="region"][aria-labelledby][tabindex]:focus {
     outline: .1em solid rgba(0,0,0,0);
@@ -746,12 +753,12 @@ table.settingsTable div.th{
 .fppSelectableRowTable>tbody>tr>td{
 	padding-top: 0.25em;
 	padding-bottom: 0.25em;
-	background-color: #F5F5F5;
-	border-bottom: 1px solid #d5d7da;
+	background-color: var(--bs-tertiary-bg);
+	border-bottom: 1px solid var(--bs-border-color);
 }
 
 .fppSelectableRowTable>tbody>tr:first-child{
-    border-top-color: lightgray;
+    border-top-color: var(--bs-border-color);
     border-top-style: inherit;
     border-top-width: 0.15em;
 }
@@ -774,7 +781,7 @@ table.settingsTable div.th{
 }
 .fppSelectableRowTable>tbody>tr:first-child>td:last-child, #tblSchedule>tbody>tr:first-child>td:nth-last-child(2) {
 	border-top-right-radius: 8px;
-    border-top-color: lightgray;
+    border-top-color: var(--bs-border-color);
     border-top-style: inherit;
     border-top-width: 0.15em;
 }
@@ -795,7 +802,7 @@ table.settingsTable div.th{
 	padding-bottom:1em;
 }
 .fppSelectableRowTable>tbody>tr>th{
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid var(--bs-border-color);
 }
 .fppSelectableRowTable>tbody>tr.selectedEntry>td,
 .fppSelectableRowTable>tbody>tr.fppTableSelectedEntry>td
@@ -818,8 +825,8 @@ $fppTableExtraPadding:1.65em;
 .fppActionTable>tbody>tr>td{
 	padding-top: $fppTableDefaultPadding;
 	padding-bottom: $fppTableDefaultPadding;
-	background-color: #F5F5F5;
-	border-bottom: 1px solid #dee2e6;
+	background-color: var(--bs-tertiary-bg);
+	border-bottom: 1px solid var(--bs-border-color);
 }
 .fppActionTable.fppActionTable-success>tbody>tr>td{
     background-color: #3E9A50;
@@ -827,7 +834,7 @@ $fppTableExtraPadding:1.65em;
     transition:none;
 }
 .fppActionTable>tbody>tr:hover>td{
-	background-color: #ECECEC;
+	background-color: var(--bs-secondary-bg);
 }
 .fppActionTable.fppActionTable-success>tbody>tr:hover>td{
     background-color: lighten($green, 5%);
@@ -912,10 +919,9 @@ $fppTableExtraPadding:1.65em;
     width: 8em;
 }
 input[type=file]::file-selector-button {
-    color: #171720;
-    border-color: #171720;
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
     background-color: transparent;
-    border-color: #171720;
     padding-top: 0.33rem;
     padding-bottom: 0.33rem;
     padding-left: 0.65rem;
@@ -924,11 +930,11 @@ input[type=file]::file-selector-button {
     font-weight: bold;
     line-height: 1.5;
     border-radius: 0.25rem;
-    border: 1px solid;
+    border: 1px solid var(--bs-border-color);
 }
 input[type=file]::file-selector-button:hover {
-    background-color: #171720;
-    color: #FFFFFF;
+    background-color: var(--bs-secondary-bg);
+    color: var(--bs-body-color);
 }
 .form-select {
     display:inline-block;

--- a/www/css/fpp-dark.css
+++ b/www/css/fpp-dark.css
@@ -247,28 +247,9 @@
     border-color: var(--bs-border-color);
 }
 
-/* ------------------------------------------------------------- */
-/* Command preset warnings (keep legible in dark)               */
-/* ------------------------------------------------------------- */
-
-[data-bs-theme="dark"] .commandPresetInvalidCommand {
-    background-color: #3d2e00 !important;
-    border-color: #cc7a00 !important;
-}
-
-[data-bs-theme="dark"] .commandPresetInvalidCommand .cmdTmplCommand {
-    background-color: #4a1a1a !important;
-}
-
-[data-bs-theme="dark"] .commandPresetInvalidWarning {
-    background-color: #3d2e00;
-    border-color: #cc7a00;
-    color: #ffd166;
-}
-
-[data-bs-theme="dark"] .commandPresetInvalidWarning strong {
-    color: #ff6b6b;
-}
+/* Command preset warning rules removed — auto-adapt via Bootstrap subtle tokens
+   (var(--bs-warning-bg-subtle), --bs-warning, --bs-danger-bg-subtle, --bs-danger)
+   in fpp.css. No theme-specific override needed. */
 
 /* ------------------------------------------------------------- */
 /* LED Panel matrix                                              */

--- a/www/css/fpp-dark.css
+++ b/www/css/fpp-dark.css
@@ -1,0 +1,530 @@
+/* =============================================================
+ * fpp-dark.css — FPP Dark Mode Overrides
+ *
+ * Supplements Bootstrap 5.3 data-bs-theme="dark".
+ * All rules are scoped to [data-bs-theme="dark"] so they only
+ * fire when the theme is active (set by system preference via
+ * the inline script in htmlMeta.inc).
+ * ============================================================= */
+
+/* ------------------------------------------------------------- */
+/* FPP design-system custom variables — override for dark mode  */
+/* fpp-system-design.css defines these in :root with light vals */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] {
+    --fpp-text-primary: #dee2e6;
+    --fpp-text-secondary: #adb5bd;
+    --fpp-text-muted: #6c757d;
+    --fpp-text-light: #6c757d;
+    --fpp-bg-page: #212529;
+    --fpp-bg-card: #2c3034;
+    --fpp-bg-hover: #343a40;
+    --fpp-bg-disabled: #343a40;
+    --fpp-border: #495057;
+    --fpp-border-light: #343a40;
+    --fpp-border-medium: #495057;
+    --fpp-border-dark: #6c757d;
+    /* Bootstrap variable overrides for dark mode */
+    --bs-secondary-color: rgba(222, 226, 230, 0.9);
+    --bs-link-color: #adb5bd;
+    --bs-link-hover-color: #ced4da;
+    --bs-link-color-rgb: 173, 181, 189;
+}
+
+/* ------------------------------------------------------------- */
+/* Raw form elements — Bootstrap covers .form-control /          */
+/* .form-select but bare <input>, <select>, <textarea>, and      */
+/* custom-classed elements are not auto-themed                   */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] input:not([type=checkbox]),
+[data-bs-theme="dark"] input[list],
+[data-bs-theme="dark"] select,
+[data-bs-theme="dark"] textarea,
+[data-bs-theme="dark"] #eth_ssid,
+[data-bs-theme="dark"] #backupeth_ssid {
+    background: var(--bs-body-bg) !important;
+    color: var(--bs-body-color) !important;
+    border-color: var(--bs-border-color) !important;
+}
+[data-bs-theme="dark"] input[type=checkbox]:not(:checked) {
+    background-color: var(--bs-secondary-bg) !important;
+    border-color: var(--bs-border-color) !important;
+}
+[data-bs-theme="dark"] input[type=checkbox]:checked {
+    background: #56B760 url(/images/redesign/check-white.svg) no-repeat center center !important;
+    border-color: #56B760 !important;
+}
+[data-bs-theme="dark"] input[type=checkbox][disabled=""]:checked {
+    background: #bdd3bf url(/images/redesign/check-white.svg) no-repeat center center !important;
+    border-color: #969996 !important;
+}
+
+[data-bs-theme="dark"] .fpp-select {
+    background: var(--bs-body-bg) !important;
+    color: var(--bs-body-color) !important;
+    border-color: var(--bs-border-color) !important;
+}
+
+[data-bs-theme="dark"] input[list]:focus,
+[data-bs-theme="dark"] #eth_ssid:focus,
+[data-bs-theme="dark"] #backupeth_ssid:focus {
+    border-color: #6ea8fe !important;
+    box-shadow: 0 0 3px rgba(110, 168, 254, 0.3) !important;
+}
+
+[data-bs-theme="dark"] input[type='range']::-webkit-slider-thumb,
+[data-bs-theme="dark"] input[type='range']::-moz-range-thumb,
+[data-bs-theme="dark"] input[type='range']::-ms-thumb {
+    background-color: var(--bs-secondary-bg);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] input[type='range']::-webkit-slider-runnable-track,
+[data-bs-theme="dark"] input[type='range']::-moz-range-track,
+[data-bs-theme="dark"] input[type='range']::-ms-track {
+    background: var(--bs-border-color);
+}
+
+/* ------------------------------------------------------------- */
+/* Main page content area                                        */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .pageContent {
+    background: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    /* no box-shadow: body bg is already dark, no fill paint needed */
+}
+
+/* Touch scroll-fade gradient for tab bars */
+[data-bs-theme="dark"] body.has-touch .pageContent-tabs {
+    background: linear-gradient(
+            to left,
+            var(--bs-body-bg),
+            var(--bs-body-bg),
+            rgba(33, 37, 41, 0) 1.5em
+        ),
+        radial-gradient(
+                farthest-side at 100% 50%,
+                rgba(0, 0, 0, 0.5),
+                rgba(33, 37, 41, 0)
+            )
+            100%;
+    background-color: var(--bs-body-bg);
+    background-repeat: no-repeat;
+    background-attachment: local, scroll;
+    background-size: 100% 100%, 0.75em 100%;
+}
+
+[data-bs-theme="dark"] .pageContent-tabs {
+    border-color: var(--bs-border-color);
+}
+
+/* ------------------------------------------------------------- */
+/* Sticky / pinned bars (Zebra_Pin)                              */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .controlsSectionToPin.Zebra_Pin,
+[data-bs-theme="dark"] #playerControls.Zebra_Pin,
+[data-bs-theme="dark"] #playerTime.Zebra_Pin,
+[data-bs-theme="dark"] .tablePageHeader.Zebra_Pin,
+[data-bs-theme="dark"] .tableTabPageHeader.Zebra_Pin {
+    background-color: var(--bs-body-bg);
+    box-shadow: 0px 5px 4px -5px rgba(0, 0, 0, 0.5),
+        5px 0px 0px 0px var(--bs-body-bg);
+}
+
+/* ------------------------------------------------------------- */
+/* Tables                                                        */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .fppTableWrapper thead th {
+    background-color: var(--bs-secondary-bg);
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .modal thead {
+    background: var(--bs-secondary-bg);
+    color: var(--bs-body-color);
+}
+
+[data-bs-theme="dark"] .playlistRow td {
+    border-top-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .fileDetails td {
+    border-top-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] hr {
+    border-top-color: var(--bs-border-color);
+}
+
+/* ------------------------------------------------------------- */
+/* Playlist & file manager panels                                */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .tblPlaylistWrap {
+    background-color: var(--bs-secondary-bg);
+}
+
+[data-bs-theme="dark"] .playlistEntriesBody {
+    background-color: var(--bs-secondary-bg);
+}
+
+[data-bs-theme="dark"] .fileManagerDivData {
+    background-color: var(--bs-secondary-bg);
+}
+
+[data-bs-theme="dark"] .playlistSelectedEntry:not(.unselectable),
+[data-bs-theme="dark"] .playlistSelectedEntry.PlaylistRowPlaying:not(.unselectable),
+[data-bs-theme="dark"] .fileDetails.selectedEntry:not(.unselectable) {
+    color: #dee2e6;
+    background-color: #1c3a6e;
+}
+
+/* ------------------------------------------------------------- */
+/* Settings section headings                                     */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .settingsGroupTable h2,
+[data-bs-theme="dark"] .settingsTable h2,
+[data-bs-theme="dark"] .network-subsection + .settingsGroupTable h2 {
+    color: var(--bs-secondary-color) !important;
+    border-color: var(--bs-border-color) !important;
+}
+
+/* ------------------------------------------------------------- */
+/* Network configuration sections                               */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .global-network-section,
+[data-bs-theme="dark"] .interface-config-section,
+[data-bs-theme="dark"] .network-utilities-section,
+[data-bs-theme="dark"] .tethering-section {
+    background-color: var(--bs-secondary-bg);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .global-network-section h2,
+[data-bs-theme="dark"] .interface-config-section h2,
+[data-bs-theme="dark"] .network-utilities-section h2,
+[data-bs-theme="dark"] .tethering-section h2 {
+    color: var(--bs-body-color);
+}
+
+[data-bs-theme="dark"] .interface-selection {
+    background: var(--bs-body-bg) !important;
+    border-color: var(--bs-border-color) !important;
+}
+
+[data-bs-theme="dark"] .interface-selection h3 {
+    color: var(--bs-body-color) !important;
+    border-color: var(--bs-border-color) !important;
+}
+
+[data-bs-theme="dark"] #wifiNetworksTable {
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] #wifiNetworksTable thead {
+    background-color: var(--bs-secondary-bg);
+}
+
+[data-bs-theme="dark"] #wifiNetworksTable th {
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] #wifiNetworksTable td {
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .wifi-network-row:hover {
+    background-color: var(--bs-tertiary-bg) !important;
+}
+
+[data-bs-theme="dark"] .wifi-network-row.table-primary {
+    background-color: #1c3a6e !important;
+}
+
+[data-bs-theme="dark"] .wifi-network-row.table-primary:hover {
+    background-color: #254d8f !important;
+}
+
+[data-bs-theme="dark"] .network-subsection {
+    border-color: var(--bs-border-color);
+}
+
+/* ------------------------------------------------------------- */
+/* Command preset warnings (keep legible in dark)               */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .commandPresetInvalidCommand {
+    background-color: #3d2e00 !important;
+    border-color: #cc7a00 !important;
+}
+
+[data-bs-theme="dark"] .commandPresetInvalidCommand .cmdTmplCommand {
+    background-color: #4a1a1a !important;
+}
+
+[data-bs-theme="dark"] .commandPresetInvalidWarning {
+    background-color: #3d2e00;
+    border-color: #cc7a00;
+    color: #ffd166;
+}
+
+[data-bs-theme="dark"] .commandPresetInvalidWarning strong {
+    color: #ff6b6b;
+}
+
+/* ------------------------------------------------------------- */
+/* LED Panel matrix                                              */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .panelMatrix-tab-content .divLEDPanelsData,
+[data-bs-theme="dark"] .panelMatrix-tab-content .divLEDPanelsLayoutData {
+    background-color: var(--bs-secondary-bg);
+}
+
+[data-bs-theme="dark"] .LEDPanelTable table {
+    background-color: var(--bs-secondary-bg);
+    border-color: var(--bs-border-color);
+}
+
+/* ------------------------------------------------------------- */
+/* Min/max slider range widget                                   */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .fppMinMaxSliderRange {
+    background-color: var(--bs-body-bg) !important;
+    border-color: var(--bs-border-color) !important;
+    color: var(--bs-body-color) !important;
+}
+
+/* ------------------------------------------------------------- */
+/* Mobile (< 991px) slide-out navigation                        */
+/* ------------------------------------------------------------- */
+
+@media (max-width: 990px) {
+    [data-bs-theme="dark"] #fppMenu .navbar-collapse {
+        background-color: var(--bs-secondary-bg);
+    }
+
+    [data-bs-theme="dark"] #fppMenu .navbar-collapse::after {
+        background-color: var(--bs-secondary-bg);
+    }
+
+    [data-bs-theme="dark"] #fppMenu .navbar-collapse .navbar-nav .nav-item .nav-link {
+        color: var(--bs-body-color);
+    }
+
+    [data-bs-theme="dark"] #fppMenu .navbar-collapse .navbar-nav .nav-item:after {
+        background-color: var(--bs-border-color);
+    }
+
+    [data-bs-theme="dark"] #bodyClick {
+        background-color: #000;
+    }
+}
+
+/* ------------------------------------------------------------- */
+/* jQuery UI widgets                                             */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .ui-widget-content {
+    background: var(--bs-secondary-bg);
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .ui-widget-content a {
+    color: var(--bs-body-color);
+}
+
+[data-bs-theme="dark"] .ui-widget.ui-widget-content {
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .ui-widget-header {
+    background: var(--bs-tertiary-bg);
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .ui-state-default,
+[data-bs-theme="dark"] .ui-widget-content .ui-state-default,
+[data-bs-theme="dark"] .ui-widget-header .ui-state-default {
+    background: var(--bs-secondary-bg);
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .ui-state-hover,
+[data-bs-theme="dark"] .ui-widget-content .ui-state-hover,
+[data-bs-theme="dark"] .ui-widget-header .ui-state-hover,
+[data-bs-theme="dark"] .ui-state-focus,
+[data-bs-theme="dark"] .ui-widget-content .ui-state-focus {
+    background: var(--bs-tertiary-bg);
+    color: var(--bs-emphasis-color);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .ui-tooltip {
+    background: var(--bs-secondary-bg);
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .ui-dialog {
+    background: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .ui-dialog .ui-dialog-titlebar {
+    background: var(--bs-secondary-bg);
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .ui-state-highlight,
+[data-bs-theme="dark"] .ui-widget-content .ui-state-highlight {
+    background: #3a3500;
+    border-color: #6b5f00;
+    color: #ffe066;
+}
+
+[data-bs-theme="dark"] .ui-state-error,
+[data-bs-theme="dark"] .ui-widget-content .ui-state-error {
+    background: #4a1a1a;
+    border-color: #8b3030;
+    color: #ffaaaa;
+}
+
+/* ------------------------------------------------------------- */
+/* Misc: tooltip, disable state, badge-light                     */
+/* ------------------------------------------------------------- */
+
+[data-bs-theme="dark"] .pageContent .disableButtons {
+    background-color: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.6);
+}
+
+[data-bs-theme="dark"] .badge-light {
+    color: var(--bs-body-color);
+    background-color: var(--bs-secondary-bg);
+}
+
+/* ------------------------------------------------------------- */
+/* fpp-system-design.css hardcoded-light component overrides     */
+/* ------------------------------------------------------------- */
+
+/* Version indicator — default (update available) */
+[data-bs-theme="dark"] .fpp-version-indicator {
+    background: linear-gradient(135deg, #0d2b1a 0%, #1a3a2a 100%);
+    border-color: #2d6a4f;
+}
+
+[data-bs-theme="dark"] .fpp-version-indicator__from,
+[data-bs-theme="dark"] .fpp-version-indicator__to,
+[data-bs-theme="dark"] .fpp-version-indicator__current {
+    background: var(--bs-secondary-bg);
+}
+
+/* Version indicator hover */
+[data-bs-theme="dark"] .fpp-version-indicator--clickable:hover {
+    background: linear-gradient(135deg, #1a3a2a 0%, #2d5a3d 100%);
+    border-color: #4ade80;
+    box-shadow: 0 2px 8px rgba(34, 197, 94, 0.15);
+}
+
+/* Version indicator — up-to-date */
+[data-bs-theme="dark"] .fpp-version-indicator--current {
+    background: linear-gradient(135deg, #2c3034 0%, #343a40 100%);
+    border-color: var(--bs-border-color);
+}
+
+/* Version indicator — OS upgrade warning */
+[data-bs-theme="dark"] .fpp-version-indicator--upgrade {
+    background: linear-gradient(135deg, #2b2000 0%, #3d2e00 100%);
+    border-color: #b45309;
+}
+
+[data-bs-theme="dark"] .fpp-version-indicator--upgrade .fpp-version-indicator__to {
+    color: #fcd34d;
+    border-color: #b45309;
+}
+
+[data-bs-theme="dark"] .fpp-version-indicator--upgrade .fpp-version-indicator__label {
+    color: #fcd34d;
+}
+
+[data-bs-theme="dark"] .fpp-version-indicator--upgrade.fpp-version-indicator--clickable:hover {
+    background: linear-gradient(135deg, #3d2e00 0%, #4a3800 100%);
+    border-color: #d97706;
+    box-shadow: 0 2px 8px rgba(245, 158, 11, 0.2);
+}
+
+[data-bs-theme="dark"] .fpp-version-indicator--upgrade.fpp-version-indicator--clickable:hover
+    .fpp-version-indicator__label {
+    color: #fbbf24;
+}
+
+/* FAQ accordion */
+[data-bs-theme="dark"] .fpp-faq__item {
+    background: var(--bs-secondary-bg);
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme="dark"] .fpp-faq__item--open {
+    border-color: var(--bs-primary);
+    background: var(--bs-tertiary-bg);
+}
+
+/* ------------------------------------------------------------- */
+/* fpp.css hardcoded-light component overrides                   */
+/* ------------------------------------------------------------- */
+
+/* Multi-select widget */
+[data-bs-theme="dark"] .pageContent .multiSelect {
+    background: var(--bs-secondary-bg);
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
+}
+
+/* jQuery UI active/selected state (e.g. selected tab) */
+[data-bs-theme="dark"] .ui-state-active,
+[data-bs-theme="dark"] .ui-widget-content .ui-state-active,
+[data-bs-theme="dark"] .ui-widget-header .ui-state-active,
+[data-bs-theme="dark"] a.ui-button:active,
+[data-bs-theme="dark"] .ui-button:active,
+[data-bs-theme="dark"] .ui-button.ui-state-active:hover {
+    background: var(--bs-tertiary-bg);
+    color: var(--bs-emphasis-color);
+    border-color: var(--bs-border-color);
+}
+
+/* Playlist back button */
+[data-bs-theme="dark"] .playlistEditorBackButton {
+    background-color: var(--bs-secondary-bg);
+    border-color: var(--bs-border-color);
+    color: var(--bs-body-color);
+}
+
+/* minimal.css slider range track */
+[data-bs-theme="dark"] .ui-slider-range {
+    background: var(--bs-border-color);
+}
+
+/* Table sort headers (bootstrap-table plugin) */
+[data-bs-theme="dark"] #tblEffectLibrary thead th,
+[data-bs-theme="dark"] #fppSystemsTable thead th,
+[data-bs-theme="dark"] #fppSystemsTable thead td,
+[data-bs-theme="dark"] .table-download-existing-backups thead,
+[data-bs-theme="dark"] .table-restore-existing-backups thead {
+    background-color: #737373;
+}

--- a/www/css/fpp-dark.css
+++ b/www/css/fpp-dark.css
@@ -13,10 +13,10 @@
 /* ------------------------------------------------------------- */
 
 [data-bs-theme="dark"] {
-    --fpp-text-primary: #dee2e6;
-    --fpp-text-secondary: #adb5bd;
-    --fpp-text-muted: #6c757d;
-    --fpp-text-light: #6c757d;
+    --bs-primary: #dee2e6;
+    --bs-secondary: #a6acb2;
+    --fpp-text-muted: #83898f;
+    --fpp-text-light: #a1a1a1;
     --fpp-bg-page: #212529;
     --fpp-bg-card: #2c3034;
     --fpp-bg-hover: #343a40;
@@ -26,13 +26,11 @@
     --fpp-border-medium: #495057;
     --fpp-border-dark: #6c757d;
     /* Component token dark overrides */
-    --fpp-thead-bg: #737373;
     --fpp-selected-row-bg: #495057;
     /* Bootstrap variable overrides for dark mode */
     --bs-secondary-color: rgba(222, 226, 230, 0.9);
     --bs-link-color: #adb5bd;
     --bs-link-hover-color: #ced4da;
-    --bs-link-color-rgb: 173, 181, 189;
 }
 
 /* ------------------------------------------------------------- */
@@ -41,7 +39,7 @@
 /* custom-classed elements are not auto-themed                   */
 /* ------------------------------------------------------------- */
 
-[data-bs-theme="dark"] input:not([type=checkbox]),
+/* [data-bs-theme="dark"] input:not([type=checkbox]),
 [data-bs-theme="dark"] input[list],
 [data-bs-theme="dark"] select,
 [data-bs-theme="dark"] textarea,
@@ -50,7 +48,7 @@
     background: var(--bs-body-bg) !important;
     color: var(--bs-body-color) !important;
     border-color: var(--bs-border-color) !important;
-}
+} */
 [data-bs-theme="dark"] input[type=checkbox]:not(:checked) {
     background-color: var(--bs-secondary-bg) !important;
     border-color: var(--bs-border-color) !important;

--- a/www/css/fpp-dark.css
+++ b/www/css/fpp-dark.css
@@ -25,6 +25,9 @@
     --fpp-border-light: #343a40;
     --fpp-border-medium: #495057;
     --fpp-border-dark: #6c757d;
+    /* Component token dark overrides */
+    --fpp-thead-bg: #737373;
+    --fpp-selected-row-bg: #495057;
     /* Bootstrap variable overrides for dark mode */
     --bs-secondary-color: rgba(222, 226, 230, 0.9);
     --bs-link-color: #adb5bd;
@@ -92,9 +95,8 @@
 /* ------------------------------------------------------------- */
 
 [data-bs-theme="dark"] .pageContent {
-    background: var(--bs-body-bg);
+    background-color: #171720;
     color: var(--bs-body-color);
-    /* no box-shadow: body bg is already dark, no fill paint needed */
 }
 
 /* Touch scroll-fade gradient for tab bars */
@@ -139,16 +141,8 @@
 /* Tables                                                        */
 /* ------------------------------------------------------------- */
 
-[data-bs-theme="dark"] .fppTableWrapper thead th {
-    background-color: var(--bs-secondary-bg);
-    color: var(--bs-body-color);
-    border-color: var(--bs-border-color);
-}
-
-[data-bs-theme="dark"] .modal thead {
-    background: var(--bs-secondary-bg);
-    color: var(--bs-body-color);
-}
+/* .fppTableWrapper thead + .modal thead now inherit via unified thead rule in fpp.css
+   + --fpp-thead-bg; dark override is handled by the component token, not per-selector. */
 
 [data-bs-theme="dark"] .playlistRow td {
     border-top-color: var(--bs-border-color);
@@ -227,10 +221,6 @@
 
 [data-bs-theme="dark"] #wifiNetworksTable {
     border-color: var(--bs-border-color);
-}
-
-[data-bs-theme="dark"] #wifiNetworksTable thead {
-    background-color: var(--bs-secondary-bg);
 }
 
 [data-bs-theme="dark"] #wifiNetworksTable th {
@@ -520,11 +510,5 @@
     background: var(--bs-border-color);
 }
 
-/* Table sort headers (bootstrap-table plugin) */
-[data-bs-theme="dark"] #tblEffectLibrary thead th,
-[data-bs-theme="dark"] #fppSystemsTable thead th,
-[data-bs-theme="dark"] #fppSystemsTable thead td,
-[data-bs-theme="dark"] .table-download-existing-backups thead,
-[data-bs-theme="dark"] .table-restore-existing-backups thead {
-    background-color: #737373;
-}
+/* Table sort headers — bg handled by unified thead rule in fpp.css + --fpp-thead-bg
+   token (dark value set at top of this file). Per-id dark tweaks go here if ever needed. */

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -1,6 +1,37 @@
 /* ==========================================================================
    FPP Standard Design System
    Standard reusable design tokens and components
+
+   Light-mode token values live in :root below.
+   Dark-mode overrides live in fpp-dark.css under [data-bs-theme="dark"].
+   See www/css/THEME_INCONSISTENCIES.md for unresolved semantic conflicts.
+
+   Canonical token index (search by name below):
+
+   Colors — semantic:
+     --fpp-primary, --fpp-primary-hover
+     --fpp-success, --fpp-success-dark, --fpp-success-light, --fpp-success-text
+     --fpp-warning, --fpp-warning-dark, --fpp-warning-light, --fpp-warning-text
+     --fpp-danger,  --fpp-danger-dark,  --fpp-danger-light
+     --fpp-info,    --fpp-info-light,   --fpp-info-text
+     --fpp-gray
+
+   Colors — text / backgrounds / borders:
+     --fpp-text-primary, --fpp-text-secondary, --fpp-text-muted, --fpp-text-light
+     --fpp-bg-page, --fpp-bg-card, --fpp-bg-hover, --fpp-bg-disabled
+     --fpp-border, --fpp-border-light, --fpp-border-medium, --fpp-border-dark
+
+   Spacing:       --fpp-spacing-1..5, --fpp-sp-{xs,icon,sm,md,lg,xl,2xl}
+   Typography:    --fpp-fs-{xs,sm,base,md,lg,xl,2xl,3xl}, --fpp-fw-{normal,medium,semibold,bold},
+                  --fpp-font-sans, --fpp-font-mono
+   Radii:         --fpp-radius-{sm,md,lg,xl,pill}
+   Shadows:       --fpp-shadow-{sm,md,lg}
+   Transitions:   --fpp-transition-{fast,normal,slow}
+   Z-index:       --fpp-z-{dropdown,sticky,fixed,modal-backdrop,modal,popover,tooltip}
+   Component:     --fpp-progress-*, --fpp-card-*, --fpp-gauge-*, --fpp-btn-*, --fpp-alert-*
+
+   When adding a new raw color to fpp.css or a PHP file, check this list first —
+   if a token already represents the role, use var(--fpp-*) instead.
    ========================================================================== */
 
 :root {
@@ -8,23 +39,19 @@
        COLOR TOKENS: Extracted from FPP Bootstrap theme and inline styles
        ========================================================================== */
 
-	/* Primary Colors - FPP actual color palette from fpp.css */
+	/* Primary Colors - semantic tokens resolve through Bootstrap (auto-adapt to dark via variables-dark) */
 	--fpp-primary: #007bff;
 	--fpp-primary-hover: #0056b3;
-	--fpp-success: #56b760;
-	/* FPP green (playlist playing, installed plugins) */
+	--fpp-success: var(--bs-success);
 	--fpp-success-dark: #449c4d;
 	--fpp-success-light: #e8f5e9;
-	--fpp-warning: #f2bc5f;
-	/* FPP amber (untested plugins) */
+	--fpp-warning: var(--bs-warning);
 	--fpp-warning-dark: #d9a84e;
 	--fpp-warning-light: #fef8e8;
-	--fpp-danger: #f63939;
-	/* FPP red (menu hover, incompatible) */
+	--fpp-danger: var(--bs-danger);
 	--fpp-danger-dark: #d92d2d;
 	--fpp-danger-light: #fde8e8;
 	--fpp-info: #6b95ec;
-	/* FPP blue (available plugins) */
 	--fpp-info-light: #e8f0fd;
 
 	/* Neutral Colors - Text */
@@ -53,6 +80,21 @@
 	--fpp-success-text: #155724;
 	--fpp-warning-text: #856404;
 	--fpp-info-text: #0c5460;
+
+	/* ==========================================================================
+       COMPONENT TOKENS: one knob per repeated UI role.
+       Change here to re-theme every consumer at once.
+       Dark overrides live in fpp-dark.css under [data-bs-theme="dark"].
+       ========================================================================== */
+
+	/* Table header row (used by systems, effects, backup, wifi, running/overlay effects tables,
+	   and the shared .tblheader class) */
+	--fpp-thead-bg: #d9d9d9;
+	--fpp-thead-color: inherit;
+
+	/* Selected-row highlight for list tables (.selectedEntry class used by scheduler,
+	   co-pixelStrings, co-universes, commandPresets, pixeloverlaymodels, channelinputs, ...) */
+	--fpp-selected-row-bg: #cccccc;
 
 	/* ==========================================================================
        SPACING TOKENS: Bootstrap-compatible spacing scale

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -1263,7 +1263,7 @@
 .fpp-version-indicator__to,
 .fpp-version-indicator__current {
 	padding: 4px 10px;
-	background: #fff;
+	background: var(--fpp-bg-card);
 	border-radius: var(--fpp-radius-md);
 }
 
@@ -1382,7 +1382,7 @@
 	border-radius: var(--fpp-radius-lg);
 	overflow: hidden;
 	transition: all var(--fpp-transition-normal);
-	background: #fff;
+	background: var(--fpp-bg-card);
 }
 
 .fpp-faq__item:hover {
@@ -1987,7 +1987,7 @@
 	font-family: var(--fpp-font-mono);
 	font-size: var(--fpp-fs-base);
 	padding: var(--fpp-sp-sm) var(--fpp-sp-md);
-	background: #fff;
+	background: var(--fpp-bg-card);
 	border: 1px solid var(--fpp-border);
 	border-radius: var(--fpp-radius-lg);
 	color: var(--fpp-text-secondary);

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -10,9 +10,9 @@
 
    Colors — semantic:
      --fpp-primary, --fpp-primary-hover
-     --fpp-success, --fpp-success-dark, --fpp-success-light, --fpp-success-text
-     --fpp-warning, --fpp-warning-dark, --fpp-warning-light, --fpp-warning-text
-     --fpp-danger,  --fpp-danger-dark,  --fpp-danger-light
+     --fpp-success-dark, --fpp-success-light, --fpp-success-text   (use var(--bs-success) for the base)
+     --fpp-warning-dark, --fpp-warning-light, --fpp-warning-text   (use var(--bs-warning) for the base)
+     --fpp-danger-dark,  --fpp-danger-light                        (use var(--bs-danger)  for the base)
      --fpp-info,    --fpp-info-light,   --fpp-info-text
      --fpp-gray
 
@@ -39,16 +39,15 @@
        COLOR TOKENS: Extracted from FPP Bootstrap theme and inline styles
        ========================================================================== */
 
-	/* Primary Colors - semantic tokens resolve through Bootstrap (auto-adapt to dark via variables-dark) */
+	/* Primary semantic colors resolve through Bootstrap (--bs-success/danger/warning) directly.
+	   The bare --fpp-success/-danger/-warning aliases were removed — use var(--bs-*) directly.
+	   The -dark / -light / -text variants below are FPP-specific shades not in Bootstrap. */
 	--fpp-primary: #007bff;
 	--fpp-primary-hover: #0056b3;
-	--fpp-success: var(--bs-success);
 	--fpp-success-dark: #449c4d;
 	--fpp-success-light: #e8f5e9;
-	--fpp-warning: var(--bs-warning);
 	--fpp-warning-dark: #d9a84e;
 	--fpp-warning-light: #fef8e8;
-	--fpp-danger: var(--bs-danger);
 	--fpp-danger-dark: #d92d2d;
 	--fpp-danger-light: #fde8e8;
 	--fpp-info: #6b95ec;
@@ -238,15 +237,15 @@
 }
 
 .fpp-text-success {
-	color: var(--fpp-success) !important;
+	color: var(--bs-success) !important;
 }
 
 .fpp-text-warning {
-	color: var(--fpp-warning) !important;
+	color: var(--bs-warning) !important;
 }
 
 .fpp-text-danger {
-	color: var(--fpp-danger) !important;
+	color: var(--bs-danger) !important;
 }
 
 .fpp-text-info {
@@ -276,15 +275,15 @@
 }
 
 .fpp-bg-success {
-	background-color: var(--fpp-success) !important;
+	background-color: var(--bs-success) !important;
 }
 
 .fpp-bg-warning {
-	background-color: var(--fpp-warning) !important;
+	background-color: var(--bs-warning) !important;
 }
 
 .fpp-bg-danger {
-	background-color: var(--fpp-danger) !important;
+	background-color: var(--bs-danger) !important;
 }
 
 .fpp-bg-info {
@@ -571,8 +570,8 @@
 /* Danger/Warning variant, uses FPP red #f63939 */
 .fpp-alert--danger {
 	color: #fff;
-	background-color: var(--fpp-danger);
-	border-color: var(--fpp-danger);
+	background-color: var(--bs-danger);
+	border-color: var(--bs-danger);
 }
 
 .fpp-alert--danger a,
@@ -591,14 +590,14 @@
 .fpp-alert--warning {
 	color: var(--fpp-warning-text);
 	background-color: var(--fpp-warning-light);
-	border-color: var(--fpp-warning);
+	border-color: var(--bs-warning);
 }
 
 /* Success variant */
 .fpp-alert--success {
 	color: var(--fpp-success-text);
 	background-color: var(--fpp-success-light);
-	border-color: var(--fpp-success);
+	border-color: var(--bs-success);
 }
 
 /* Info variant */
@@ -654,15 +653,15 @@
 }
 
 .fpp-health-summary__count--success {
-	color: var(--fpp-success);
+	color: var(--bs-success);
 }
 
 .fpp-health-summary__count--warning {
-	color: var(--fpp-warning);
+	color: var(--bs-warning);
 }
 
 .fpp-health-summary__count--danger {
-	color: var(--fpp-danger);
+	color: var(--bs-danger);
 }
 
 .fpp-health-summary__label {
@@ -751,15 +750,15 @@
 
 /* Status Color Classes */
 .fpp-status--pass {
-	color: var(--fpp-success);
+	color: var(--bs-success);
 }
 
 .fpp-status--warn {
-	color: var(--fpp-warning);
+	color: var(--bs-warning);
 }
 
 .fpp-status--fail {
-	color: var(--fpp-danger);
+	color: var(--bs-danger);
 }
 
 .fpp-status--loading {
@@ -828,7 +827,7 @@
 .fpp-health-check__details {
 	display: none;
 	background: var(--fpp-warning-light);
-	border-left: 3px solid var(--fpp-warning);
+	border-left: 3px solid var(--bs-warning);
 	margin: 0 0 var(--fpp-spacing-2) 0;
 	padding: var(--fpp-spacing-2) var(--fpp-sp-sm);
 	border-radius: 0 var(--fpp-radius-sm) var(--fpp-radius-sm) 0;
@@ -895,7 +894,7 @@
 
 .fpp-gauge__fill {
 	fill: none;
-	stroke: var(--fpp-success);
+	stroke: var(--bs-success);
 	stroke-width: 8;
 	stroke-linecap: round;
 	transition: stroke-dasharray var(--fpp-transition-slow),
@@ -903,15 +902,15 @@
 }
 
 .fpp-gauge__fill--success {
-	stroke: var(--fpp-success);
+	stroke: var(--bs-success);
 }
 
 .fpp-gauge__fill--warning {
-	stroke: var(--fpp-warning);
+	stroke: var(--bs-warning);
 }
 
 .fpp-gauge__fill--danger {
-	stroke: var(--fpp-danger);
+	stroke: var(--bs-danger);
 }
 
 .fpp-gauge__value {
@@ -988,7 +987,7 @@
 }
 
 .fpp-help-swatch--success {
-	background: var(--fpp-success);
+	background: var(--bs-success);
 }
 
 .fpp-help-swatch--info {
@@ -996,11 +995,11 @@
 }
 
 .fpp-help-swatch--warning {
-	background: var(--fpp-warning);
+	background: var(--bs-warning);
 }
 
 .fpp-help-swatch--danger {
-	background: var(--fpp-danger);
+	background: var(--bs-danger);
 }
 
 .fpp-help-swatch--muted {
@@ -1031,7 +1030,7 @@
 }
 
 .fpp-donate-banner__title i {
-	color: var(--fpp-danger);
+	color: var(--bs-danger);
 	animation: pulse-heart 2s ease-in-out infinite;
 }
 
@@ -1123,7 +1122,7 @@
 .fpp-banner--success {
 	background: linear-gradient(
 		135deg,
-		var(--fpp-success) 0%,
+		var(--bs-success) 0%,
 		var(--fpp-success-dark) 100%
 	);
 	color: white;
@@ -1132,7 +1131,7 @@
 .fpp-banner--warning {
 	background: linear-gradient(
 		135deg,
-		var(--fpp-danger) 0%,
+		var(--bs-danger) 0%,
 		var(--fpp-danger-dark) 100%
 	);
 	color: white;
@@ -1140,7 +1139,7 @@
 
 .fpp-banner--info {
 	background: var(--fpp-success-light);
-	border: 1px solid var(--fpp-success);
+	border: 1px solid var(--bs-success);
 	color: var(--fpp-text-primary);
 }
 
@@ -1261,15 +1260,15 @@
 }
 
 .fpp-badge--success {
-	background: var(--fpp-success);
+	background: var(--bs-success);
 }
 
 .fpp-badge--warning {
-	background: var(--fpp-warning);
+	background: var(--bs-warning);
 }
 
 .fpp-badge--danger {
-	background: var(--fpp-danger);
+	background: var(--bs-danger);
 }
 
 .fpp-badge--info {
@@ -1315,13 +1314,13 @@
 }
 
 .fpp-version-indicator__to {
-	color: var(--fpp-success);
+	color: var(--bs-success);
 	font-weight: var(--fpp-fw-semibold);
 	border: 1px solid #86efac;
 }
 
 .fpp-version-indicator__arrow {
-	color: var(--fpp-success);
+	color: var(--bs-success);
 	font-size: 1.1rem;
 }
 
@@ -1352,7 +1351,7 @@
 }
 
 .fpp-version-indicator--clickable:hover .fpp-version-indicator__label {
-	color: var(--fpp-success);
+	color: var(--bs-success);
 }
 
 .fpp-version-indicator--clickable:active {
@@ -1366,7 +1365,7 @@
 }
 
 .fpp-version-indicator--current > i {
-	color: var(--fpp-success);
+	color: var(--bs-success);
 	font-size: 1.1rem;
 }
 
@@ -1376,7 +1375,7 @@
 }
 
 .fpp-version-indicator--current .fpp-version-indicator__label {
-	color: var(--fpp-success);
+	color: var(--bs-success);
 }
 
 /* Warning/upgrade theme (for OS upgrades) */
@@ -1386,7 +1385,7 @@
 }
 
 .fpp-version-indicator--upgrade .fpp-version-indicator__arrow {
-	color: var(--fpp-warning);
+	color: var(--bs-warning);
 }
 
 .fpp-version-indicator--upgrade .fpp-version-indicator__to {
@@ -1529,17 +1528,17 @@
 
 .fpp-comparison-table .text-success,
 .fpp-comparison-table .fpp-text-success {
-	color: var(--fpp-success);
+	color: var(--bs-success);
 }
 
 .fpp-comparison-table .text-warning,
 .fpp-comparison-table .fpp-text-warning {
-	color: var(--fpp-warning);
+	color: var(--bs-warning);
 }
 
 .fpp-comparison-table .text-danger,
 .fpp-comparison-table .fpp-text-danger {
-	color: var(--fpp-danger);
+	color: var(--bs-danger);
 }
 
 .fpp-comparison-note {
@@ -1610,17 +1609,17 @@
 
 .fpp-card__icon--success {
 	background: var(--fpp-success-light);
-	color: var(--fpp-success);
+	color: var(--bs-success);
 }
 
 .fpp-card__icon--warning {
 	background: var(--fpp-warning-light);
-	color: var(--fpp-warning);
+	color: var(--bs-warning);
 }
 
 .fpp-card__icon--danger {
 	background: var(--fpp-danger-light);
-	color: var(--fpp-danger);
+	color: var(--bs-danger);
 }
 
 .fpp-card__icon--neutral {
@@ -1680,15 +1679,15 @@
 }
 
 .fpp-card--accent-success::before {
-	background: var(--fpp-success);
+	background: var(--bs-success);
 }
 
 .fpp-card--accent-warning::before {
-	background: var(--fpp-warning);
+	background: var(--bs-warning);
 }
 
 .fpp-card--accent-danger::before {
-	background: var(--fpp-danger);
+	background: var(--bs-danger);
 }
 
 .fpp-card--accent-neutral::before {
@@ -1812,7 +1811,7 @@
 }
 
 .fpp-btn--success {
-	background: var(--fpp-success);
+	background: var(--bs-success);
 	color: white;
 	box-shadow: 0 2px 4px rgba(86, 183, 96, 0.25);
 }
@@ -1823,7 +1822,7 @@
 }
 
 .fpp-btn--warning {
-	background: var(--fpp-warning);
+	background: var(--bs-warning);
 	color: #000;
 }
 
@@ -2131,7 +2130,7 @@
 	padding: var(--fpp-sp-md);
 	background: var(--fpp-success-light);
 	border-radius: var(--fpp-radius-md);
-	border-left: 4px solid var(--fpp-success);
+	border-left: 4px solid var(--bs-success);
 }
 
 .fpp-changelog-group {

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -3370,34 +3370,27 @@ table#fppSystemsTable > thead > tr:last-child > td {
 /* = Command Presets = */
 /* ===================== */
 
-/* Command Preset Invalid Command Styling */
-
-
-[data-bs-theme="light"] .commandPresetInvalidCommand {
+/* Command Preset Invalid Command Styling — fully driven by Bootstrap subtle tokens
+   so light/dark adapt automatically. No fpp-dark.css override needed. */
+.commandPresetInvalidCommand {
 	background-color: var(--bs-warning-bg-subtle) !important;
-	border-left: 3px solid #ff9800 !important;
+	border-left: 3px solid var(--bs-warning) !important;
 }
 
-
-[data-bs-theme="light"] .commandPresetInvalidCommand .cmdTmplCommand {
-	background-color: #ffcccc !important;
-}
-
-
-[data-bs-theme="light"] .commandPresetInvalidWarning {
-	background-color: var(--bs-warning-bg-subtle);
-	border: 1px solid var(--bs-warning);
-	color: var(--bs-warning-text-emphasis);
+.commandPresetInvalidCommand .cmdTmplCommand {
+	background-color: var(--bs-danger-bg-subtle) !important;
 }
 
 .commandPresetInvalidWarning {
+	background-color: var(--bs-warning-bg-subtle);
+	border: 1px solid var(--bs-warning);
+	color: var(--bs-warning-text-emphasis);
 	border-radius: 4px;
 	padding: 10px;
 	margin-bottom: 15px;
 }
 
-
-[data-bs-theme="light"] .commandPresetInvalidWarning strong {
+.commandPresetInvalidWarning strong {
 	color: var(--bs-danger);
 }
 

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -12,7 +12,7 @@ html {
 }
 
 
-input {
+[data-bs-theme="light"] input {
 	background: white;
 }
 
@@ -20,7 +20,7 @@ input {
 /* Fix dark border on datalist inputs (SSID fields) */
 
 
-input[list] {
+[data-bs-theme="light"] input[list] {
 	background: white !important;
 	border: 1px solid #ccc !important;
 	border-radius: 3px !important;
@@ -53,8 +53,8 @@ input[list]::-webkit-list-button {
 /* Specific styling for SSID input fields to match other inputs */
 
 
-#eth_ssid,
-#backupeth_ssid {
+[data-bs-theme="light"] #eth_ssid,
+[data-bs-theme="light"] #backupeth_ssid {
 	background: white !important;
 	border: 1px solid #ccc !important;
 	border-radius: 3px !important;
@@ -208,7 +208,7 @@ input[type='range']::-ms-track {
 }
 
 
-input[type='range']::-webkit-slider-thumb {
+[data-bs-theme="light"] input[type='range']::-webkit-slider-thumb {
 	-webkit-appearance: none;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.1);
 	border-radius: 1.5em;
@@ -221,7 +221,7 @@ input[type='range']::-webkit-slider-thumb {
 }
 
 
-input[type='range']::-moz-range-thumb {
+[data-bs-theme="light"] input[type='range']::-moz-range-thumb {
 	-webkit-appearance: none;
 	appearance: none;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.1);
@@ -235,7 +235,7 @@ input[type='range']::-moz-range-thumb {
 }
 
 
-input[type='range']::-ms-thumb {
+[data-bs-theme="light"] input[type='range']::-ms-thumb {
 	-webkit-appearance: none;
 	appearance: none;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.1);
@@ -362,13 +362,18 @@ input[type='color']::-moz-color-swatch {
 }
 
 
-.pageContent {
+[data-bs-theme="light"] .pageContent {
 	background: #fff;
 	border-radius: 8px;
 	color: #000;
 	padding: 2.5em 3em;
 	box-shadow: 5px 10100px 0px 10000px #20222e, -1000px 100px 0px 0px #20222e,
 		1000px 100px 0px 0px #20222e;
+}
+
+.pageContent {
+	border-radius: 8px;
+	padding: 2.5em 3em;
 }
 
 
@@ -384,7 +389,7 @@ input[type='color']::-moz-color-swatch {
 }
 
 
-body.has-touch .pageContent-tabs {
+[data-bs-theme="light"] body.has-touch .pageContent-tabs {
 	overflow: auto;
 	display: block;
 	margin-right: -20px;
@@ -497,7 +502,7 @@ body.has-touch .pageContent-tabs > .nav-item:not(.hidden) {
 }
 
 
-.pageContent .multiSelect {
+[data-bs-theme="light"] .pageContent .multiSelect {
 	background: #fff;
 	padding-right: 0.65rem;
 }
@@ -538,12 +543,12 @@ html .ui-button.ui-state-disabled:active {
 }
 
 
-.ui-state-active,
-.ui-widget-content .ui-state-active,
-.ui-widget-header .ui-state-active,
-a.ui-button:active,
-.ui-button:active,
-.ui-button.ui-state-active:hover {
+[data-bs-theme="light"] .ui-state-active,
+[data-bs-theme="light"] .ui-widget-content .ui-state-active,
+[data-bs-theme="light"] .ui-widget-header .ui-state-active,
+[data-bs-theme="light"] a.ui-button:active,
+[data-bs-theme="light"] .ui-button:active,
+[data-bs-theme="light"] .ui-button.ui-state-active:hover {
 	background: #fff;
 }
 
@@ -555,11 +560,14 @@ a.ui-button:active,
 }
 
 
-.fppMinMaxSliderRange .ui-slider-handle {
+[data-bs-theme="light"] .fppMinMaxSliderRange .ui-slider-handle {
 	background-color: lightgrey;
+	border-color: #c5c5c5;
+}
+
+.fppMinMaxSliderRange .ui-slider-handle {
 	border: 1px;
 	border-style: solid;
-	border-color: #c5c5c5;
 	border-radius: 0.5rem;
 	width: 0.75em;
 	height: 1.25em;
@@ -828,11 +836,16 @@ a.ui-button:active,
 	font-family: Helvetica, Arial, sans-serif;
 	font-weight: bold;
 	cursor: pointer;
+}
+
+[data-bs-theme="light"] .nav-open #fppMenu a:hover,
+[data-bs-theme="light"] .nav-open #fppMenu a:focus,
+[data-bs-theme="light"] .nav-open #fppMenu a:active {
 	color: #363636;
 }
 
 
-#fppMenuList .dropdown-item {
+[data-bs-theme="light"] #fppMenuList .dropdown-item {
 	color: #363636;
 }
 
@@ -873,7 +886,7 @@ a.ui-button:active,
 }
 
 
-.nav-open #fppMenuList > li.active > a {
+[data-bs-theme="light"] .nav-open #fppMenuList > li.active > a {
 	color: #363636;
 }
 
@@ -1005,17 +1018,21 @@ a.ui-button:active,
 }
 
 
-#fppMenu .dropdown-menu .disabled > a {
+[data-bs-theme="light"] #fppMenu .dropdown-menu .disabled > a {
 	color: #777;
 }
 
+
+[data-bs-theme="light"] #fppMenu .dropdown-menu .disabled > a:focus,
+[data-bs-theme="light"] #fppMenu .dropdown-menu .disabled > a:hover {
+	color: #777;
+}
 
 #fppMenu .dropdown-menu .disabled > a:focus,
 #fppMenu .dropdown-menu .disabled > a:hover {
 	text-decoration: none;
 	background-color: transparent;
 	background-image: none;
-	color: #777;
 }
 
 
@@ -1051,7 +1068,6 @@ a.ui-button:active,
 	display: flex;
 	flex-flow: nowrap;
 	align-items: center;
-	color: #333;
 	text-decoration: none;
 	font-size: 0.9rem;
 	border-radius: 5px;
@@ -1067,6 +1083,11 @@ a.ui-button:active,
 	line-height: 1.428571;
 	text-overflow: ellipsis;
 	word-wrap: break-word;
+}
+
+[data-bs-theme="light"] #fppMenu .dropdown-menu .dropdown-item,
+[data-bs-theme="light"] #fppMenu .dropdown-menu li > a {
+	color: #333;
 }
 
 
@@ -1517,9 +1538,12 @@ body.is-loading #schedulerInfo .labelValue:before {
 }
 
 
-.controlsSectionToPin.Zebra_Pin {
+[data-bs-theme="light"] .controlsSectionToPin.Zebra_Pin {
 	background-color: #fff;
 	box-shadow: 0px 5px 4px -5px rgba(0, 0, 0, 0.2), 5px 0px 0px 0px #fff;
+}
+
+.controlsSectionToPin.Zebra_Pin {
 	padding-top: 0.5em;
 	margin-left: 0%;
 }
@@ -1530,16 +1554,22 @@ body.is-loading #schedulerInfo .labelValue:before {
 }
 
 
-#playerControls.Zebra_Pin {
+[data-bs-theme="light"] #playerControls.Zebra_Pin {
 	background-color: #fff;
 	box-shadow: 0px 5px 4px -5px rgba(0, 0, 0, 0.2), 5px 0px 0px 0px #fff;
+}
+
+#playerControls.Zebra_Pin {
 	padding-top: 0.5em;
 }
 
 
-#playerTime.Zebra_Pin {
+[data-bs-theme="light"] #playerTime.Zebra_Pin {
 	background-color: #fff;
 	box-shadow: 0px 5px 4px -5px rgba(0, 0, 0, 0.2), 5px 0px 0px 0px #fff;
+}
+
+#playerTime.Zebra_Pin {
 	padding-top: 0.5em;
 }
 
@@ -1637,9 +1667,9 @@ body.is-loading #schedulerInfo .labelValue:before {
 }
 
 
-.playlistSelectedEntry:not(.unselectable),
-.playlistSelectedEntry.PlaylistRowPlaying:not(.unselectable),
-.fileDetails.selectedEntry:not(.unselectable) {
+[data-bs-theme="light"] .playlistSelectedEntry:not(.unselectable),
+[data-bs-theme="light"] .playlistSelectedEntry.PlaylistRowPlaying:not(.unselectable),
+[data-bs-theme="light"] .fileDetails.selectedEntry:not(.unselectable) {
 	color: #000;
 	background-color: #c5d6f9;
 }
@@ -1900,12 +1930,15 @@ body.is-loading #schedulerInfo .labelValue:before {
 }
 
 
-.playlistEditorBackButton {
-	appearance: none;
+[data-bs-theme="light"] .playlistEditorBackButton {
 	background-color: #fff;
 	border: 1px solid #d2d2d2;
-	font-size: 1.2em;
 	color: #707070;
+}
+
+.playlistEditorBackButton {
+	appearance: none;
+	font-size: 1.2em;
 	padding: 0.3em 1em;
 	border-radius: 1.5rem;
 	transition: 0.5s all cubic-bezier(0.075, 0.82, 0.165, 1);
@@ -2104,8 +2137,11 @@ body.is-loading #schedulerInfo .labelValue:before {
 /* = Tables & Data Display = */
 /* =========================== */
 
-.fppTableWrapper thead th {
+[data-bs-theme="light"] .fppTableWrapper thead th {
 	background-color: white;
+}
+
+.fppTableWrapper thead th {
 	font-weight: bold;
 }
 
@@ -2122,9 +2158,12 @@ body.is-loading #schedulerInfo .labelValue:before {
 }
 
 
-.tablePageHeader.Zebra_Pin {
+[data-bs-theme="light"] .tablePageHeader.Zebra_Pin {
 	background-color: #fff;
 	box-shadow: 0px 5px 4px -5px rgba(0, 0, 0, 0.2), 5px 0px 0px 0px #fff;
+}
+
+.tablePageHeader.Zebra_Pin {
 	padding-top: 0.5em;
 }
 
@@ -2141,9 +2180,12 @@ body.is-loading #schedulerInfo .labelValue:before {
 }
 
 
-.tableTabPageHeader.Zebra_Pin {
+[data-bs-theme="light"] .tableTabPageHeader.Zebra_Pin {
 	background-color: #fff;
 	box-shadow: 0px 5px 4px -5px rgba(0, 0, 0, 0.2), 5px 0px 0px 0px #fff;
+}
+
+.tableTabPageHeader.Zebra_Pin {
 	padding-top: 0.5em;
 }
 
@@ -2397,13 +2439,65 @@ select#backup\.Direction {
 }
 
 
-.table-download-existing-backups thead {
+[data-bs-theme="light"] .table-download-existing-backups thead {
 	background-color: #f5f5f5;
 }
 
-
-.table-restore-existing-backups thead {
+[data-bs-theme="light"] .table-restore-existing-backups thead {
 	background-color: #f5f5f5;
+}
+
+/* Effect library sort table header */
+#tblEffectLibrary thead th:first-child {
+	border-top-left-radius: 8px;
+}
+#tblEffectLibrary thead th:last-child {
+	border-top-right-radius: 8px;
+}
+[data-bs-theme="light"] #tblEffectLibrary thead th {
+	background-color: #d9d9d9;
+}
+
+/* Multisync systems table header */
+#fppSystemsTable thead th {
+	padding-top: 0.4em;
+}
+#fppSystemsTable thead th .th-inner {
+	padding-top: 0.2em;
+}
+#fppSystemsTable thead th:first-child {
+	border-top-left-radius: 8px;
+}
+#fppSystemsTable thead th:last-child {
+	border-top-right-radius: 8px;
+}
+#fppSystemsTable thead td {
+	padding-bottom: 1.1em;
+}
+#fppSystemsTable thead td:first-child {
+	border-bottom-left-radius: 8px;
+}
+#fppSystemsTable thead td:last-child {
+	border-bottom-right-radius: 8px;
+}
+#fppSystemsTable th .th-inner:has(#selectAllCheckbox) {
+	overflow: visible;
+	text-overflow: clip;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+#fppSystemsTable td.centerCenter {
+	text-align: center;
+	vertical-align: middle;
+}
+#fppSystemsTable .multisyncRowCheckbox {
+	margin: 0;
+	vertical-align: middle;
+}
+[data-bs-theme="light"] #fppSystemsTable thead th,
+[data-bs-theme="light"] #fppSystemsTable thead td {
+	background-color: #d9d9d9;
 }
 
 
@@ -2720,16 +2814,18 @@ table#fppSystemsTable > thead > tr:last-child > td {
 }
 
 
-#divRunningEffects table thead th {
+[data-bs-theme="light"] #divRunningEffects table thead th {
 	color: black;
 	background-color: lightgrey;
-	font: inherit;
 }
 
-
-#divOverlayEffects table thead th {
+[data-bs-theme="light"] #divOverlayEffects table thead th {
 	color: black;
 	background-color: lightgrey;
+}
+
+#divRunningEffects table thead th,
+#divOverlayEffects table thead th {
 	font: inherit;
 }
 
@@ -2934,19 +3030,25 @@ table#fppSystemsTable > thead > tr:last-child > td {
 }
 
 
+[data-bs-theme="light"] .panelMatrix-tab-content .divLEDPanelsData {
+	background-color: whitesmoke;
+}
+
 .panelMatrix-tab-content .divLEDPanelsData {
 	border-radius: 10px;
 	padding: 10px;
 	margin-top: 5px;
-	background-color: whitesmoke;
 }
 
+
+[data-bs-theme="light"] .panelMatrix-tab-content .divLEDPanelsLayoutData {
+	background-color: whitesmoke;
+}
 
 .panelMatrix-tab-content .divLEDPanelsLayoutData {
 	border-radius: 10px;
 	padding: 10px;
 	margin-top: 5px;
-	background-color: whitesmoke;
 }
 
 
@@ -2994,12 +3096,15 @@ table#fppSystemsTable > thead > tr:last-child > td {
 }
 
 
-.global-network-section {
+[data-bs-theme="light"] .global-network-section {
 	background-color: #f8f9fa;
+	border: 1px solid #e9ecef;
+}
+
+.global-network-section {
 	border-radius: 8px;
 	padding: 20px;
 	margin-bottom: 20px;
-	border: 1px solid #e9ecef;
 }
 
 
@@ -3014,12 +3119,15 @@ table#fppSystemsTable > thead > tr:last-child > td {
 /* Interface Configuration Styles */
 
 
-.interface-config-section {
+[data-bs-theme="light"] .interface-config-section {
 	background-color: #f8f9fa;
+	border: 1px solid #e9ecef;
+}
+
+.interface-config-section {
 	border-radius: 8px;
 	padding: 20px;
 	margin-bottom: 20px;
-	border: 1px solid #e9ecef;
 }
 
 
@@ -3053,21 +3161,27 @@ table#fppSystemsTable > thead > tr:last-child > td {
 /* Interface Selection Styles */
 
 
-.interface-selection {
+[data-bs-theme="light"] .interface-selection {
 	background: #ffffff !important;
 	border: 1px solid #ddd !important;
+}
+
+.interface-selection {
 	border-radius: 6px !important;
 	padding: 15px !important;
 	margin-bottom: 20px !important;
 }
 
 
+[data-bs-theme="light"] .interface-selection h3 {
+	color: #444 !important;
+	border-bottom: 1px solid #ddd !important;
+}
+
 .interface-selection h3 {
 	margin-top: 0 !important;
-	color: #444 !important;
 	font-size: 18px !important;
 	padding-bottom: 8px !important;
-	border-bottom: 1px solid #ddd !important;
 	display: flex;
 	align-items: center;
 }
@@ -3083,12 +3197,15 @@ table#fppSystemsTable > thead > tr:last-child > td {
 /* Network Utilities Section Styles */
 
 
-.network-utilities-section {
+[data-bs-theme="light"] .network-utilities-section {
 	background-color: #f8f9fa;
+	border: 1px solid #e9ecef;
+}
+
+.network-utilities-section {
 	border-radius: 8px;
 	padding: 20px;
 	margin-bottom: 20px;
-	border: 1px solid #e9ecef;
 }
 
 
@@ -3103,12 +3220,15 @@ table#fppSystemsTable > thead > tr:last-child > td {
 /* Tethering Section Styles */
 
 
-.tethering-section {
+[data-bs-theme="light"] .tethering-section {
 	background-color: #f8f9fa;
+	border: 1px solid #e9ecef;
+}
+
+.tethering-section {
 	border-radius: 8px;
 	padding: 20px;
 	margin-bottom: 20px;
-	border: 1px solid #e9ecef;
 }
 
 
@@ -3143,8 +3263,11 @@ table#fppSystemsTable > thead > tr:last-child > td {
 }
 
 
-#wifiNetworksTable thead {
+[data-bs-theme="light"] #wifiNetworksTable thead {
 	background-color: #f8f9fa;
+}
+
+#wifiNetworksTable thead {
 	position: relative;
 	z-index: auto;
 }
@@ -3171,17 +3294,17 @@ table#fppSystemsTable > thead > tr:last-child > td {
 }
 
 
-.wifi-network-row:hover {
+[data-bs-theme="light"] .wifi-network-row:hover {
 	background-color: #f8f9fa !important;
 }
 
 
-.wifi-network-row.table-primary {
+[data-bs-theme="light"] .wifi-network-row.table-primary {
 	background-color: #d1ecf1 !important;
 }
 
 
-.wifi-network-row.table-primary:hover {
+[data-bs-theme="light"] .wifi-network-row.table-primary:hover {
 	background-color: #bee5eb !important;
 }
 
@@ -3215,28 +3338,31 @@ table#fppSystemsTable > thead > tr:last-child > td {
 /* Command Preset Invalid Command Styling */
 
 
-.commandPresetInvalidCommand {
+[data-bs-theme="light"] .commandPresetInvalidCommand {
 	background-color: #fff3cd !important;
 	border-left: 3px solid #ff9800 !important;
 }
 
 
-.commandPresetInvalidCommand .cmdTmplCommand {
+[data-bs-theme="light"] .commandPresetInvalidCommand .cmdTmplCommand {
 	background-color: #ffcccc !important;
 }
 
 
-.commandPresetInvalidWarning {
+[data-bs-theme="light"] .commandPresetInvalidWarning {
 	background-color: #fff3cd;
 	border: 1px solid #ffc107;
-	border-radius: 4px;
-	padding: 10px;
-	margin-bottom: 15px;
 	color: #856404;
 }
 
+.commandPresetInvalidWarning {
+	border-radius: 4px;
+	padding: 10px;
+	margin-bottom: 15px;
+}
 
-.commandPresetInvalidWarning strong {
+
+[data-bs-theme="light"] .commandPresetInvalidWarning strong {
 	color: #dc3545;
 }
 
@@ -3245,7 +3371,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 /* = Modals & Dialogs = */
 /* ====================== */
 
-.modal thead {
+[data-bs-theme="light"] .modal thead {
 	background: white;
 }
 
@@ -3812,13 +3938,16 @@ a.api-anchor {
 		transition: all 0.5s cubic-bezier(0.685, 0.0473, 0.346, 1);
 	}
 
+	[data-bs-theme="light"] #fppMenu .navbar-collapse::after {
+		background-color: #ffffff;
+	}
+
 	#fppMenu .navbar-collapse::after {
 		top: 0;
 		left: 0;
 		height: 100%;
 		width: 100%;
 		position: absolute;
-		background-color: #ffffff;
 		display: block;
 		content: '';
 		z-index: 1;
@@ -3835,8 +3964,11 @@ a.api-anchor {
 		z-index: 3;
 	}
 
-	#fppMenu .navbar-collapse .navbar-nav .nav-item .nav-link {
+	[data-bs-theme="light"] #fppMenu .navbar-collapse .navbar-nav .nav-item .nav-link {
 		color: #000000;
+	}
+
+	#fppMenu .navbar-collapse .navbar-nav .nav-item .nav-link {
 		margin: 5px 15px;
 	}
 
@@ -3971,6 +4103,10 @@ a.api-anchor {
 		}
 	}
 
+	[data-bs-theme="light"] #bodyClick {
+		background-color: #ffffff;
+	}
+
 	#bodyClick {
 		height: 100%;
 		width: 100%;
@@ -3982,7 +4118,6 @@ a.api-anchor {
 		content: '';
 		z-index: 1029;
 		overflow-x: hidden;
-		background-color: #ffffff;
 		-webkit-animation: fadeIn ease 1s;
 		animation: fadeIn ease 1s;
 	}

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -16,7 +16,6 @@ html {
 	background: white;
 }
 
-
 /* Fix dark border on datalist inputs (SSID fields) */
 
 
@@ -48,6 +47,7 @@ input[list]::-webkit-calendar-picker-indicator {
 input[list]::-webkit-list-button {
 	display: none;
 }
+
 
 
 /* Specific styling for SSID input fields to match other inputs */
@@ -2652,7 +2652,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 
 #fppSystems > tr > td {
-	border-top: 1px solid #dee2e6;
+	border-top: 1px solid var(--bs-border-color);
 }
 
 
@@ -2666,9 +2666,9 @@ table#fppSystemsTable > thead > tr:last-child > td {
 }
 
 
-#fppSystems > tr > td:last-child {
+/* #fppSystems > tr > td:last-child {
 	padding-right: 1em;
-}
+} */
 
 
 #multisyncViewOptions .settingsTable {
@@ -2716,13 +2716,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 	margin-left: 0.5em;
 }
 
-
-#selectAllCheckbox {
-	transform: translateY(37px);
-}
-
-
-#fppSystemsTable {
+#fppSystemsTable, #syncStatsTable {
 	width: 100%;
 }
 
@@ -2740,11 +2734,6 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 .txtDesc {
 	width: 150px;
-}
-
-
-#syncStatsTable {
-	width: 100%;
 }
 
 

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -2,7 +2,7 @@
 /* = Base & Reset Styles = */
 /* ========================= */
 
-body {
+[data-bs-theme="light"] body {
 	background-color: #171720;
 }
 
@@ -22,7 +22,7 @@ html {
 
 [data-bs-theme="light"] input[list] {
 	background: white !important;
-	border: 1px solid #ccc !important;
+	border: 1px solid var(--fpp-border) !important;
 	border-radius: 3px !important;
 	-webkit-appearance: none !important;
 	-moz-appearance: none !important;
@@ -56,7 +56,7 @@ input[list]::-webkit-list-button {
 [data-bs-theme="light"] #eth_ssid,
 [data-bs-theme="light"] #backupeth_ssid {
 	background: white !important;
-	border: 1px solid #ccc !important;
+	border: 1px solid var(--fpp-border) !important;
 	border-radius: 3px !important;
 	padding: 4px 6px !important;
 	font-family: inherit !important;
@@ -155,7 +155,7 @@ body fieldset {
 	border: 0;
 	padding: 0;
 	margin: 0;
-	border-bottom: 1px solid #d2d2d2;
+	border-bottom: 1px solid var(--fpp-border);
 	padding-bottom: 2em;
 	margin-bottom: 1em;
 	margin-top: 1.5em;
@@ -212,7 +212,7 @@ input[type='range']::-ms-track {
 	-webkit-appearance: none;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.1);
 	border-radius: 1.5em;
-	border: 1px solid #d2d2d2;
+	border: 1px solid var(--fpp-border);
 	background-color: #fff;
 	border-radius: 50%;
 	width: 35px;
@@ -226,7 +226,7 @@ input[type='range']::-ms-track {
 	appearance: none;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.1);
 	border-radius: 1.5em;
-	border: 1px solid #d2d2d2;
+	border: 1px solid var(--fpp-border);
 	background-color: #fff;
 	border-radius: 50%;
 	width: 35px;
@@ -240,7 +240,7 @@ input[type='range']::-ms-track {
 	appearance: none;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.1);
 	border-radius: 1.5em;
-	border: 1px solid #d2d2d2;
+	border: 1px solid var(--fpp-border);
 	background-color: #fff;
 	border-radius: 50%;
 	width: 35px;
@@ -252,7 +252,7 @@ input[type='range']::-ms-track {
 hr {
 	border: 0px;
 	border-style: solid;
-	border-top: 1px solid #d2d2d2;
+	border-top: 1px solid var(--fpp-border);
 }
 
 
@@ -379,7 +379,7 @@ input[type='color']::-moz-color-swatch {
 
 .pageContent-tabs {
 	padding-bottom: 0.85em;
-	border-bottom: 1px solid #dadada;
+	border-bottom: 1px solid var(--fpp-border);
 	margin-bottom: 1em;
 }
 
@@ -423,7 +423,7 @@ body.has-touch .pageContent-tabs > .nav-item:not(.hidden) {
 
 
 .pageContent .volumeControls .buttons {
-	border-color: #d2d2d2;
+	border-color: var(--fpp-border);
 	border-radius: 29px;
 	width: 62px;
 	height: 46px;
@@ -486,7 +486,7 @@ body.has-touch .pageContent-tabs > .nav-item:not(.hidden) {
 .settingsGroupTable .row.loading > :last-child:after {
 	content: '';
 	display: inline-block;
-	color: #f63939;
+	color: var(--bs-danger);
 	width: 22px;
 	height: 22px;
 	opacity: 1;
@@ -853,7 +853,7 @@ html .ui-button.ui-state-disabled:active {
 #fppMenuList li ul a:hover,
 #fppMenu li ul a:focus,
 #fppMenu li ul a:active {
-	background-color: #f63939;
+	background-color: var(--bs-danger);
 	color: #fff;
 }
 
@@ -870,7 +870,7 @@ html .ui-button.ui-state-disabled:active {
 
 
 #fppMenuList > li.active {
-	border-bottom-color: #f63939;
+	border-bottom-color: var(--bs-danger);
 }
 
 
@@ -1106,7 +1106,7 @@ html .ui-button.ui-state-disabled:active {
 .dropdown-menu a:active {
 	box-shadow: 0 4px 5px 0px rgba(0, 0, 0, 0.14),
 		0 7px 10px -5px rgba(156, 39, 176, 0.4);
-	background-color: #f63939;
+	background-color: var(--bs-danger);
 	color: #fff !important;
 }
 
@@ -1644,7 +1644,7 @@ body.is-loading #schedulerInfo .labelValue:before {
 
 .PlaylistRowPlaying {
 	color: #fff;
-	background-color: #56b760;
+	background-color: var(--bs-success);
 }
 
 
@@ -1697,7 +1697,7 @@ body.is-loading #schedulerInfo .labelValue:before {
 .playlistRow td {
 	padding: 0.1em 1em;
 	transition: background-color 0.15s ease-out;
-	border-top: 1px solid #dadada;
+	border-top: 1px solid var(--fpp-border);
 }
 
 
@@ -1932,7 +1932,7 @@ body.is-loading #schedulerInfo .labelValue:before {
 
 [data-bs-theme="light"] .playlistEditorBackButton {
 	background-color: #fff;
-	border: 1px solid #d2d2d2;
+	border: 1px solid var(--fpp-border);
 	color: #707070;
 }
 
@@ -1951,13 +1951,13 @@ body.is-loading #schedulerInfo .labelValue:before {
 
 
 .playlistEditorBackButton:hover {
-	border-color: #f63939;
-	color: #f63939;
+	border-color: var(--bs-danger);
+	color: var(--bs-danger);
 }
 
 
 .playlistEditorBackButton .fa-grip-horizontal {
-	color: #f63939;
+	color: var(--bs-danger);
 }
 
 
@@ -2034,7 +2034,7 @@ body.is-loading #schedulerInfo .labelValue:before {
 
 
 .playlistCard:hover {
-	color: #f63939;
+	color: var(--bs-danger);
 	transition: 0.3s all cubic-bezier(0.075, 0.82, 0.165, 1);
 	transform: translateY(-4px);
 }
@@ -2042,7 +2042,7 @@ body.is-loading #schedulerInfo .labelValue:before {
 
 .playlistCard h3:before {
 	content: '\f0cb';
-	background-color: #f63939;
+	background-color: var(--bs-danger);
 	color: #fff;
 	display: inline-block;
 	text-align: center;
@@ -2137,12 +2137,41 @@ body.is-loading #schedulerInfo .labelValue:before {
 /* = Tables & Data Display = */
 /* =========================== */
 
-[data-bs-theme="light"] .fppTableWrapper thead th {
-	background-color: white;
+/* Single-knob thead styling — all FPP data-table headers share one background.
+   Adjust --fpp-thead-bg in fpp-system-design.css / fpp-dark.css to re-theme everyone.
+   Structural rules (border-radius, padding, font-weight) stay on per-table selectors below. */
+.tblheader,
+#tblEffectLibrary thead th,
+#fppSystemsTable thead th,
+#fppSystemsTable thead td,
+.table-download-existing-backups thead,
+.table-restore-existing-backups thead,
+#wifiNetworksTable thead,
+#divRunningEffects table thead th,
+#divOverlayEffects table thead th {
+	background-color: var(--fpp-thead-bg);
+	color: var(--fpp-thead-color);
+}
+
+.tblheader {
+	text-align: center;
+}
+
+/* Shared "selected row" highlight — used by scheduler, co-pixelStrings, co-universes,
+   commandPresets, pixeloverlaymodels, channelinputs, outputprocessors, and more.
+   Previously defined inside scheduler.php's <style> block; now global. */
+.selectedEntry {
+	background: var(--fpp-selected-row-bg);
 }
 
 .fppTableWrapper thead th {
 	font-weight: bold;
+}
+
+/* Generic clearfix-child utility (legacy). Kept global so pages don't need
+   to redefine it. Used by about.php and potentially elsewhere. */
+.clear {
+	clear: both;
 }
 
 
@@ -2236,7 +2265,7 @@ body.is-loading #schedulerInfo .labelValue:before {
 	color: #666 !important;
 	margin: 10px 0 15px 0 !important;
 	padding: 8px 0 8px 0 !important;
-	border-bottom: 1px solid #ddd !important;
+	border-bottom: 1px solid var(--fpp-border) !important;
 	font-weight: 600 !important;
 	background: none !important;
 }
@@ -2251,7 +2280,7 @@ body.is-loading #schedulerInfo .labelValue:before {
 	color: #666 !important;
 	margin: 10px 0 15px 0 !important;
 	padding: 8px 0 8px 0 !important;
-	border-bottom: 1px solid #ddd !important;
+	border-bottom: 1px solid var(--fpp-border) !important;
 	font-weight: 600 !important;
 	background: none !important;
 }
@@ -2280,7 +2309,7 @@ body.is-loading #schedulerInfo .labelValue:before {
 .fileDetails td {
 	padding: 0.4em 0.4em;
 	cursor: pointer;
-	border-top: 1px solid #dadada;
+	border-top: 1px solid var(--fpp-border);
 }
 
 
@@ -2439,23 +2468,42 @@ select#backup\.Direction {
 }
 
 
-[data-bs-theme="light"] .table-download-existing-backups thead {
-	background-color: #f5f5f5;
-}
-
-[data-bs-theme="light"] .table-restore-existing-backups thead {
-	background-color: #f5f5f5;
-}
-
-/* Effect library sort table header */
+/* Effect library sort table header (structural only — bg lives in the unified thead rule) */
 #tblEffectLibrary thead th:first-child {
 	border-top-left-radius: 8px;
 }
 #tblEffectLibrary thead th:last-child {
 	border-top-right-radius: 8px;
 }
-[data-bs-theme="light"] #tblEffectLibrary thead th {
-	background-color: #d9d9d9;
+
+/* Sort-icon spans: use CSS mask so the icon color comes from background-color,
+   which can be a CSS variable that auto-adapts to dark mode.
+   Overrides bootstrap-table's static-colored background-image SVGs. */
+#tblEffectLibrary thead th .both,
+#tblEffectLibrary thead th .asc,
+#tblEffectLibrary thead th .desc {
+	background-image: none;
+	mask-repeat: no-repeat;
+	mask-position: center right 2px;
+	mask-size: 16px 16px;
+	-webkit-mask-repeat: no-repeat;
+	-webkit-mask-position: center right 2px;
+	-webkit-mask-size: 16px 16px;
+}
+#tblEffectLibrary thead th .both {
+	background-color: var(--fpp-text-muted);
+	mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path d="m103.05877,41.4c9.37707,-12.5 24.60541,-12.5 33.98248,0l96.02113,128c6.90152,9.2 8.92696,22.9 5.17614,34.9s-12.45274,19.8 -22.20489,19.8l-192.04225,-0.1c-9.67713,0 -18.45406,-7.8 -22.20489,-19.8s-1.65036,-25.7 5.17614,-34.9l96.02113,-128l0.07501,0.1zm0,429.3l-96.02113,-128c-6.90152,-9.2 -8.92696,-22.9 -5.17614,-34.9s12.45274,-19.8 22.20489,-19.8l192.04225,0c9.67713,0 18.45406,7.8 22.20489,19.8s1.65036,25.7 -5.17614,34.9l-96.02113,128c-9.37707,12.5 -24.60541,12.5 -33.98248,0l-0.07501,0z"/></svg>');
+	-webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path d="m103.05877,41.4c9.37707,-12.5 24.60541,-12.5 33.98248,0l96.02113,128c6.90152,9.2 8.92696,22.9 5.17614,34.9s-12.45274,19.8 -22.20489,19.8l-192.04225,-0.1c-9.67713,0 -18.45406,-7.8 -22.20489,-19.8s-1.65036,-25.7 5.17614,-34.9l96.02113,-128l0.07501,0.1zm0,429.3l-96.02113,-128c-6.90152,-9.2 -8.92696,-22.9 -5.17614,-34.9s12.45274,-19.8 22.20489,-19.8l192.04225,0c9.67713,0 18.45406,7.8 22.20489,19.8s1.65036,25.7 -5.17614,34.9l-96.02113,128c-9.37707,12.5 -24.60541,12.5 -33.98248,0l-0.07501,0z"/></svg>');
+}
+#tblEffectLibrary thead th .asc {
+	background-color: var(--bs-body-color);
+	mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path d="m136.9496,41.4c-9.3763,-12.5 -24.60342,-12.5 -33.97972,0l-96.01334,128c-6.90096,9.2 -8.92624,22.9 -5.17572,34.9s12.45173,19.8 22.20309,19.8l192.02668,0c9.67634,0 18.45256,-7.8 22.20309,-19.8s1.65023,-25.7 -5.17572,-34.9l-96.01334,-128l-0.07501,0z"/></svg>');
+	-webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path d="m136.9496,41.4c-9.3763,-12.5 -24.60342,-12.5 -33.97972,0l-96.01334,128c-6.90096,9.2 -8.92624,22.9 -5.17572,34.9s12.45173,19.8 22.20309,19.8l192.02668,0c9.67634,0 18.45256,-7.8 22.20309,-19.8s1.65023,-25.7 -5.17572,-34.9l-96.01334,-128l-0.07501,0z"/></svg>');
+}
+#tblEffectLibrary thead th .desc {
+	background-color: var(--bs-body-color);
+	mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path d="m136.94959,471.6c-9.3763,12.5 -24.60342,12.5 -33.97972,0l-96.01334,-128c-6.90096,-9.2 -8.92624,-22.9 -5.17572,-34.9s12.45173,-19.8 22.20308,-19.8l192.02667,0c9.67634,0 18.45256,7.8 22.20308,19.8s1.65023,25.7 -5.17572,34.9l-96.01334,128l-0.07501,0z"/></svg>');
+	-webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path d="m136.94959,471.6c-9.3763,12.5 -24.60342,12.5 -33.97972,0l-96.01334,-128c-6.90096,-9.2 -8.92624,-22.9 -5.17572,-34.9s12.45173,-19.8 22.20308,-19.8l192.02667,0c9.67634,0 18.45256,7.8 22.20308,19.8s1.65023,25.7 -5.17572,34.9l-96.01334,128l-0.07501,0z"/></svg>');
 }
 
 /* Multisync systems table header */
@@ -2494,10 +2542,6 @@ select#backup\.Direction {
 #fppSystemsTable .multisyncRowCheckbox {
 	margin: 0;
 	vertical-align: middle;
-}
-[data-bs-theme="light"] #fppSystemsTable thead th,
-[data-bs-theme="light"] #fppSystemsTable thead td {
-	background-color: #d9d9d9;
 }
 
 
@@ -2550,7 +2594,7 @@ select#backup\.Direction {
 .fpp-backup-action-loading:before {
 	content: '';
 	display: inline-block;
-	color: #f63939;
+	color: var(--bs-danger);
 	width: 16px;
 	height: 16px;
 	opacity: 1;
@@ -2573,7 +2617,7 @@ select#backup\.Direction {
 
 
 .host_rsyncd_warning b {
-	color: #f63939 !important;
+	color: var(--bs-danger) !important;
 }
 
 
@@ -2718,7 +2762,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 	height: 33px;
 	border-radius: 8px;
 	box-shadow: 3px 3px 8px rgb(0 0 0 / 10%);
-	border: 1px solid #d2d2d2;
+	border: 1px solid var(--fpp-border);
 	cursor: pointer;
 	display: block;
 }
@@ -2813,16 +2857,6 @@ table#fppSystemsTable > thead > tr:last-child > td {
 	color: #d1d1d1;
 }
 
-
-[data-bs-theme="light"] #divRunningEffects table thead th {
-	color: black;
-	background-color: lightgrey;
-}
-
-[data-bs-theme="light"] #divOverlayEffects table thead th {
-	color: black;
-	background-color: lightgrey;
-}
 
 #divRunningEffects table thead th,
 #divOverlayEffects table thead th {
@@ -2925,7 +2959,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 
 #installedPlugins .fppPluginEntryBackdrop:before {
-	background-color: #56b760;
+	background-color: var(--bs-success);
 }
 
 
@@ -2940,7 +2974,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 
 #incompatiblePlugins .fppPluginEntryBackdrop:before {
-	background-color: #f63939;
+	background-color: var(--bs-danger);
 }
 
 
@@ -2988,7 +3022,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 .piPixelOutputTableWrapper {
 	padding-bottom: 0.85em;
-	border-bottom: 1px solid #dadada;
+	border-bottom: 1px solid var(--fpp-border);
 	margin-bottom: 1em;
 }
 
@@ -3163,7 +3197,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 [data-bs-theme="light"] .interface-selection {
 	background: #ffffff !important;
-	border: 1px solid #ddd !important;
+	border: 1px solid var(--fpp-border) !important;
 }
 
 .interface-selection {
@@ -3175,7 +3209,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 [data-bs-theme="light"] .interface-selection h3 {
 	color: #444 !important;
-	border-bottom: 1px solid #ddd !important;
+	border-bottom: 1px solid var(--fpp-border) !important;
 }
 
 .interface-selection h3 {
@@ -3246,7 +3280,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 #wifiNetworksTable {
 	max-height: 200px;
 	overflow-y: auto;
-	border: 1px solid #ddd;
+	border: 1px solid var(--fpp-border);
 	border-radius: 4px;
 	margin-bottom: 10px;
 }
@@ -3262,10 +3296,6 @@ table#fppSystemsTable > thead > tr:last-child > td {
 	z-index: auto;
 }
 
-
-[data-bs-theme="light"] #wifiNetworksTable thead {
-	background-color: #f8f9fa;
-}
 
 #wifiNetworksTable thead {
 	position: relative;
@@ -3296,6 +3326,11 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 [data-bs-theme="light"] .wifi-network-row:hover {
 	background-color: #f8f9fa !important;
+}
+
+
+.wifi-network-row:active {
+	background-color: var(--bs-secondary-bg);
 }
 
 
@@ -3339,7 +3374,7 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 
 [data-bs-theme="light"] .commandPresetInvalidCommand {
-	background-color: #fff3cd !important;
+	background-color: var(--bs-warning-bg-subtle) !important;
 	border-left: 3px solid #ff9800 !important;
 }
 
@@ -3350,9 +3385,9 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 
 [data-bs-theme="light"] .commandPresetInvalidWarning {
-	background-color: #fff3cd;
-	border: 1px solid #ffc107;
-	color: #856404;
+	background-color: var(--bs-warning-bg-subtle);
+	border: 1px solid var(--bs-warning);
+	color: var(--bs-warning-text-emphasis);
 }
 
 .commandPresetInvalidWarning {
@@ -3363,18 +3398,13 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 
 [data-bs-theme="light"] .commandPresetInvalidWarning strong {
-	color: #dc3545;
+	color: var(--bs-danger);
 }
 
 
 /* ====================== */
 /* = Modals & Dialogs = */
 /* ====================== */
-
-[data-bs-theme="light"] .modal thead {
-	background: white;
-}
-
 
 #bankSlider {
 	width: 800px;
@@ -3419,13 +3449,15 @@ table#fppSystemsTable > thead > tr:last-child > td {
 /* = Footer = */
 /* ============ */
 
+[data-bs-theme="light"] #footer {
+	background-color: #20222e;
+	box-shadow: 1000px 100px 0px 0px #20222e, -1000px 100px 0px 0px #20222e,
+		0px 100px 0px 0px #20222e;
+}
 #footer {
 	position: relative;
 	text-align: center;
 	padding: 2em;
-	background-color: #20222e;
-	box-shadow: 1000px 100px 0px 0px #20222e, -1000px 100px 0px 0px #20222e,
-		0px 100px 0px 0px #20222e;
 }
 
 
@@ -3650,12 +3682,12 @@ a.api-anchor {
 
 
 .text-muted {
-	color: #6c757d !important;
+	color: var(--fpp-text-muted) !important;
 }
 
 
 .text-success {
-	color: #56b760 !important;
+	color: var(--bs-success) !important;
 }
 
 
@@ -3667,7 +3699,7 @@ a.api-anchor {
 
 
 .bg-success {
-	background-color: #56b760 !important;
+	background-color: var(--bs-success) !important;
 }
 
 
@@ -3681,17 +3713,17 @@ a.api-anchor {
 
 
 .text-success {
-	color: #28a745 !important;
+	color: var(--bs-success) !important;
 }
 
 
 .text-warning {
-	color: #ffc107 !important;
+	color: var(--bs-warning) !important;
 }
 
 
 .text-danger {
-	color: #dc3545 !important;
+	color: var(--bs-danger) !important;
 }
 
 
@@ -3711,9 +3743,9 @@ a.api-anchor {
 }
 
 
-.badge-secondary {
+[data-bs-theme="light"] .badge-secondary {
 	color: #fff;
-	background-color: #6c757d;
+	background-color: var(--bs-secondary);
 }
 
 
@@ -4386,8 +4418,8 @@ a.api-anchor {
 
 		padding-left: 0;
 		justify-content: flex-end;
-		border-bottom: 1px solid #d2d2d2;
-		border-top: 1px solid #d2d2d2;
+		border-bottom: 1px solid var(--fpp-border);
+		border-top: 1px solid var(--fpp-border);
 		padding-bottom: 0.6em;
 		padding-top: 0.6em;
 		margin-top: 1.2em;
@@ -4815,7 +4847,7 @@ a.api-anchor {
 
 	.pageContent {
 		box-shadow: none;
-		border: 1px solid #ddd;
+		border: 1px solid var(--fpp-border);
 	}
 
 	.btn-outline-light,
@@ -4827,4 +4859,10 @@ a.api-anchor {
 		border-color: #000;
 		color: #000;
 	}
+}
+
+/* Current Monitor demo (currentmonitor_bootstrap.php): fault-state port SVG.
+   Replaces 16 identical inline style="--color_fill: red;" attributes. */
+.svg-fault-fill {
+	--color_fill: red;
 }

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -208,7 +208,7 @@ input[type='range']::-ms-track {
 }
 
 
-[data-bs-theme="light"] input[type='range']::-webkit-slider-thumb {
+input[type='range']::-webkit-slider-thumb {
 	-webkit-appearance: none;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.1);
 	border-radius: 1.5em;
@@ -221,7 +221,7 @@ input[type='range']::-ms-track {
 }
 
 
-[data-bs-theme="light"] input[type='range']::-moz-range-thumb {
+input[type='range']::-moz-range-thumb {
 	-webkit-appearance: none;
 	appearance: none;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.1);
@@ -235,7 +235,7 @@ input[type='range']::-ms-track {
 }
 
 
-[data-bs-theme="light"] input[type='range']::-ms-thumb {
+input[type='range']::-ms-thumb {
 	-webkit-appearance: none;
 	appearance: none;
 	box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.1);

--- a/www/currentmonitor_bootstrap.php
+++ b/www/currentmonitor_bootstrap.php
@@ -235,7 +235,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -260,7 +260,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -285,7 +285,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -310,7 +310,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -336,7 +336,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -361,7 +361,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -386,7 +386,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -411,7 +411,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -463,7 +463,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -488,7 +488,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -513,7 +513,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -538,7 +538,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -564,7 +564,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -589,7 +589,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -614,7 +614,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>
@@ -639,7 +639,7 @@
                                                 </div>
                                             </div>
                                             <div class="col-10">
-                                                <img src="images/3P-phoenix-cad.svg" style="--color_fill: red;"
+                                                <img src="images/3P-phoenix-cad.svg" class="svg-fault-fill"
                                                     alt="Port-img-1" width="70%" />
                                             </div>
                                         </div>

--- a/www/effects.php
+++ b/www/effects.php
@@ -21,21 +21,6 @@
   <script src="bootstrap-table/js/bootstrap-table.min.js"></script>
   <script src="bootstrap-table/extensions/bootstrap-table-filter-control.min.js"></script>
 
-  <style>
-    #tblEffectLibrary thead th .both {
-      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" fill="%23888"><path d="m103.05877,41.4c9.37707,-12.5 24.60541,-12.5 33.98248,0l96.02113,128c6.90152,9.2 8.92696,22.9 5.17614,34.9s-12.45274,19.8 -22.20489,19.8l-192.04225,-0.1c-9.67713,0 -18.45406,-7.8 -22.20489,-19.8s-1.65036,-25.7 5.17614,-34.9l96.02113,-128l0.07501,0.1zm0,429.3l-96.02113,-128c-6.90152,-9.2 -8.92696,-22.9 -5.17614,-34.9s12.45274,-19.8 22.20489,-19.8l192.04225,0c9.67713,0 18.45406,7.8 22.20489,19.8s1.65036,25.7 -5.17614,34.9l-96.02113,128c-9.37707,12.5 -24.60541,12.5 -33.98248,0l-0.07501,0z"/></svg>');
-    }
-
-    #tblEffectLibrary thead th .asc {
-      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" fill="%230d47a1"><path d="m136.9496,41.4c-9.3763,-12.5 -24.60342,-12.5 -33.97972,0l-96.01334,128c-6.90096,9.2 -8.92624,22.9 -5.17572,34.9s12.45173,19.8 22.20309,19.8l192.02668,0c9.67634,0 18.45256,-7.8 22.20309,-19.8s1.65023,-25.7 -5.17572,-34.9l-96.01334,-128l-0.07501,0z"/></svg>');
-    }
-
-    #tblEffectLibrary thead th .desc {
-      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" fill="%230d47a1"><path d="m136.94959,471.6c-9.3763,12.5 -24.60342,12.5 -33.97972,0l-96.01334,-128c-6.90096,-9.2 -8.92624,-22.9 -5.17572,-34.9s12.45173,-19.8 22.20308,-19.8l192.02667,0c9.67634,0 18.45256,7.8 22.20308,19.8s1.65023,25.7 -5.17572,34.9l-96.01334,128l-0.07501,0z"/></svg>');
-    }
-  </style>
-
-
   <script>
     var EffectSelectedName = "";
     var EffectSelectedType = "";

--- a/www/effects.php
+++ b/www/effects.php
@@ -22,18 +22,6 @@
   <script src="bootstrap-table/extensions/bootstrap-table-filter-control.min.js"></script>
 
   <style>
-    #tblEffectLibrary thead th {
-      background-color: #d9d9d9;
-    }
-
-    #tblEffectLibrary thead th:first-child {
-      border-top-left-radius: 8px;
-    }
-
-    #tblEffectLibrary thead th:last-child {
-      border-top-right-radius: 8px;
-    }
-
     #tblEffectLibrary thead th .both {
       background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" fill="%23888"><path d="m103.05877,41.4c9.37707,-12.5 24.60541,-12.5 33.98248,0l96.02113,128c6.90152,9.2 8.92696,22.9 5.17614,34.9s-12.45274,19.8 -22.20489,19.8l-192.04225,-0.1c-9.67713,0 -18.45406,-7.8 -22.20489,-19.8s-1.65036,-25.7 5.17614,-34.9l96.02113,-128l0.07501,0.1zm0,429.3l-96.02113,-128c-6.90152,-9.2 -8.92696,-22.9 -5.17614,-34.9s12.45274,-19.8 22.20489,-19.8l192.04225,0c9.67713,0 18.45406,7.8 22.20489,19.8s1.65036,25.7 -5.17614,34.9l-96.02113,128c-9.37707,12.5 -24.60541,12.5 -33.98248,0l-0.07501,0z"/></svg>');
     }

--- a/www/gpio.php
+++ b/www/gpio.php
@@ -314,22 +314,22 @@ foreach ($gpiojson as $gpio) {
                 if ($isGpioInUse) {
                     // Pin is in use - show read-only information
                     ?>
-                    <td><span style="color: #888;">N/A</span></td>
+                    <td><span class="text-muted">N/A</span></td>
                     <td><?=$pinName?></td>
                     <td><?=$gpio['gpioChip']?>/<?=$gpio['gpioLine']?></td>
                     <?php
                     if ($gpio['supportsPullUp'] || $gpio['supportsPullDown']) {
                         ?>
-                        <td><span style="color: #888;">Cape Controlled</span></td>
-                        <td><span style="color: #888;">N/A</span></td>
-                        <td><span style="color: #888;">N/A</span></td>
+                        <td><span class="text-muted">Cape Controlled</span></td>
+                        <td><span class="text-muted">N/A</span></td>
+                        <td><span class="text-muted">N/A</span></td>
                         <?php
                     } else if ($pCount > 0) {
                         echo "<td></td><td></td><td></td>";
                     }
                     ?>
                     <td><strong style="color: #0066cc;">In Use: <?=htmlspecialchars($usedGpioPins[$pinName])?></strong></td>
-                    <td colspan="2" style="color: #888; font-style: italic;">GPIO pin reserved by cape configuration</td>
+                    <td colspan="2" class="text-muted fst-italic">GPIO pin reserved by cape configuration</td>
                     <?php
                 } else {
                     // Pin is available - show normal configuration options

--- a/www/index.php
+++ b/www/index.php
@@ -554,7 +554,7 @@
 
                             <!-- Controls / Elapsed and Volume section --->
 
-                            <div id="controlsSection" class="container-fluid bg-white">
+                            <div id="controlsSection" class="container-fluid">
                                 <div class="row gx-0">
                                     <div class="col-xs-12 col-md-6 col-lg-8 col-xxl-7">
                                         <div id="playerControls"

--- a/www/multisync.php
+++ b/www/multisync.php
@@ -94,58 +94,7 @@
             color: #ddd;
         }
 
-        /* Bootstrap Table header styling — replaces old .tablesorter thead rules */
-        #fppSystemsTable thead th {
-            background-color: #d9d9d9;
-            padding-top: 0.4em;
-        }
-
-        #fppSystemsTable thead th .th-inner {
-            padding-top: 0.2em;
-        }
-
-        #fppSystemsTable thead th:first-child {
-            border-top-left-radius: 8px;
-        }
-
-        #fppSystemsTable thead th:last-child {
-            border-top-right-radius: 8px;
-        }
-
-        #fppSystemsTable thead td {
-            background-color: #d9d9d9;
-            padding-bottom: 1.1em;
-        }
-
-        #fppSystemsTable thead td:first-child {
-            border-bottom-left-radius: 8px;
-        }
-
-        #fppSystemsTable thead td:last-child {
-            border-bottom-right-radius: 8px;
-        }
-
-        /* Ensure the select-all checkbox in the header is not clipped by BT's th-inner */
-        #fppSystemsTable th .th-inner:has(#selectAllCheckbox) {
-            overflow: visible;
-            text-overflow: clip;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        /* Align row checkboxes to center like the header checkbox */
-        #fppSystemsTable td.centerCenter {
-            text-align: center;
-            vertical-align: middle;
-        }
-
-        #fppSystemsTable .multisyncRowCheckbox {
-            margin: 0;
-            vertical-align: middle;
-        }
-
-        /* Make the unsorted (both arrows) icon visible on the grey header */
+        /* Bootstrap Table sort icons for #fppSystemsTable — structural/theming in fpp.css/fpp-dark.css */
         #fppSystemsTable thead th .both {
             background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="%23888" d="m103.05877,41.4c9.37707,-12.5 24.60541,-12.5 33.98248,0l96.02113,128c6.90152,9.2 8.92696,22.9 5.17614,34.9s-12.45274,19.8 -22.20489,19.8l-192.04225,-0.1c-9.67713,0 -18.45406,-7.8 -22.20489,-19.8s-1.65036,-25.7 5.17614,-34.9l96.02113,-128l0.07501,0.1z"/><path fill="%23888" d="m103.05877,470.7l-96.02113,-128c-6.90152,-9.2 -8.92696,-22.9 -5.17614,-34.9s12.45274,-19.8 22.20489,-19.8l192.04225,0c9.67713,0 18.45406,7.8 22.20489,19.8s1.65036,25.7 -5.17614,34.9l-96.02113,128c-9.37707,12.5 -24.60541,12.5 -33.98248,0l-0.07501,0z"/></svg>');
         }

--- a/www/multisync.php
+++ b/www/multisync.php
@@ -36,11 +36,11 @@
         }
 
         .channel-io-icon-input {
-            color: #17a2b8;
+            color: var(--bs-info);
         }
 
         .channel-io-icon-output {
-            color: #28a745;
+            color: var(--bs-success);
         }
 
         .channel-io-icon-output[data-ip],
@@ -91,7 +91,7 @@
         }
 
         #popover-target .disabled {
-            color: #ddd;
+            color: var(--fpp-text-light);
         }
 
         /* Bootstrap Table sort icons for #fppSystemsTable — structural/theming in fpp.css/fpp-dark.css */
@@ -114,7 +114,7 @@
         }
 
         #columnSelector label:first-of-type {
-            border-bottom: 2px dotted #000;
+            border-bottom: 2px dotted var(--bs-body-color);
             /* Adjust thickness and color as needed */
             padding-bottom: 1px;
             /* Adds spacing between the label and the border */
@@ -150,8 +150,8 @@
         }
 
         .reorder-mode .ui-sortable-placeholder {
-            background-color: #f0f0f0;
-            border: 2px dashed #ccc;
+            background-color: var(--bs-tertiary-bg);
+            border: 2px dashed var(--fpp-border);
             visibility: visible !important;
             height: 2.5em;
         }

--- a/www/networkconfig.php
+++ b/www/networkconfig.php
@@ -66,19 +66,19 @@
 
         /* WiFi Signal Strength Styling */
         .wifi-signal.excellent {
-            color: #28a745;
+            color: var(--bs-success);
         }
 
         .wifi-signal.good {
-            color: #fd7e14;
+            color: var(--bs-orange);
         }
 
         .wifi-signal.fair {
-            color: #dc3545;
+            color: var(--bs-danger);
         }
 
         .wifi-signal.poor {
-            color: #6c757d;
+            color: var(--fpp-text-muted);
         }
 
         /* Security Badge Styling */
@@ -92,37 +92,36 @@
         }
 
         .security-none {
-            background-color: #dc3545;
+            background-color: var(--bs-danger);
             color: white;
         }
 
         .security-wep {
-            background-color: #fd7e14;
+            background-color: var(--bs-orange);
             color: white;
         }
 
         .security-wpa {
-            background-color: #198754;
+            background-color: var(--bs-success);
             color: white;
         }
 
         .security-wpa2 {
-            background-color: #0d6efd;
+            background-color: var(--bs-blue);
             color: white;
         }
 
         .security-wpa3 {
-            background-color: #6f42c1;
+            background-color: var(--bs-purple);
             color: white;
         }
 
-        /* WiFi Network Row Hover Effects */
-        .wifi-network-row:hover {
-            background-color: #f5f5f5;
-        }
+        /* WiFi Network Row :hover/:active handled in fpp.css + fpp-dark.css */
 
-        .wifi-network-row:active {
-            background-color: #e9ecef;
+        .description-text {
+            font-size: 0.9em;
+            color: var(--fpp-text-muted);
+            margin-top: 5px;
         }
     </style>
 </head>
@@ -361,7 +360,7 @@
                     $('#global_gateway').next('.buttons').prop('disabled', true); // Disable ping button
                     $('#global_gateway').siblings('.btn-success').prop('disabled', true); // Disable update button
                     $('#globalGatewayRow .description-text').html(
-                        '<span style="color: #666;">Gateway disabled because all interfaces use DHCP. DHCP will provide default routing.</span>'
+                        '<span class="text-muted">Gateway disabled because all interfaces use DHCP. DHCP will provide default routing.</span>'
                     );
                 } else {
                     $('#global_gateway').prop('disabled', false);
@@ -576,13 +575,13 @@
                     $("#wifiNetworksList").html(networksHtml.join(''));
                     $("#wifiNetworksRow").show();
                 } else {
-                    $("#wifiNetworksList").html('<tr><td colspan="3" style="padding: 8px; text-align: center; color: #666;">No WiFi networks found</td></tr>');
+                    $("#wifiNetworksList").html('<tr><td colspan="3" class="p-2 text-center text-muted">No WiFi networks found</td></tr>');
                     $("#wifiNetworksRow").show();
                 }
 
             }).fail(function () {
                 DialogError("Scan Failed", "Failed to Scan for wifi networks");
-                $("#wifiNetworksList").html('<tr><td colspan="3" style="padding: 8px; text-align: center; color: #666;">Scan failed</td></tr>');
+                $("#wifiNetworksList").html('<tr><td colspan="3" class="p-2 text-center text-muted">Scan failed</td></tr>');
                 $("#wifiNetworksRow").show();
             }).always(function () {
                 $("#wifisearch").hide();
@@ -1391,7 +1390,7 @@
                 }
                 wifiTableBody.html(html);
             }).fail(function () {
-                wifiTableBody.html('<tr><td colspan="3" style="padding: 8px; text-align: center; color: #666;">Scan failed</td></tr>');
+                wifiTableBody.html('<tr><td colspan="3" class="p-2 text-center text-muted">Scan failed</td></tr>');
             });
         }
 
@@ -1708,9 +1707,9 @@
                                                     Scanning
                                                     for WiFi networks...</div>
                                                 <div id="wifiNetworksTable"
-                                                    style="max-height: 200px; overflow-y: auto; border: 1px solid #ddd; border-radius: 4px; margin-bottom: 10px;">
+                                                    style="max-height: 200px; overflow-y: auto; border: 1px solid var(--fpp-border); border-radius: 4px; margin-bottom: 10px;">
                                                     <table class="table table-sm table-hover" style="margin: 0;">
-                                                        <thead style="background-color: #f8f9fa;">
+                                                        <thead style="background-color: var(--bs-tertiary-bg);">
                                                             <tr>
                                                                 <th style="padding: 8px;">Network Name (SSID)</th>
                                                                 <th style="padding: 8px; width: 100px;">Signal</th>
@@ -2035,8 +2034,7 @@
                                                 value="Create Persistent Names" onClick="CreatePersistentNames();">
                                             <input id="btnConfigNetworkPersistClear" type="button" class="buttons"
                                                 value="Clear Persistent Names" onClick="ClearPersistentNames();">
-                                            <div class="description-text"
-                                                style="font-size: 0.9em; color: #666; margin-top: 5px;">
+                                            <div class="description-text">
                                                 Create or clear persistent network interface names to ensure consistent
                                                 interface naming across reboots.
                                             </div>
@@ -2085,8 +2083,7 @@
                                             onClick='PingIP($("#global_gateway").val(), 3);' value='Ping'>
                                         <input type="button" class="buttons btn-success" onClick='SaveGlobalGateway();'
                                             value='Update Gateway'>
-                                        <div class="description-text"
-                                            style="font-size: 0.9em; color: #666; margin-top: 5px;">
+                                        <div class="description-text">
                                             Global gateway for all interfaces. Leave blank if using DHCP on any
                                             interface for routing.
                                         </div>
@@ -2133,8 +2130,7 @@
                                     <div class="printSettingFieldCol col-md">
                                         <input type="button" class="buttons btn-success" onClick='SaveDNSConfig();'
                                             value='Update DNS'>
-                                        <div class="description-text"
-                                            style="font-size: 0.9em; color: #666; margin-top: 5px;">
+                                        <div class="description-text">
                                             Global DNS configuration for all interfaces. This is how FPP resolves
                                             hostnames back to IP addresses
                                         </div>

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -268,8 +268,8 @@
             }
 
             html += '</div>';
-            html += '<div class="col-lg-2 text-muted"><div class="labelHeading">Author:</div>' + data.author + '</div>';
-            html += '<div class="col-lg text-muted"><div class="labelHeading">Description:</div><div class="fppPluginEntryDescription">' + data.description + '</div>';
+            html += '<div class="col-lg-2"><div class="labelHeading text-secondary">Author:</div><div class="text-primary">' + data.author + '</div></div>';
+            html += '<div class="col-lg"><div class="labelHeading text-secondary">Description:</div><div class="text-primary">' + data.description + '</div>';
 
             html += '</div>';
             html += '<div class="col-lg-auto fppPluginEntryActions">';

--- a/www/scheduler.php
+++ b/www/scheduler.php
@@ -986,13 +986,9 @@ error_reporting(E_ALL);
 
         .items {
             width: 40%;
-            background: rgb#FFF;
+            background: var(--fpp-bg-card);
             float: right;
-            margin: 0, auto;
-        }
-
-        .selectedEntry {
-            background: #CCC;
+            margin: 0 auto;
         }
 
         .pl_title {
@@ -1003,11 +999,6 @@ error_reporting(E_ALL);
         h3 {
             padding: 0;
             margin: 0;
-        }
-
-        .tblheader {
-            background-color: #CCC;
-            text-align: center;
         }
 
         .dayMaskTable {


### PR DESCRIPTION
This is just like Phase 1 of X to improve tokenization and theming.

**This should have a negligible effect on Light Mode**, I tested what I could, but I do not have some pages (for example, matrix, specific hats) because every page has their own css styling.

My work will continue on individual pages to bring them into a standard to be themed.

This also STUBS out Dark Mode. Things will change, but it at least gets in tokenization.

I feel it's important to break this project up into multiple PRs so that decoupling individual pages becomes easier without having a MASSIVE conflict resolution on rebase.