### PR TITLE
Update command to check for 64-bit architectures

### DIFF
--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -592,7 +592,7 @@ install_base_packages() {
             sleep 5
         fi
         
-		echo "FPP - Removing anything left that wasn't explicity removed"
+		echo "FPP - Removing anything left that wasn't explicitly removed"
 		apt-get -y --purge autoremove
 
 		echo "FPP - Updating package list"
@@ -683,7 +683,7 @@ install_base_packages() {
         PACKAGE_LIST="$PACKAGE_LIST ntpsec pipewire"
         
         if $skip_apt_install; then
-            echo "skipping apt install because skpt_apt_install == $skip_apt_install"
+            echo "skipping apt install because skip_apt_install == $skip_apt_install"
             PACKAGE_LIST=""
         else
             echo "--------------------------"

--- a/www/troubleshoot-commands.json
+++ b/www/troubleshoot-commands.json
@@ -440,14 +440,6 @@
                         "all"
                     ]
                 },
-                "Image32-64": {
-                    "title": "FPP Image 32/64-bit",
-                    "description": "",
-                    "cmd": "dpkg --print-architecture | grep -qE \"amd64|arm64\" && echo \"64-bit FPP\" || echo \"32-bit FPP\"",
-                    "platforms": [
-                        "all"
-                    ]
-                },
                 "ImagePlatform": {
                     "title": "FPP Image Platform",
                     "description": "",

--- a/www/troubleshoot-commands.json
+++ b/www/troubleshoot-commands.json
@@ -443,7 +443,7 @@
                 "Image32-64": {
                     "title": "FPP Image 32/64-bit",
                     "description": "",
-                    "cmd": "dpkg --print-architecture | grep -q arm64 && echo \"64-bit FPP\" || echo \"32-bit FPP\"",
+                    "cmd": "dpkg --print-architecture | grep -qE \"amd64|arm64\" && echo \"64-bit FPP\" || echo \"32-bit FPP\"",
                     "platforms": [
                         "all"
                     ]


### PR DESCRIPTION
This minor change fixes the troubleshooting command for architecture when installed on an OS using the FPP script.
It now checks for amd64 or arm64 instead of just arm64.
Previously, the troubleshooting command would report 32-bit when ran on 64-bit systems

Plus a couple typo fixes in FPP_Install