### PR TITLE
Fix: WLAN password eye icon not toggling in multi-interface network config

### DIFF
--- a/www/networkconfig.php
+++ b/www/networkconfig.php
@@ -1037,6 +1037,17 @@
                     contentDiv.find('[for="' + oldId + '"]').attr('for', newId);
                 });
 
+                // Fix HideShow icon IDs and onclick handlers for suffixed interface IDs
+                contentDiv.find('[id$="HideShow_' + safeName + '"]').each(function() {
+                    var $icon = $(this);
+                    var oldId = $icon.attr('id');
+                    var inputBase = oldId.replace('HideShow_' + safeName, '');
+                    var inputId = inputBase + '_' + safeName;
+                    // Rename icon ID to match TogglePasswordHideShow's expected pattern: inputId + 'HideShow'
+                    $icon.attr('id', inputId + 'HideShow');
+                    this.onclick = function() { TogglePasswordHideShow(inputId); };
+                });
+
                 // Update wireless visibility for this interface
                 if (visible) {
                     contentDiv.find('#WirelessSubsection_' + safeName).show();


### PR DESCRIPTION
## Fix: WLAN password eye icon not toggling in multi-interface network config (Issue #2681)

### Problem
When configuring WLAN on the Network Settings page, clicking the eye icon to show/hide the WiFi password did nothing on interfaces loaded from the config template (e.g., `wlan0`, `wlp2s0`).

### Root Cause
The interface configuration is rendered from a hidden template (`#interfaceConfigTemplate`) that gets cloned for each interface. A general ID-rewriting loop appends `_<safeName>` to all element IDs (e.g., `eth_psk` → `eth_psk_wlan0`), but the inline `onclick` attributes on the eye icons were never updated — they continued referencing the original unsuffixed IDs. Additionally, the icon's ID after rewriting (`eth_pskHideShow_wlan0`) did not match the pattern `inputId + 'HideShow'` that `TogglePasswordHideShow()` expects.

### Fix
After the ID-rewriting loop in `loadInterfaceConfiguration()`, a new fixup step renames each eye icon's ID to follow the pattern `inputId + 'HideShow'` and sets its `onclick` to call `TogglePasswordHideShow()` with the correct suffixed input ID — matching the same pattern used by the tethering tab and all other settings pages.

**File changed:** `www/networkconfig.php` (lines 1040–1049)

```javascript
contentDiv.find('[id$="HideShow_' + safeName + '"]').each(function() {
    var $icon = $(this);
    var oldId = $icon.attr('id');
    var inputBase = oldId.replace('HideShow_' + safeName, '');
    var inputId = inputBase + '_' + safeName;
    $icon.attr('id', inputId + 'HideShow');
    this.onclick = function() { TogglePasswordHideShow(inputId); };
});
```

### Additional Comments

This PR Closes #2681.