### PR TITLE
Refactor uptime interval function to increment seconds

### DIFF
--- a/www/system-stats.php
+++ b/www/system-stats.php
@@ -261,7 +261,6 @@ if (isset($_GET['cpu'])) {
         }
 
         function updateUptimeDisplay() {
-            uptimeSeconds++;
             var days = Math.floor(uptimeSeconds / 86400);
             var hours = Math.floor((uptimeSeconds % 86400) / 3600);
             var minutes = Math.floor((uptimeSeconds % 3600) / 60);
@@ -332,7 +331,7 @@ if (isset($_GET['cpu'])) {
                     uptimeSeconds = parseInt(data.systemUptimeTotalSeconds);
                     updateUptimeDisplay();
                     if (!uptimeInterval) {
-                        uptimeInterval = setInterval(updateUptimeDisplay, 1000);
+                        uptimeInterval = setInterval(function () { uptimeSeconds++; updateUptimeDisplay(); }, 1000);
                     }
                 }
 


### PR DESCRIPTION
## Fix Health Check Uptime Tick Drift

**File changed:** `www/system-stats.php`

### Problem

The Health & Status uptime counter ran ~20% fast (6 ticks per 5 real seconds). The `updateUptimeDisplay()` function had a side effect (`uptimeSeconds++`) and was called from two places:

1. A `setInterval` every 1 second
2. `updateStats()` every 5 seconds after re-setting `uptimeSeconds` from the server

Each `updateStats()` call added an extra increment on top of the normal interval ticks. While the server-side correction every 5 seconds kept the drift bounded, it caused the display to jump back by roughly 1 second on every refresh cycle, and over longer periods the counter would transiently show values ahead of the real uptime.

### Fix

1. **Removed the `uptimeSeconds++` side effect from `updateUptimeDisplay()`** — it now only reads and renders the current value.

2. **Moved the increment into the interval callback exclusively** — the `setInterval` wrapper now does the tick before calling `updateUptimeDisplay()`.

This ensures the counter increments exactly once per second and never drifts from the server-synced value.

### Additional Comments

This PR, along with PR #2692, closes #2619.