### PR TITLE
MultiSync: honor secondsElapsed in media START packets

### DIFF
--- a/src/MultiSync.cpp
+++ b/src/MultiSync.cpp
@@ -2445,12 +2445,12 @@ void MultiSync::OpenSyncedMedia(const std::string& filename) {
     OpenMediaOutput(filename);
 }
 
-void MultiSync::StartSyncedMedia(const std::string& filename) {
-    LogDebug(VB_SYNC, "StartSyncedMedia(%s)\n", filename.c_str());
+void MultiSync::StartSyncedMedia(const std::string& filename, float secondsElapsed) {
+    LogDebug(VB_SYNC, "StartSyncedMedia(%s, %.2f)\n", filename.c_str(), secondsElapsed);
     for (auto a : m_plugins) {
         a->ReceivedMediaSyncStartPacket(filename);
     }
-    StartMediaOutput(filename);
+    StartMediaOutput(filename, secondsElapsed);
 }
 
 /*
@@ -2536,7 +2536,11 @@ void MultiSync::ProcessSyncPacket(ControlPkt* pkt, int len, MultiSyncStats* stat
             stats->pktSyncMedOpen++;
             break;
         case SYNC_PKT_START:
-            StartSyncedMedia(spkt->filename);
+            secondsElapsed = spkt->secondsElapsed - m_remoteOffset;
+            if (secondsElapsed < 0)
+                secondsElapsed = 0.0;
+
+            StartSyncedMedia(spkt->filename, secondsElapsed);
             stats->pktSyncMedStart++;
             break;
         case SYNC_PKT_STOP:

--- a/src/MultiSync.h
+++ b/src/MultiSync.h
@@ -292,7 +292,7 @@ public:
     void SyncSyncedSequence(const std::string& filename, int frameNumber, float secondsElapsed);
 
     void OpenSyncedMedia(const std::string& filename);
-    void StartSyncedMedia(const std::string& filename);
+    void StartSyncedMedia(const std::string& filename, float secondsElapsed = 0.0f);
     void StopSyncedMedia(const std::string& filename);
     void SyncSyncedMedia(const std::string& filename, int frameNumber, float secondsElapsed);
 

--- a/src/mediaoutput/mediaoutput.cpp
+++ b/src/mediaoutput/mediaoutput.cpp
@@ -371,7 +371,7 @@ bool MatchesRunningMediaFilename(const std::string& filename) {
     return false;
 }
 
-int StartMediaOutput(const std::string& filename) {
+int StartMediaOutput(const std::string& filename, float secondsElapsed) {
     if (!MatchesRunningMediaFilename(filename)) {
         CloseMediaOutput();
     }
@@ -390,7 +390,8 @@ int StartMediaOutput(const std::string& filename) {
         multiSync->SendMediaSyncStartPacket(mediaOutput->m_mediaFilename);
     }
 
-    if (!mediaOutput->Start()) {
+    int msTime = (secondsElapsed > 0.0f) ? (int)(secondsElapsed * 1000.0f) : 0;
+    if (!mediaOutput->Start(msTime)) {
         LogErr(VB_MEDIAOUT, "Could not start media %s\n", mediaOutput->m_mediaFilename.c_str());
         delete mediaOutput;
         mediaOutput = 0;
@@ -458,7 +459,7 @@ void UpdateMasterMediaPosition(const std::string& filename, float seconds) {
     } else {
         // with VLC, we can jump forward a bit and get close
         OpenMediaOutput(filename);
-        StartMediaOutput(filename);
+        StartMediaOutput(filename, seconds);
         masterMediaPosition = seconds;
         std::unique_lock<std::mutex> lock(mediaOutputLock);
         if (!mediaOutput) {

--- a/src/mediaoutput/mediaoutput.h
+++ b/src/mediaoutput/mediaoutput.h
@@ -25,7 +25,7 @@ void CleanupMediaOutput(void);
 
 bool MatchesRunningMediaFilename(const std::string& filename);
 int OpenMediaOutput(const std::string& filename);
-int StartMediaOutput(const std::string& filename);
+int StartMediaOutput(const std::string& filename, float secondsElapsed = 0.0f);
 void UpdateMasterMediaPosition(const std::string& filename, float seconds);
 void CloseMediaOutput();
 


### PR DESCRIPTION
Fixes #2626.

## Summary

Plumbs `secondsElapsed` from MultiSync's media `START` dispatch through `StartSyncedMedia` → `StartMediaOutput` → `mediaOutput->Start(msTime)`. The receive infrastructure (`VLCInternalData::startPos`, `seekableEventCallBack`, `SDLOutput::Start(int)`) already existed; only the plumbing from MultiSync was missing.

Also forwards the value in `UpdateMasterMediaPosition`'s file-change branch so a master switching to a different media file mid-playback gets the same correct seek-on-start treatment. `m_remoteOffset` is applied to mirror the existing handling in `SYNC_PKT_SYNC`.

4 files, +14 / -9. Source-compatible (default-valued parameter); no plugin headers affected.

## Test plan

- [x] Regression: play from beginning unchanged
- [x] Mid-video START on three 1080p H.264 files (24/30 fps, .mov/.mp4) — all start at the requested position with no visible jump
- [x] Drift correction continues to work after seek-on-start

Tested on Pi 4, Falcon Player image v2025-11 (FPP 9.5.2, libvlc 3.0.21), hardware decoding ON.