### PR TITLE
Add (advanced) option to enable Pi 5 Fan Header in Settings>System

### DIFF
--- a/scripts/handle_boot_actions
+++ b/scripts/handle_boot_actions
@@ -21,6 +21,8 @@ function HandleSettings()
         ApplySetting("ForceHDMIResolutionPort2", $settings["ForceHDMIResolutionPort2"]);
     if (array_key_exists("GPIOFan", $settings))
         ApplySetting("GPIOFan", $settings["GPIOFan"]);
+    if (array_key_exists("Pi5Fan", $settings))
+        ApplySetting("Pi5Fan", $settings["Pi5Fan"]);
     if (array_key_exists("Kiosk", $settings))
         ApplySetting("Kiosk", $settings["Kiosk"]);
     if (array_key_exists("EnableBBBHDMI", $settings))

--- a/www/common/settings.php
+++ b/www/common/settings.php
@@ -283,6 +283,65 @@ function SetGPIOFanProperties()
     }
 }
 
+function SetPi5FanProperties()
+{
+    global $settings;
+
+    if (strpos($settings['SubPlatform'], "Raspberry Pi 5") === false &&
+        strpos($settings['SubPlatform'], "Raspberry Pi Compute Module 5") === false) {
+        return;
+    }
+
+    $fanOn = ReadSettingFromFile('Pi5Fan');
+    $fanTemp = ReadSettingFromFile('Pi5FanTemperature');
+    $fanSpeed = ReadSettingFromFile('Pi5FanSpeed');
+    $fanHysteresis = ReadSettingFromFile('Pi5FanHysteresis');
+
+    if ($fanTemp == '') { $fanTemp = '50'; }
+    if ($fanSpeed == '') { $fanSpeed = '255'; }
+    if ($fanHysteresis == '') { $fanHysteresis = '10'; }
+
+    $pfx = "";
+    if ($fanOn == '0') {
+        $pfx = "#";
+    }
+
+    $tempMilli = $fanTemp * 1000;
+    $hystMilli = $fanHysteresis * 1000;
+
+    $lines = [
+        "dtparam=cooling_fan=on",
+        "dtparam=fan_temp0=" . $tempMilli,
+        "dtparam=fan_temp0_speed=" . $fanSpeed,
+        "dtparam=fan_temp0_hyst=" . $hystMilli
+    ];
+
+    $bootDir = GetDirSetting('boot');
+    $configFile = $bootDir . "/config.txt";
+
+    $contents = file_get_contents($configFile);
+    $hasCoolingFan = (strpos($contents, "dtparam=cooling_fan") !== false);
+    $hasTempLines = (strpos($contents, "dtparam=fan_temp") !== false);
+
+    if (!$hasCoolingFan && !$hasTempLines) {
+        if ($pfx == "") {
+            exec("echo \"\" | sudo tee -a " . $configFile);
+            exec("echo \"[all]\" | sudo tee -a " . $configFile);
+            foreach ($lines as $line) {
+                exec("echo \"" . $line . "\" | sudo tee -a " . $configFile);
+            }
+            exec("echo \"\" | sudo tee -a " . $configFile);
+        }
+    } else {
+        foreach ($lines as $line) {
+            $escapedLine = str_replace('/', '\/', $line);
+            $sedFile = escapeshellarg($configFile);
+            exec("sudo sed -i -e 's/^dtparam=" . $escapedLine . "$/" . $pfx . $escapedLine . "/g' " . $sedFile, $output, $return_val);
+            exec("sudo sed -i -e 's/^#" . $escapedLine . "$/" . $pfx . $escapedLine . "/g' " . $sedFile, $output, $return_val);
+        }
+    }
+}
+
 function SetupLocalMQTTBroker($value)
 {
     global $settings;
@@ -394,6 +453,12 @@ function ApplySetting($setting, $value)
         case 'GPIOFanTemperature':
         case 'GPIOFan':
             SetGPIOFanProperties();
+            break;
+        case 'Pi5FanTemperature':
+        case 'Pi5FanSpeed':
+        case 'Pi5FanHysteresis':
+        case 'Pi5Fan':
+            SetPi5FanProperties();
             break;
         case 'screensaver':
             SetupScreenBlanking($value);

--- a/www/settings.json
+++ b/www/settings.json
@@ -318,6 +318,10 @@
 			"settings": [
 				"GPIOFan",
 				"GPIOFanTemperature",
+				"Pi5Fan",
+				"Pi5FanTemperature",
+				"Pi5FanSpeed",
+				"Pi5FanHysteresis",
 				"LEDDisplayType",
 				"bootDelay",
 				"FPP_UUID"
@@ -1648,6 +1652,95 @@
 			"default": 70,
 			"min": 30,
 			"max": 85,
+			"step": 1,
+			"suffix": " C"
+		},
+		"Pi5Fan": {
+			"name": "Pi5Fan",
+			"description": "Pi 5 Fan Header",
+			"gatherStats": true,
+			"tip": "Enable the Raspberry Pi 5's dedicated fan header (JST connector). Uses onboard PWM fan control via dtparam=cooling_fan.",
+			"level": 1,
+			"reboot": 1,
+			"platforms": [
+				"Raspberry Pi"
+			],
+			"variants": {
+				"Raspberry Pi": [
+					"Pi 5"
+				]
+			},
+			"children": {
+				"1": [
+					"Pi5FanTemperature",
+					"Pi5FanSpeed",
+					"Pi5FanHysteresis"
+				]
+			},
+			"type": "checkbox"
+		},
+		"Pi5FanTemperature": {
+			"name": "Pi5FanTemperature",
+			"description": "    Fan Temp Target",
+			"gatherStats": true,
+			"tip": "Temperature at which the fan will reach full speed.",
+			"level": 1,
+			"reboot": 1,
+			"platforms": [
+				"Raspberry Pi"
+			],
+			"variants": {
+				"Raspberry Pi": [
+					"Pi 5"
+				]
+			},
+			"type": "number",
+			"default": 50,
+			"min": 30,
+			"max": 85,
+			"step": 1,
+			"suffix": " C"
+		},
+		"Pi5FanSpeed": {
+			"name": "Pi5FanSpeed",
+			"description": "    Fan Speed",
+			"gatherStats": true,
+			"tip": "Fan speed at the target temperature. 0-255, 255 = 100%.",
+			"level": 1,
+			"reboot": 1,
+			"platforms": [
+				"Raspberry Pi"
+			],
+			"variants": {
+				"Raspberry Pi": [
+					"Pi 5"
+				]
+			},
+			"type": "number",
+			"default": 255,
+			"min": 0,
+			"max": 255,
+			"step": 1
+		},
+		"Pi5FanHysteresis": {
+			"name": "Pi5FanHysteresis",
+			"description": "    Fan Hysteresis",
+			"gatherStats": true,
+			"tip": "Temperature hysteresis in degrees C. The fan will turn off when the temperature drops this far below the target.",
+			"level": 1,
+			"reboot": 1,
+			"platforms": [
+				"Raspberry Pi"
+			],
+			"variants": {
+				"Raspberry Pi": [
+					"Pi 5"
+				]
+			},
+			"type": "number",
+			"default": 10,
+			"min": 1,
+			"max": 30,
 			"step": 1,
 			"suffix": " C"
 		},


### PR DESCRIPTION
## Add Raspberry Pi 5 Dedicated Fan Header Support

The Raspberry Pi 5 has a dedicated 4-pin JST fan connector controlled via `dtparam=cooling_fan=on` in `config.txt`, which is separate from the existing GPIO 14 fan overlay (`dtoverlay=gpio-fan`). This PR adds native Pi 5 fan control to FPP's settings UI so users don't need to manually edit `/boot/firmware/config.txt`.

### Changes

**`www/settings.json`**
- Added 4 new settings in the System tab: `Pi5Fan` (checkbox), `Pi5FanTemperature` (number), `Pi5FanSpeed` (number), `Pi5FanHysteresis` (number)
- All settings use `"variants": {"Raspberry Pi": ["Pi 5"]}` so they only appear on Pi 5 hardware
- Temperature/speed/hysteresis are child settings shown only when Pi5Fan is enabled

**`www/common/settings.php`**
- Added `SetPi5FanProperties()` function that writes/removes the following lines to `/boot/firmware/config.txt`:
  - `dtparam=cooling_fan=on`
  - `dtparam=fan_temp0=<temp_millidegrees>`
  - `dtparam=fan_temp0_speed=<speed_0_255>`
  - `dtparam=fan_temp0_hyst=<hysteresis_millidegrees>`
- Has a Pi 5 hardware guard (reads `/proc/device-tree/model`)
- When disabled, lines are commented out with `#` prefix (matching existing GPIO fan pattern)
- Added dispatch cases in `ApplySetting()` for all 4 settings

**`scripts/handle_boot_actions`**
- Added `Pi5Fan` boot-time application alongside the existing `GPIOFan`

### UI Preview

In Settings → System on Pi 5, users will see:

```
[ ] Pi 5 Fan Header
    Fan Temp Target: [50] C
    Fan Speed:       [255]
    Fan Hysteresis:  [10] C
```

UI level must be set to Advanced or higher.

### Backward Compatibility

- Existing GPIO 14 fan control (`GPIOFan` / `GPIOFanTemperature`) is completely unchanged
- Pi 5 fan uses a different mechanism (`dtparam` vs `dtoverlay`) — no conflict
- Settings default to disabled — opt-in only
- All new settings require a reboot to take effect (`"reboot": 1`)
- Code follows the exact same patterns as the existing `SetGPIOFanProperties()` function

### Additional Comments

This PR Closes #2670.