### PR TITLE
FPP_Install.sh - Implement seamless migration to systemd-networkd, plus failsafe tweaks

### DIFF
--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -726,9 +726,10 @@ install_base_packages() {
             # generic display-manager alias cover the desktop-DM cases we
             # might encounter when --img is run on a desktop install. The
             # legacy gdm/wdm/xdm names are gone from supported releases.
-            systemctl disable gdm3
-            systemctl disable lightdm
-            systemctl disable display-manager.service
+			# Check if exists before disabling using cat
+			systemctl cat gdm3 >/dev/null 2>&1 && systemctl disable gdm3
+			systemctl cat lightdm >/dev/null 2>&1 && systemctl disable lightdm
+			systemctl cat display-manager.service >/dev/null 2>&1 && systemctl disable display-manager.service
             
             echo "FPP - Disabling dhcp-helper and hostapd from automatically starting"
             systemctl disable dhcp-helper

--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -509,8 +509,11 @@ install_base_packages() {
         if $skip_apt_install; then
             PACKAGE_REMOVE=""
         fi
-
-		apt-get install curl -y
+		
+		# Install base packages
+		echo "FPP - Installing SSH and Curl"
+		apt-get update
+		apt-get install openssh-server curl -y
         
         # Seamlessly migrate to systemd-networkd without dropping connectivity
         if [ "x${PACKAGE_REMOVE}" != "x" ]; then

--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -510,17 +510,74 @@ install_base_packages() {
             PACKAGE_REMOVE=""
         fi
         
+        # Seamlessly migrate to systemd-networkd without dropping connectivity
         if [ "x${PACKAGE_REMOVE}" != "x" ]; then
             # Need to make sure there is configuration for eth0 or uninstalling dhcpclient will cause network to drop
+            echo "FPP - Detecting active network manager"
+
+            USE_NM=0
+
+            if systemctl list-unit-files | grep -q '^NetworkManager.service'; then
+                if systemctl is-active --quiet NetworkManager; then
+                    USE_NM=1
+                fi
+            fi
+
+            # Ensure networkd config exists BEFORE switching anything
             rm -f /etc/systemd/network/50-default.network
-            curl -o /etc/systemd/network/50-default.network https://raw.githubusercontent.com/FalconChristmas/fpp/master/etc/systemd/network/50-default.network
-            
+
+            curl -fsSL \
+                -o /etc/systemd/network/50-default.network \
+                https://raw.githubusercontent.com/FalconChristmas/fpp/master/etc/systemd/network/50-default.network
+
+            # Install required packages first
+            apt-get update
             apt-get install -y systemd-resolved
-            systemctl reload systemd-networkd
+
+            # Unmask + enable services
+            systemctl unmask systemd-networkd || true
+            systemctl unmask systemd-resolved || true
+
+            systemctl enable systemd-networkd
+            systemctl enable systemd-resolved
+
+            # If NetworkManager is active, migrate cleanly
+            if [ "$USE_NM" = "1" ]; then
+                echo "FPP - NetworkManager detected, migrating to systemd-networkd"
+
+                # Start networkd while NM still owns the interface
+                systemctl start systemd-networkd
+                systemctl start systemd-resolved
+
+                echo "FPP - Waiting for networkd startup"
+                sleep 5
+
+                # Gracefully release interfaces from NM
+                if command -v nmcli >/dev/null 2>&1; then
+                    nmcli networking off || true
+                fi
+
+                # Stop/disable NM
+                systemctl stop NetworkManager || true
+                systemctl disable NetworkManager || true
+
+                echo "FPP - Restarting networkd after migration"
+                systemctl restart systemd-networkd
+                systemctl restart systemd-resolved
+
+                echo "FPP - Waiting for network stabilization"
+                sleep 5
+
+            else
+                echo "FPP - NetworkManager not active, ensuring networkd is running"
+
+                systemctl restart systemd-networkd
+                systemctl restart systemd-resolved
+
+                sleep 3
+            fi
+
             apt-get remove -y --purge --autoremove --allow-change-held-packages ${PACKAGE_REMOVE}
-            
-            systemctl unmask systemd-networkd
-            systemctl unmask systemd-resolved
 
             systemctl restart systemd-networkd
             systemctl restart systemd-resolved

--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -509,6 +509,8 @@ install_base_packages() {
         if $skip_apt_install; then
             PACKAGE_REMOVE=""
         fi
+
+		apt-get install curl -y
         
         # Seamlessly migrate to systemd-networkd without dropping connectivity
         if [ "x${PACKAGE_REMOVE}" != "x" ]; then

--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -75,6 +75,7 @@ FPPHOME=/home/${FPPUSER}
 OSVER="UNKNOWN"
 FPPSCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FPPSCRIPTNAME="$(basename "${BASH_SOURCE[0]}")"
+FPPSCRIPTLOG=${FPPSCRIPTNAME%.sh}.log
 
 # Make sure the sbin directories are on the path as we will
 # need the adduser/addgroup/ldconfig/a2enmod/etc... commands
@@ -342,7 +343,7 @@ echo "OS Version       : ${OSVER}"
 echo "OS ID            : ${OSID}"
 echo "Image            : ${isimage}"
 echo "Install Script   : $FPPSCRIPTDIR/$FPPSCRIPTNAME"
-echo "Install Log      : $FPPSCRIPTDIR/${FPPSCRIPTNAME%.sh}.log"
+echo "Install Log      : $FPPSCRIPTDIR/$FPPSCRIPTLOG"
 echo "============================================================"
 #############################################################################
 
@@ -378,8 +379,8 @@ STARTTIME=$(date)
 
 #######################################
 # Log output and notify user
-echo "ALL output will be copied to ${FPPSCRIPTNAME%.sh}.log"
-exec > >(tee -a "${FPPSCRIPTNAME%.sh}.log")
+echo "ALL output will be copied to ${FPPSCRIPTLOG}"
+exec > >(tee -a "${FPPSCRIPTLOG}")
 exec 2>&1
 echo "========================================================================"
 echo "${FPPSCRIPTNAME} started at ${STARTTIME}"
@@ -1939,5 +1940,6 @@ EOF
 generate_apache_csp
 print_install_complete
 
-cp "$FPPSCRIPTDIR/${FPPSCRIPTNAME%.sh}".* "${FPPHOME}/"
+cp "${FPPSCRIPTDIR}/${FPPSCRIPTNAME%.sh}".* "${FPPHOME}/"
 chown fpp:fpp "${FPPHOME}/${FPPSCRIPTNAME%.sh}".*
+cp "${FPPSCRIPTDIR}/${FPPSCRIPTLOG}" "/var/log/${FPPSCRIPTLOG}"

--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -73,6 +73,8 @@ FPPDIR=/opt/fpp
 FPPUSER=fpp
 FPPHOME=/home/${FPPUSER}
 OSVER="UNKNOWN"
+FPPSCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FPPSCRIPTNAME="$(basename "${BASH_SOURCE[0]}")"
 
 # Make sure the sbin directories are on the path as we will
 # need the adduser/addgroup/ldconfig/a2enmod/etc... commands
@@ -339,6 +341,8 @@ echo "Platform         : ${FPPPLATFORM}"
 echo "OS Version       : ${OSVER}"
 echo "OS ID            : ${OSID}"
 echo "Image            : ${isimage}"
+echo "Install Script   : $FPPSCRIPTDIR/$FPPSCRIPTNAME"
+echo "Install Log      : $FPPSCRIPTDIR/${FPPSCRIPTNAME%.sh}.log"
 echo "============================================================"
 #############################################################################
 
@@ -374,11 +378,11 @@ STARTTIME=$(date)
 
 #######################################
 # Log output and notify user
-echo "ALL output will be copied to FPP_Install.log"
-exec > >(tee -a FPP_Install.log)
+echo "ALL output will be copied to ${FPPSCRIPTNAME%.sh}.log"
+exec > >(tee -a "${FPPSCRIPTNAME%.sh}.log")
 exec 2>&1
 echo "========================================================================"
-echo "FPP_Install.sh started at ${STARTTIME}"
+echo "${FPPSCRIPTNAME} started at ${STARTTIME}"
 echo "------------------------------------------------------------------------"
 
 #######################################
@@ -1935,5 +1939,5 @@ EOF
 generate_apache_csp
 print_install_complete
 
-cp /root/FPP_Install.* ${FPPHOME}/
-chown fpp:fpp ${FPPHOME}/FPP_Install.*
+cp "$FPPSCRIPTDIR/${FPPSCRIPTNAME%.sh}".* "${FPPHOME}/"
+chown fpp:fpp "${FPPHOME}/${FPPSCRIPTNAME%.sh}".*


### PR DESCRIPTION
To fix issues with FPP_Install.sh:
Added logic to seamlessly migrate from NetworkManager to systemd-networkd without dropping connectivity. Enhanced network configuration handling and ensured required packages are installed.

When installing on a base version of Debian 13 Trixie using the "--img" flag, the install fails as systemd-networkd is disabled by default and NetworkManager is in use. These changes will fix this by examining which service is in use, and cleanly migrating to systemd-networkd if necessary without losing connection. Previously, the script would call commands to systemd-networkd with no regards to whether or not that was the running network daemon. If it was not, the script would fail. This is a clean fix to move everything to systemd-networkd if NetworkManager is in use.

Also added checks when disabling display managers to check if the display managers are installed before attempting to disable - preventing errors from base installs where no GUI is present.

Also ensures curl is installed before executing curl commands as it is not packaged with base Debian 13 and makes sure that ssh is installed. With these changes, the script will now install on the most minimal install of Debian 13 with the --img flag.

And last but not least, a tweak to capture the install script name and install script directory. Previously, the script made references to /root/FPP_Install.sh which would leave an error if not installed from that directory. You can now install the script from any directory or rename the script and it will still install.