### PR TITLE
Fix GPIO Input bias settings

### DIFF
--- a/src/util/GPIOUtils.cpp
+++ b/src/util/GPIOUtils.cpp
@@ -181,10 +181,13 @@ int GPIODCapabilities::configPin(const std::string& mode,
             settings.set_direction(gpiod::line::direction::INPUT);
             if (mode == "gpio_pu") {
                 settings.set_bias(gpiod::line::bias::PULL_UP);
+                lastBias = gpiod::line::bias::PULL_UP;
             } else if (mode == "gpio_pd") {
                 settings.set_bias(gpiod::line::bias::PULL_DOWN);
+                lastBias = gpiod::line::bias::PULL_DOWN;
             } else {
                 settings.set_bias(gpiod::line::bias::DISABLED);
+                lastBias = gpiod::line::bias::DISABLED;
             }
         }
 
@@ -352,6 +355,9 @@ int GPIODCapabilities::requestEventFile(bool risingEdge, bool fallingEdge) const
         } else if (fallingEdge) {
             settings.set_edge_detection(gpiod::line::edge::FALLING);
         }
+        if (lastBias != gpiod::line::bias::UNKNOWN) {
+            settings.set_bias(lastBias);
+        }
         std::string consumer = lastDesc.empty() ? PROCESS_NAME : lastDesc;
 
         LogDebug(VB_GPIO, "Building request for pin %s: chip device=%s, line=%d\n",
@@ -376,6 +382,9 @@ int GPIODCapabilities::requestEventFile(bool risingEdge, bool fallingEdge) const
         try {
             gpiod::line_settings settings;
             settings.set_direction(gpiod::line::direction::INPUT);
+            if (lastBias != gpiod::line::bias::UNKNOWN) {
+                settings.set_bias(lastBias);
+            }
             std::string consumer = lastDesc.empty() ? PROCESS_NAME : lastDesc;
             gpiod::request_builder builder = chip->prepare_request();
             builder.add_line_settings(gpio, settings);
@@ -392,6 +401,7 @@ int GPIODCapabilities::requestEventFile(bool risingEdge, bool fallingEdge) const
     gpiod::line_request req;
     req.consumer = lastDesc.empty() ? PROCESS_NAME : lastDesc;
     req.request_type = lastRequestType;
+    req.flags = lastRequestFlags;
     if (risingEdge && fallingEdge) {
         req.request_type |= gpiod::line_request::EVENT_BOTH_EDGES;
     } else if (risingEdge) {

--- a/src/util/GPIOUtils.h
+++ b/src/util/GPIOUtils.h
@@ -165,6 +165,7 @@ public:
 #ifdef IS_GPIOD_CXX_V2
     mutable std::shared_ptr<gpiod::chip> chip = nullptr;
     mutable std::shared_ptr<gpiod::line_request> request = nullptr;
+    mutable gpiod::line::bias lastBias = gpiod::line::bias::UNKNOWN;
 #else
     mutable gpiod::chip* chip = nullptr;
     mutable gpiod::line line;


### PR DESCRIPTION
## Fix: GPIO input bias (pull-up/pull-down) settings lost when requesting edge events (Issue #2680)

### Problem

When configuring a GPIO pin as an input trigger (e.g., a push button), the user can select a pull-up or pull-down mode in the FPP UI. However, the internal pull resistor is never actually enabled, making push button inputs unreliable (floating pins).

### Root Cause

The GPIO setup flow is:

1. `SetupGPIOInput()` calls `configPin(mode, false, "GPIO Input")` — this correctly applies the bias (pull-up/pull-down/disabled) to the GPIO line
2. Then `addState()` calls `requestEventFile()` — this calls `releaseGPIOD()` which **destroys the previous line request** (including the bias setting), then creates a **new** line request with only direction + edge detection

The new request never re-applies the bias. This affects both the libgpiod v2 API path and the v1 API path.

The same bug also exists in the polling fallback path (when the GPIO chip doesn't support edge detection) and in the OLED input configuration.

### Changes

**`src/util/GPIOUtils.h`**
- Added `mutable gpiod::line::bias lastBias = gpiod::line::bias::UNKNOWN` member to `GPIODCapabilities` (v2 API path only) to track the configured bias across request re-creation

**`src/util/GPIOUtils.cpp`**
- **`configPin()` v2 path**: Store the bias value in `lastBias` alongside each `set_bias()` call
- **`requestEventFile()` v2 event path**: Restore bias via `settings.set_bias(lastBias)` when `lastBias != UNKNOWN` before creating the edge-detection request
- **`requestEventFile()` v2 polling fallback**: Same restore in the catch block when edge detection isn't supported
- **`requestEventFile()` v1 path**: Add `req.flags = lastRequestFlags` — the bias flags were already stored in the existing `lastRequestFlags` member but never copied into the new request

### Verification

- All changed files compile cleanly with no warnings
- The pattern follows existing conventions (`lastDesc`, `lastRequestType`, `lastRequestFlags` are all mutable members that survive `releaseGPIOD()` for exactly this purpose)
- `lastBias` defaults to `UNKNOWN` — no bias is applied unless `configPin()` was previously called with input direction, so output pins and unconfigured pins are unaffected
- `releaseGPIOD()` intentionally does not clear `lastBias` — mirrors how `lastDesc` is saved/restored around the call in `requestEventFile()`
- Non-`GPIODCapabilities` pin types (PiFace, MCP23x17, etc.) are unaffected as they don't override `requestEventFile()`

### Additional Comments

The theory that "P1-36" should be "P0-36" is a misunderstanding. "P1" in "P1-36" refers to Header P1 (the main 40-pin GPIO header on the Raspberry Pi), not gpiochip1. This naming convention has been used since the original Pi.

The code at src/util/PiGPIOUtils.cpp:212-242 hardcodes these as e.g. PiGPIODCapabilities("P1-36", 16). The actual gpiochip used is determined at runtime by getPinctrlRpiChip() (PiGPIOUtils.cpp:151), which correctly finds the pinctrl-bcm2711 chip (gpiochip0 on the Pi 4).

This PR Closes #2680