### PR TITLE
Fix active parent menu

### DIFF
--- a/www/about.php
+++ b/www/about.php
@@ -921,7 +921,7 @@
 <body>
     <div id="bodyWrapper">
         <?php
-        $activeParentMenuItem = 'status';
+        $activeParentMenuItem = 'help';
         include 'menu.inc';
         ?>
         <div class="mainContainer">

--- a/www/system-stats.php
+++ b/www/system-stats.php
@@ -574,7 +574,7 @@ if (isset($_GET['cpu'])) {
 <body>
     <div id="bodyWrapper">
         <?php
-        $activeParentMenuItem = 'status';
+        $activeParentMenuItem = 'help';
         include 'menu.inc';
         ?>
         <div class="mainContainer">


### PR DESCRIPTION
This PR is a minor UI fix for the active menu icon on the "System Upgrade" and "System Health Check" page.

Issue: Go to Help > System Upgrade or Help > System Health Check
Currently, the active parent menu for both those pages is set to the Status / Control menu, so the Status / Control menu stays lit up with a badge underneath it when we should be showing that the active menu is the Help menu.