### PR TITLE
Fix: Add dynamic page title to system upgrade page

### DIFF
--- a/www/system-upgrade.php
+++ b/www/system-upgrade.php
@@ -10,6 +10,7 @@
     include 'common/menuHead.inc';
     ?>
     <link rel="stylesheet" href="css/fpp-system-design.css?ref=<?php echo filemtime('css/fpp-system-design.css'); ?>">
+    <title><? echo $pageTitle; ?></title>
     <?php
     $fppVersion = getFPPVersion();
     $localGitVersion = get_local_git_version();


### PR DESCRIPTION
<title><? echo $pageTitle; ?></title> is missing from html head, causing the page to show the URL in the titlebar. This fix makes the system-upgrade.php page consistent with the titles of every other page.