### PR TITLE
Update FPP_Install to correct time URL

### DIFF
--- a/LICENSE.exception
+++ b/LICENSE.exception
@@ -1,4 +1,4 @@
-Copyright (C) 2013-2024 Falcon Player (FPP) developers
+Copyright (C) 2013-2026 Falcon Player (FPP) developers
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the

--- a/LICENSE.exception
+++ b/LICENSE.exception
@@ -1,4 +1,4 @@
-Copyright (C) 2013-2026 Falcon Player (FPP) developers
+Copyright (C) 2013-2024 Falcon Player (FPP) developers
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the

--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -156,7 +156,7 @@ checkTimeAgainstUSNO () {
 
 		# allow clocks to differ by 24 hours to handle time zone differences
 		THRESHOLD=86400
-        USNODATE=$(curl -I --connect-timeout 10 --max-time 10 --retry 2 --retry-max-time 10 -f -v --silent https://nist.time.gov/ 2>&1 \ | grep '< Date' | sed -e 's/< Date: //')
+        USNODATE=$(curl -I --connect-timeout 10 --max-time 10 --retry 2 --retry-max-time 10 -f -v --silent https://time.gov/ 2>&1 \ | grep '< Date' | sed -e 's/< Date: //')
         if  [ "x${USNODATE}" != "x" ]
         then
         USNOSECS=$(date -d "${USNODATE}" +%s)

--- a/SD/README.Debian
+++ b/SD/README.Debian
@@ -79,11 +79,10 @@ Useful flags
 Thermal note (low-power SBCs)
 -----------------------------
 
-The compile (especially VLC if you opt into building it) pegs all CPU cores
-near 100% for a long time. Headless SBCs without a heatsink/fan can hit
-thermal-shutdown in the middle of the install -- recovery means starting
-over from a fresh image. If you're hitting thermals, lock the CPU lower
-before starting:
+The compile pegs all CPU cores near 100% for a long time. Headless SBCs
+without a heatsink/fan can hit thermal-shutdown in the middle of the
+install -- recovery means starting over from a fresh image. If you're
+hitting thermals, lock the CPU lower before starting:
 
     cpufreq-set -u 800000   # lock to 800 MHz max
 


### PR DESCRIPTION
Corrected time URL in FPP_Install.sh
nist.time.gov throws a TLS error everytime resulting the script to always announce incorrect result.
time.gov is the working, corrected URL.

Revised thermal note in README.debian to remove VLC references

Update copyright year in LICENSE.exception