### PR TITLE
Fix Health Check Stats: Monotonic uptime & consistent memory display

### DIFF
--- a/www/system-stats.php
+++ b/www/system-stats.php
@@ -328,8 +328,8 @@ if (isset($_GET['cpu'])) {
                 }
 
                 // Uptime
-                if (data.uptimeTotalSeconds) {
-                    uptimeSeconds = parseInt(data.uptimeTotalSeconds);
+                if (data.systemUptimeTotalSeconds) {
+                    uptimeSeconds = parseInt(data.systemUptimeTotalSeconds);
                     updateUptimeDisplay();
                     if (!uptimeInterval) {
                         uptimeInterval = setInterval(updateUptimeDisplay, 1000);
@@ -716,7 +716,7 @@ if (isset($_GET['cpu'])) {
                                             </circle>
                                         </svg>
                                         <div class="fpp-gauge__value" id="memValue">
-                                            <?php printf('%.0f', $memTotalUsage); ?>%
+                                            <?php printf('%.0f', $memUsage); ?>%
                                             <span
                                                 class="fpp-gauge__total"><?php echo formatMemBytes($memTotal); ?></span>
                                         </div>
@@ -792,7 +792,7 @@ if (isset($_GET['cpu'])) {
                     <div class="col-md-4">
                         <div class="card compact-card">
                             <div class="card-header">
-                                <h3><i class="fas fa-clock"></i> FPP Uptime</h3>
+                                <h3><i class="fas fa-clock"></i> System Uptime</h3>
                             </div>
                             <div class="card-body uptime-display">
                                 <div class="uptime-counters">


### PR DESCRIPTION
## Fix Health Check Stats: Monotonic uptime & consistent memory display

**File changed:** `www/system-stats.php`

### Changes

#### 1. Use monotonic system uptime instead of wall-clock fppd uptime (line 331)

The "FPP Uptime" gauge was reading `data.uptimeTotalSeconds`, which comes from fppd's C++ code as `time(nullptr) - startupTime`. On systems without a hardware RTC (BeagleBone, Raspberry Pi), the wall clock is often incorrect at boot and later corrected by NTP. When NTP jumps the clock forward, `startupTime` was captured pre-NTP but `time(nullptr)` returns the corrected time, producing a wildly inflated uptime value.

**Fix:** Switched to `data.systemUptimeTotalSeconds`, which comes from `sysinfo().uptime` on Linux (a monotonic clock unaffected by NTP corrections). Relabeled the card header from "FPP Uptime" to "System Uptime" to match. This PR Closes #2690.

#### 2. Consistent memory usage in center gauge text (line 719)

The memory gauge had an inconsistency:
- The gauge arc (green fill) used `$memUsage` = `usage_percent` = `used / total * 100` — excludes buffer/cache
- The center text used `$memTotalUsage` = `total_used_percent` = `(used + buffer_cache) / total * 100` — includes buffer/cache

This caused the displayed number to be higher than what `top` reports and disagreed with the gauge's own visual representation.

**Fix:** Changed the center text to use `$memUsage`, matching the gauge arc and aligning with system monitoring conventions. This PR Closes #2691.