### PR TITLE
System-Upgrade.php tweaks - Tighten system upgrade page layout and improve advanced UI

### DIFF
--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -1321,6 +1321,58 @@
 	line-height: 1.5;
 }
 
+/* Collapsible wrapper for info-grid (advanced UI mode) */
+.fpp-info-collapsible {
+	margin-bottom: var(--fpp-sp-md);
+}
+
+.fpp-info-collapsible > .fpp-info-grid {
+	margin-bottom: 0;
+	margin-top: var(--fpp-sp-sm);
+}
+
+.fpp-info-collapsible__summary {
+	cursor: pointer;
+	padding: var(--fpp-sp-sm) var(--fpp-sp-md);
+	background: var(--fpp-bg-card);
+	border: 1px solid var(--fpp-border-light);
+	border-radius: var(--fpp-radius-lg);
+	font-size: var(--fpp-fs-sm);
+	font-weight: var(--fpp-fw-semibold);
+	color: var(--fpp-text-secondary);
+	list-style: none;
+	user-select: none;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	transition: all var(--fpp-transition-fast);
+}
+
+.fpp-info-collapsible__summary::-webkit-details-marker,
+.fpp-info-collapsible__summary::marker {
+	display: none;
+	content: '';
+}
+
+.fpp-info-collapsible__summary:hover {
+	border-color: var(--fpp-border-dark);
+	color: var(--fpp-text-primary);
+}
+
+.fpp-info-collapsible[open] > .fpp-info-collapsible__summary {
+	color: var(--fpp-primary);
+	border-color: var(--fpp-primary);
+}
+
+.fpp-info-collapsible__chevron {
+	font-size: var(--fpp-fs-xs);
+	transition: transform var(--fpp-transition-normal);
+}
+
+.fpp-info-collapsible[open] > .fpp-info-collapsible__summary .fpp-info-collapsible__chevron {
+	transform: rotate(180deg);
+}
+
 /* ==========================================================================
    BADGE COMPONENT
    Small status labels and tags

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -693,8 +693,8 @@
 .fpp-alert--compact {
 	display: flex;
 	align-items: center;
-	gap: 12px;
-	padding: 0.9375rem 1.25rem;
+	gap: 10px;
+	padding: 0.6rem 1rem;
 	font-size: 0.9rem;
 }
 
@@ -1089,8 +1089,8 @@
 .fpp-donate-banner {
 	background: linear-gradient(135deg, #495057 0%, #343a40 100%);
 	border-radius: var(--fpp-radius-lg);
-	padding: var(--fpp-sp-lg) var(--fpp-sp-xl);
-	margin-bottom: var(--fpp-sp-lg);
+	padding: var(--fpp-sp-md) var(--fpp-sp-xl);
+	margin-bottom: var(--fpp-sp-md);
 	text-align: center;
 	color: #fff;
 	border: 1px solid #495057;
@@ -1125,7 +1125,7 @@
 .fpp-donate-banner__text {
 	color: rgba(255, 255, 255, 0.85);
 	font-size: var(--fpp-fs-base);
-	margin: 0 0 var(--fpp-sp-md) 0;
+	margin: 0 0 var(--fpp-sp-sm) 0;
 	max-width: 550px;
 	margin-left: auto;
 	margin-right: auto;
@@ -1174,7 +1174,7 @@
 .fpp-donate-banner__footer {
 	color: rgba(255, 255, 255, 0.7);
 	font-size: var(--fpp-fs-sm);
-	margin-top: var(--fpp-sp-md);
+	margin-top: var(--fpp-sp-sm);
 	margin-bottom: 0;
 	font-style: italic;
 }
@@ -1190,10 +1190,10 @@
 .fpp-banner {
 	display: flex;
 	align-items: center;
-	gap: var(--fpp-sp-lg);
-	padding: var(--fpp-sp-lg) var(--fpp-sp-xl);
+	gap: var(--fpp-sp-md);
+	padding: var(--fpp-sp-sm) var(--fpp-sp-lg);
 	border-radius: var(--fpp-radius-lg);
-	margin-bottom: var(--fpp-sp-xl);
+	margin-bottom: var(--fpp-sp-md);
 }
 
 .fpp-banner--success {
@@ -1227,13 +1227,13 @@
 }
 
 .fpp-banner__icon {
-	width: 40px;
-	height: 40px;
+	width: 32px;
+	height: 32px;
 	border-radius: var(--fpp-radius-xl);
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 1.1rem;
+	font-size: 1rem;
 	flex-shrink: 0;
 	background: rgba(255, 255, 255, 0.2);
 }
@@ -1260,8 +1260,8 @@
 .fpp-info-grid {
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
-	gap: var(--fpp-sp-md);
-	margin-bottom: var(--fpp-sp-lg);
+	gap: var(--fpp-sp-sm);
+	margin-bottom: var(--fpp-sp-md);
 }
 
 @media (max-width: 640px) {
@@ -1271,7 +1271,7 @@
 }
 
 .fpp-info-box {
-	padding: var(--fpp-sp-lg);
+	padding: var(--fpp-sp-md);
 	border-radius: var(--fpp-radius-lg);
 	font-size: var(--fpp-fs-base);
 }
@@ -1291,7 +1291,7 @@
 	font-weight: var(--fpp-fw-bold);
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
-	margin-bottom: var(--fpp-sp-sm);
+	margin-bottom: var(--fpp-sp-xs);
 	display: flex;
 	align-items: center;
 	gap: 0.4rem;
@@ -1368,11 +1368,11 @@
 	display: flex;
 	align-items: center;
 	gap: var(--fpp-sp-md);
-	padding: var(--fpp-sp-md) var(--fpp-sp-lg);
+	padding: var(--fpp-sp-sm) var(--fpp-sp-md);
 	background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
 	border: 1px solid #86efac;
 	border-radius: var(--fpp-radius-lg);
-	margin-bottom: var(--fpp-sp-lg);
+	margin-bottom: var(--fpp-sp-md);
 	font-family: var(--fpp-font-mono);
 	font-size: var(--fpp-fs-base);
 }
@@ -1513,7 +1513,7 @@
 }
 
 .fpp-faq__question {
-	padding: var(--fpp-sp-md) var(--fpp-sp-lg);
+	padding: var(--fpp-sp-sm) var(--fpp-sp-md);
 	font-size: var(--fpp-fs-sm);
 	font-weight: var(--fpp-fw-semibold);
 	color: var(--fpp-text-secondary);
@@ -1552,7 +1552,7 @@
 }
 
 .fpp-faq__answer-inner {
-	padding: 0 var(--fpp-sp-lg) var(--fpp-sp-md) var(--fpp-sp-lg);
+	padding: 0 var(--fpp-sp-md) var(--fpp-sp-sm) var(--fpp-sp-md);
 	font-size: var(--fpp-fs-sm);
 	color: var(--fpp-text-muted);
 	line-height: 1.5;
@@ -1570,12 +1570,12 @@
 	width: 100%;
 	font-size: var(--fpp-fs-sm);
 	border-collapse: collapse;
-	margin: var(--fpp-sp-lg) 0;
+	margin: var(--fpp-sp-sm) 0;
 }
 
 .fpp-comparison-table th,
 .fpp-comparison-table td {
-	padding: 0.6rem var(--fpp-sp-sm);
+	padding: 0.4rem var(--fpp-sp-sm);
 	text-align: center;
 	border-bottom: 1px solid var(--fpp-border-light);
 }
@@ -1621,7 +1621,7 @@
 .fpp-comparison-note {
 	font-size: var(--fpp-fs-xs);
 	color: var(--fpp-text-muted);
-	margin-top: var(--fpp-sp-md);
+	margin-top: var(--fpp-sp-sm);
 	font-style: italic;
 }
 
@@ -1633,8 +1633,8 @@
 	border: 1px solid var(--fpp-border);
 	border-radius: var(--fpp-radius-lg);
 	box-shadow: var(--fpp-shadow-sm);
-	padding: var(--fpp-sp-xl);
-	margin-bottom: var(--fpp-sp-xl);
+	padding: var(--fpp-sp-md);
+	margin-bottom: var(--fpp-sp-md);
 	transition: all var(--fpp-transition-normal);
 }
 
@@ -1646,8 +1646,8 @@
 .fpp-card__header {
 	display: flex;
 	align-items: flex-start;
-	gap: var(--fpp-sp-lg);
-	margin-bottom: var(--fpp-sp-lg);
+	gap: var(--fpp-sp-md);
+	margin-bottom: var(--fpp-sp-md);
 }
 
 .fpp-card__header-status {
@@ -1668,13 +1668,13 @@
 }
 
 .fpp-card__icon {
-	width: 48px;
-	height: 48px;
+	width: 40px;
+	height: 40px;
 	border-radius: var(--fpp-radius-xl);
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 1.25rem;
+	font-size: 1.1rem;
 	flex-shrink: 0;
 	transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
@@ -1771,7 +1771,7 @@
 
 /* Compact card modifier - tighter spacing for secondary content */
 .fpp-card--compact {
-	padding: var(--fpp-sp-lg);
+	padding: var(--fpp-sp-md);
 	flex-direction: row;
 }
 
@@ -1937,11 +1937,11 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	padding: var(--fpp-sp-md) 0;
+	padding: var(--fpp-sp-sm) 0;
 	border-bottom: 1px solid var(--fpp-border-light);
 	font-size: var(--fpp-fs-base);
 	gap: var(--fpp-sp-md);
-	min-height: 48px;
+	min-height: 36px;
 }
 
 .fpp-row:last-child {
@@ -1993,7 +1993,7 @@
 	display: flex;
 	align-items: center;
 	gap: var(--fpp-sp-sm);
-	margin-bottom: var(--fpp-sp-lg);
+	margin-bottom: var(--fpp-sp-md);
 }
 
 .fpp-card__header-simple i {
@@ -2018,8 +2018,8 @@
 .fpp-info-section {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
-	gap: var(--fpp-sp-xl);
-	margin-bottom: var(--fpp-sp-2xl);
+	gap: var(--fpp-sp-md);
+	margin-bottom: var(--fpp-sp-md);
 }
 
 @media (max-width: 900px) {
@@ -2032,7 +2032,7 @@
 	background: var(--fpp-bg-card);
 	border: 1px solid var(--fpp-border);
 	border-radius: var(--fpp-radius-lg);
-	padding: var(--fpp-sp-xl);
+	padding: var(--fpp-sp-md);
 	box-shadow: var(--fpp-shadow-sm);
 }
 
@@ -2040,7 +2040,7 @@
 	font-size: var(--fpp-fs-lg);
 	font-weight: var(--fpp-fw-semibold);
 	color: var(--fpp-text-primary);
-	margin: 0 0 var(--fpp-sp-lg) 0;
+	margin: 0 0 var(--fpp-sp-md) 0;
 	display: flex;
 	align-items: center;
 	gap: var(--fpp-sp-sm);
@@ -2121,7 +2121,7 @@
 	gap: var(--fpp-sp-md);
 	flex-wrap: wrap;
 	margin-top: auto;
-	padding-top: var(--fpp-sp-lg);
+	padding-top: var(--fpp-sp-md);
 }
 
 .fpp-advanced-options {
@@ -2140,9 +2140,9 @@
 .fpp-checkbox-options {
 	display: flex;
 	flex-wrap: wrap;
-	gap: var(--fpp-sp-lg);
-	margin-top: var(--fpp-sp-md);
-	padding-top: var(--fpp-sp-md);
+	gap: var(--fpp-sp-md);
+	margin-top: var(--fpp-sp-sm);
+	padding-top: var(--fpp-sp-sm);
 	border-top: 1px solid var(--fpp-border-light);
 }
 
@@ -2185,11 +2185,11 @@
 
 /* Alert spacing modifiers */
 .fpp-alert--mb-lg {
-	margin-bottom: var(--fpp-sp-lg);
+	margin-bottom: var(--fpp-sp-md);
 }
 
 .fpp-alert--mb-md {
-	margin-bottom: var(--fpp-sp-md);
+	margin-bottom: var(--fpp-sp-sm);
 }
 
 /* ==========================================================================

--- a/www/system-upgrade.php
+++ b/www/system-upgrade.php
@@ -1098,6 +1098,12 @@
                                         <li>Experiencing OS issues</li>
                                         <li>Applying latest OS security patches</li>
                                     </ul>
+                                    <div class="fpp-alert fpp-alert--warning fpp-alert--compact"
+                                        style="margin-top: var(--fpp-sp-md); margin-bottom: var(--fpp-sp-sm);">
+                                        <i class="fas fa-exclamation-triangle"></i>
+                                        <span><strong>Warning:</strong> OS upgrade will reboot your system. Ensure no
+                                            shows are running.</span>
+                                    </div>
                                 </div>
                                 <div class="fpp-info-box fpp-info-box--info">
                                     <div class="fpp-info-box__title"><i class="fas fa-info-circle"></i> What it does
@@ -1111,13 +1117,6 @@
                                         Switching between 32-bit and 64-bit is not supported from this screen. To
                                         change architectures, flash a fresh image.</span>
                                 </div>
-                            </div>
-
-                            <!-- Warning alert -->
-                            <div class="fpp-alert fpp-alert--warning fpp-alert--compact fpp-alert--mb-lg">
-                                <i class="fas fa-exclamation-triangle"></i>
-                                <span><strong>Warning:</strong> OS upgrade will reboot your system. Ensure no shows are
-                                    running.</span>
                             </div>
 
                             <!-- Legacy OS warning (shown when checkbox is checked) -->

--- a/www/system-upgrade.php
+++ b/www/system-upgrade.php
@@ -899,32 +899,67 @@
                     </div>
                 </div>
 
-                <?php if (!isset($settings['cape-info']) || !isset($settings['cape-info']['verifiedKeyId']) || ($settings['cape-info']['verifiedKeyId'] != 'fp')) { ?>
-                    <div id="donateBanner" class="fpp-donate-banner">
-                        <h3 class="fpp-donate-banner__title">
-                            <i class="fas fa-heart"></i> Support FPP Development
+                <!-- Version Information -->
+                <div class="card fpp-card fpp-card--accent fpp-card--accent-neutral">
+                    <div class="fpp-card__header-simple">
+                        <h3>
+                            <i class="fas fa-info-circle"></i>
+                            Version Information
                         </h3>
-                        <p class="fpp-donate-banner__text">
-                            Help support the continued development of the Falcon Player. Your donation
-                            helps fund equipment, hosting, and countless hours of development.
-                        </p>
-                        <form action="https://www.paypal.com/donate" method="post" target="_top">
-                            <input type="hidden" name="hosted_button_id" value="ASF9XYZ2V2F5G" />
-                            <button type="submit" class="fpp-donate-btn" title="Donate to the Falcon Player">
-                                <svg class="paypal-logo" viewBox="0 0 24 24" width="17" height="17" fill="currentColor">
-                                    <path
-                                        d="M7.076 21.337H2.47a.641.641 0 0 1-.633-.74L4.944 3.72a.77.77 0 0 1 .757-.629h6.578c2.182 0 3.91.558 5.143 1.66 1.233 1.1 1.677 2.65 1.321 4.612-.042.236-.09.473-.152.707a7.092 7.092 0 0 1-.906 2.326c-.402.627-.905 1.16-1.5 1.586-.596.426-1.297.756-2.09.986-.792.23-1.666.345-2.604.345h-1.58a.95.95 0 0 0-.938.803l-.692 4.39-.394 2.5a.641.641 0 0 1-.633.531h-.278zm11.461-14.02c-.014.084-.03.168-.048.254-.593 3.044-2.623 4.095-5.215 4.095h-1.32a.641.641 0 0 0-.633.543l-.676 4.282-.383 2.43a.336.336 0 0 0 .332.39h2.333a.564.564 0 0 0 .557-.476l.023-.12.441-2.8.028-.154a.564.564 0 0 1 .557-.476h.35c2.268 0 4.042-.921 4.561-3.585.217-1.113.105-2.042-.47-2.695a2.238 2.238 0 0 0-.637-.488z" />
-                                </svg>
-                                Donate with PayPal
-                            </button>
-                            <img alt="" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1"
-                                style="display:none;" />
-                        </form>
-                        <p class="fpp-donate-banner__footer">
-                            <i class="fas fa-coffee"></i> It takes a lot of time, equipment, and coffee to power your shows!
-                        </p>
                     </div>
-                <?php } ?>
+                    <div class="row">
+                        <div class="col-md-4 fpp-col-divider">
+                            <div class="fpp-row">
+                                <span class="fpp-row__label">FPP Version:</span>
+                                <span class="fpp-row__value">
+                                    <span id="fppVersionStatusBadge"
+                                        class="badge text-bg-secondary">Checking...</span>
+                                    <span id="fppVersionValue"><?= $fppVersion ?></span>
+                                </span>
+                            </div>
+                            <div class="fpp-row">
+                                <span class="fpp-row__label">OS Version:</span>
+                                <span class="fpp-row__value">
+                                    <span id="osVersionStatusBadge" class="badge text-bg-success"
+                                        style="display: none;">Up to Date</span>
+                                    <span id="osVersionValue">--</span>
+                                </span>
+                            </div>
+
+                        </div>
+
+                        <div class="col-md-4 fpp-col-divider">
+                            <div class="fpp-row">
+                                <span class="fpp-row__label">OS Build:</span>
+                                <span class="fpp-row__value" id="osReleaseValue">--</span>
+                            </div>
+                            <div class="fpp-row">
+                                <span class="fpp-row__label">Platform:</span>
+                                <span class="fpp-row__value" id="platformValue">
+                                    <?php
+                                    echo $settings['Platform'];
+                                    if (($settings['Variant'] != '') && ($settings['Variant'] != $settings['Platform'])) {
+                                        echo " (" . $settings['Variant'] . ")";
+                                    }
+                                    ?>
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="col-md-4">
+                            <?php if (isset($serialNumber) && $serialNumber != "") { ?>
+                                <div class="fpp-row">
+                                    <span class="fpp-row__label">Serial Number:</span>
+                                    <span class="fpp-row__value"><?= $serialNumber ?></span>
+                                </div>
+                            <?php } ?>
+                            <div class="fpp-row">
+                                <span class="fpp-row__label">Kernel:</span>
+                                <span class="fpp-row__value" id="kernelValue">--</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
                 <!-- Upgrade Options -->
                 <div class="row">
@@ -1207,67 +1242,32 @@
                         </button>
                     </div>
 
-                    <!-- Version Information -->
-                    <div class="card fpp-card fpp-card--accent fpp-card--accent-neutral">
-                        <div class="fpp-card__header-simple">
-                            <h3>
-                                <i class="fas fa-info-circle"></i>
-                                Version Information
-                                <span class="badge text-bg-secondary">Advanced</span>
-                            </h3>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-4 fpp-col-divider">
-                                <div class="fpp-row">
-                                    <span class="fpp-row__label">FPP Version:</span>
-                                    <span class="fpp-row__value">
-                                        <span id="fppVersionStatusBadge"
-                                            class="badge text-bg-secondary">Checking...</span>
-                                        <span id="fppVersionValue"><?= $fppVersion ?></span>
-                                    </span>
-                                </div>
-                                <div class="fpp-row">
-                                    <span class="fpp-row__label">OS Version:</span>
-                                    <span class="fpp-row__value">
-                                        <span id="osVersionStatusBadge" class="badge text-bg-success"
-                                            style="display: none;">Up to Date</span>
-                                        <span id="osVersionValue">--</span>
-                                    </span>
-                                </div>
+                <?php } ?>
 
-                            </div>
-
-                            <div class="col-md-4 fpp-col-divider">
-                                <div class="fpp-row">
-                                    <span class="fpp-row__label">OS Build:</span>
-                                    <span class="fpp-row__value" id="osReleaseValue">--</span>
-                                </div>
-                                <div class="fpp-row">
-                                    <span class="fpp-row__label">Platform:</span>
-                                    <span class="fpp-row__value" id="platformValue">
-                                        <?php
-                                        echo $settings['Platform'];
-                                        if (($settings['Variant'] != '') && ($settings['Variant'] != $settings['Platform'])) {
-                                            echo " (" . $settings['Variant'] . ")";
-                                        }
-                                        ?>
-                                    </span>
-                                </div>
-                            </div>
-
-                            <div class="col-md-4">
-                                <?php if (isset($serialNumber) && $serialNumber != "") { ?>
-                                    <div class="fpp-row">
-                                        <span class="fpp-row__label">Serial Number:</span>
-                                        <span class="fpp-row__value"><?= $serialNumber ?></span>
-                                    </div>
-                                <?php } ?>
-                                <div class="fpp-row">
-                                    <span class="fpp-row__label">Kernel:</span>
-                                    <span class="fpp-row__value" id="kernelValue">--</span>
-                                </div>
-                            </div>
-                        </div>
+                <?php if (!isset($settings['cape-info']) || !isset($settings['cape-info']['verifiedKeyId']) || ($settings['cape-info']['verifiedKeyId'] != 'fp')) { ?>
+                    <div id="donateBanner" class="fpp-donate-banner">
+                        <h3 class="fpp-donate-banner__title">
+                            <i class="fas fa-heart"></i> Support FPP Development
+                        </h3>
+                        <p class="fpp-donate-banner__text">
+                            Help support the continued development of the Falcon Player. Your donation
+                            helps fund equipment, hosting, and countless hours of development.
+                        </p>
+                        <form action="https://www.paypal.com/donate" method="post" target="_top">
+                            <input type="hidden" name="hosted_button_id" value="ASF9XYZ2V2F5G" />
+                            <button type="submit" class="fpp-donate-btn" title="Donate to the Falcon Player">
+                                <svg class="paypal-logo" viewBox="0 0 24 24" width="17" height="17" fill="currentColor">
+                                    <path
+                                        d="M7.076 21.337H2.47a.641.641 0 0 1-.633-.74L4.944 3.72a.77.77 0 0 1 .757-.629h6.578c2.182 0 3.91.558 5.143 1.66 1.233 1.1 1.677 2.65 1.321 4.612-.042.236-.09.473-.152.707a7.092 7.092 0 0 1-.906 2.326c-.402.627-.905 1.16-1.5 1.586-.596.426-1.297.756-2.09.986-.792.23-1.666.345-2.604.345h-1.58a.95.95 0 0 0-.938.803l-.692 4.39-.394 2.5a.641.641 0 0 1-.633.531h-.278zm11.461-14.02c-.014.084-.03.168-.048.254-.593 3.044-2.623 4.095-5.215 4.095h-1.32a.641.641 0 0 0-.633.543l-.676 4.282-.383 2.43a.336.336 0 0 0 .332.39h2.333a.564.564 0 0 0 .557-.476l.023-.12.441-2.8.028-.154a.564.564 0 0 1 .557-.476h.35c2.268 0 4.042-.921 4.561-3.585.217-1.113.105-2.042-.47-2.695a2.238 2.238 0 0 0-.637-.488z" />
+                                </svg>
+                                Donate with PayPal
+                            </button>
+                            <img alt="" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1"
+                                style="display:none;" />
+                        </form>
+                        <p class="fpp-donate-banner__footer">
+                            <i class="fas fa-coffee"></i> It takes a lot of time, equipment, and coffee to power your shows!
+                        </p>
                     </div>
                 <?php } ?>
 

--- a/www/system-upgrade.php
+++ b/www/system-upgrade.php
@@ -695,10 +695,33 @@
 
             ShowLoadingModal('osReleaseNotesModal', 'OS Release Notes: ' + osVersion);
 
+            // Nightly builds don't have published GitHub releases
+            if (/nightly/i.test(osVersion)) {
+                var html = '<div class="fpp-alert fpp-alert--warning" style="display: block;">';
+                html += '<div><i class="fas fa-info-circle"></i> <strong>Nightly builds do not have published release notes.</strong></div>';
+                html += '<div class="mt-3">Nightly builds track the latest development changes and are rebuilt automatically. To see what\'s changed, browse recent commits or releases on GitHub.</div>';
+                html += '<div class="mt-3">';
+                html += '<a href="https://github.com/FalconChristmas/fpp/commits/master" target="_blank" class="fpp-btn fpp-btn--outline">';
+                html += '<i class="fas fa-external-link-alt"></i> View Recent Commits on GitHub';
+                html += '</a>';
+                html += '</div>';
+                html += '</div>';
+                $('#osReleaseNotesModal .modal-body').html(html);
+                return;
+            }
+
             // Extract version tag from OS filename (e.g., BBB-9.3_2025-11.fppos -> 9.3)
             var versionMatch = osVersion.match(/(v?\d+\.\d+(?:\.\d+)?(?:-[a-z]+\d*)?)/i);
             if (!versionMatch) {
-                $('#osReleaseNotesModal .modal-body').html('<div class=\"alert alert-warning\">Could not determine version number from selected OS.</div>');
+                var html = '<div class="fpp-alert fpp-alert--warning" style="display: block;">';
+                html += '<div><i class="fas fa-info-circle"></i> <strong>Could not determine version number from selected OS.</strong></div>';
+                html += '<div class="mt-3">';
+                html += '<a href="https://github.com/FalconChristmas/fpp/releases" target="_blank" class="fpp-btn fpp-btn--outline">';
+                html += '<i class="fas fa-external-link-alt"></i> Browse All Releases on GitHub';
+                html += '</a>';
+                html += '</div>';
+                html += '</div>';
+                $('#osReleaseNotesModal .modal-body').html(html);
                 return;
             }
 

--- a/www/system-upgrade.php
+++ b/www/system-upgrade.php
@@ -948,6 +948,12 @@
                                 </div>
                             </div>
 
+                            <?php $advancedInfoCollapse = isset($settings['uiLevel']) && $settings['uiLevel'] >= 1; ?>
+                            <?php if ($advancedInfoCollapse) { ?><details class="fpp-info-collapsible">
+                                <summary class="fpp-info-collapsible__summary">
+                                    <span><i class="fas fa-info-circle"></i> When to use &amp; What it does</span>
+                                    <i class="fas fa-chevron-down fpp-info-collapsible__chevron"></i>
+                                </summary><?php } ?>
                             <div class="fpp-info-grid">
                                 <div class="fpp-info-box fpp-info-box--neutral">
                                     <div class="fpp-info-box__title"><i class="fas fa-question-circle"></i> When to use
@@ -965,6 +971,7 @@
                                         takes 2-5 minutes. Reboots are not usually required.</p>
                                 </div>
                             </div>
+                            <?php if ($advancedInfoCollapse) { ?></details><?php } ?>
 
                             <!-- Standard View Version Indicators (uiLevel 0 - Basic) -->
                             <div id="fppVersionStandard" class="fpp-version-standard-wrapper">
@@ -1088,6 +1095,11 @@
                                 </div>
                             </div>
 
+                            <?php if ($advancedInfoCollapse) { ?><details class="fpp-info-collapsible">
+                                <summary class="fpp-info-collapsible__summary">
+                                    <span><i class="fas fa-info-circle"></i> When to use &amp; What it does</span>
+                                    <i class="fas fa-chevron-down fpp-info-collapsible__chevron"></i>
+                                </summary><?php } ?>
                             <div class="fpp-info-grid">
                                 <div class="fpp-info-box fpp-info-box--neutral">
                                     <div class="fpp-info-box__title"><i class="fas fa-question-circle"></i> When to use
@@ -1118,6 +1130,7 @@
                                         change architectures, flash a fresh image.</span>
                                 </div>
                             </div>
+                            <?php if ($advancedInfoCollapse) { ?></details><?php } ?>
 
                             <!-- Legacy OS warning (shown when checkbox is checked) -->
                             <div id="legacyOSWarning"


### PR DESCRIPTION
- Tighten padding/margins on cards, banners, and info boxes for a more compact vertical layout on the system upgrade page; move the OS reboot warning into the "When to use" box
- Collapse the "When to use / What it does" info grids into <details> elements when uiLevel >= 1 to reduce clutter for advanced users (basic UI still shows them expanded inline)
- Move the Version Information card out of the Advanced section so it's always visible at the top of the page, and reposition the donate banner below the upgrade options
- Fix release notes modal styling and handle nightly builds correctly
