### PR TITLE
Add fan monitoring to system-stats.php (if fan is detected)

### DIFF
--- a/src/sensors/Sensors.cpp
+++ b/src/sensors/Sensors.cpp
@@ -375,7 +375,38 @@ public:
             if (i > 0) {
                 buffer[i] = 0;
                 d = std::atof(buffer);
-                d /= 1000; // 12 bit a2d
+                d /= 1000;
+            }
+            return d;
+        }
+
+        return 0.0;
+    }
+
+    volatile int file;
+    std::string path;
+};
+
+class FanSensor : public Sensor {
+public:
+    explicit FanSensor(Json::Value& s) :
+        Sensor(s),
+        path(s["path"].asString()) {
+        file = open(path.c_str(), O_RDONLY);
+    }
+    virtual ~FanSensor() {
+        if (file != -1) close(file);
+    }
+
+    virtual double getValue() override {
+        if (file != -1) {
+            lseek(file, 0, SEEK_SET);
+            char buffer[20];
+            int i = read(file, buffer, 20);
+            double d = 0;
+            if (i > 0) {
+                buffer[i] = 0;
+                d = std::atof(buffer);
             }
             return d;
         }
@@ -510,6 +541,45 @@ void Sensors::DetectHWSensors() {
         sensors.push_back(new ThermalSensor(v));
         i++;
         snprintf(path, sizeof(path), "/sys/class/thermal/thermal_zone%d/temp", i);
+    }
+    DetectFanSensors();
+}
+void Sensors::DetectFanSensors() {
+    for (int h = 0; h < 32; h++) {
+        char hwmonPath[256];
+        snprintf(hwmonPath, sizeof(hwmonPath), "/sys/class/hwmon/hwmon%d", h);
+        if (!DirectoryExists(hwmonPath)) {
+            break;
+        }
+
+        char namePath[256];
+        snprintf(namePath, sizeof(namePath), "%s/name", hwmonPath);
+        std::string deviceName = "hwmon" + std::to_string(h);
+        if (FileExists(namePath)) {
+            int f = open(namePath, O_RDONLY);
+            if (f != -1) {
+                char buf[64] = {0};
+                int r = read(f, buf, 63);
+                if (r > 0) {
+                    if (buf[r - 1] == '\n') buf[r - 1] = 0;
+                    deviceName = buf;
+                }
+                close(f);
+            }
+        }
+
+        for (int fan = 1; fan <= 8; fan++) {
+            char fanPath[256];
+            snprintf(fanPath, sizeof(fanPath), "%s/fan%d_input", hwmonPath, fan);
+            if (FileExists(fanPath)) {
+                Json::Value v;
+                v["path"] = fanPath;
+                v["valueType"] = "FanSpeed";
+                v["label"] = deviceName + " Fan " + std::to_string(fan) + ": ";
+                v["postfix"] = " RPM";
+                sensors.push_back(new FanSensor(v));
+            }
+        }
     }
 }
 void Sensors::Close() {

--- a/src/sensors/Sensors.h
+++ b/src/sensors/Sensors.h
@@ -47,6 +47,7 @@ public:
     void Close();
 
     void DetectHWSensors();
+    void DetectFanSensors();
     void addSensors(Json::Value& config);
     void reportSensors(Json::Value& root);
 

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -2413,3 +2413,32 @@
 		font-size: var(--fpp-fs-xl);
 	}
 }
+
+/* Fan Monitoring */
+.fan-data-container {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--fpp-sp-md);
+}
+
+.fan-entry {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: var(--fpp-sp-sm) var(--fpp-sp-md);
+	background: var(--fpp-surface-secondary);
+	border-radius: var(--fpp-radius-sm);
+	min-width: 200px;
+	flex: 1 1 auto;
+}
+
+.fan-label {
+	font-size: var(--fpp-fs-sm);
+	color: var(--fpp-text-secondary);
+}
+
+.fan-value {
+	font-size: var(--fpp-fs-lg);
+	font-weight: var(--fpp-fw-bold);
+	color: var(--fpp-text-primary);
+}

--- a/www/system-stats.php
+++ b/www/system-stats.php
@@ -315,8 +315,9 @@ if (isset($_GET['cpu'])) {
             updateCpuGauge();
             $.get('api/system/status', function (data) {
                 // Temperature
-                if (data.sensors && data.sensors.length > 0) {
-                    var temp = parseFloat(data.sensors[0].value);
+                var tempSensor = data.sensors && data.sensors.find(function (s) { return s.valueType === 'Temperature'; });
+                if (tempSensor) {
+                    var temp = parseFloat(tempSensor.value);
                     <?php if (isset($settings['temperatureInF']) && $settings['temperatureInF'] == 1) { ?>
                         temp = (temp * 9 / 5) + 32;
                         // Fahrenheit thresholds: 140°F (60°C), 176°F (80°C), max 212°F (100°C)
@@ -325,6 +326,9 @@ if (isset($_GET['cpu'])) {
                         // Celsius thresholds: 60°C, 80°C, max 100°C
                         updateGauge('tempGauge', temp, { yellow: 60, red: 80, max: 100, unit: '°C' });
                     <?php } ?>
+                }
+                if (data.sensors) {
+                    updateFanData(data.sensors);
                 }
 
                 // Uptime
@@ -499,6 +503,24 @@ if (isset($_GET['cpu'])) {
             }
             statusEl.innerHTML = '<i class="fas ' + icon + ' ' + cls + '"></i> ' + text;
             statusEl.className = 'busyness-status ' + cls;
+        }
+
+        function updateFanData(sensors) {
+            var fans = sensors.filter(function (s) { return s.valueType === 'FanSpeed'; });
+            if (fans.length === 0) {
+                $('#fan-monitoring-row').hide();
+                return;
+            }
+            $('#fan-monitoring-row').show();
+            var html = '';
+            fans.forEach(function (fan) {
+                var rpm = parseFloat(fan.value).toFixed(0);
+                html += '<div class="fan-entry">' +
+                    '<span class="fan-label">' + fan.label + '</span>' +
+                    '<span class="fan-value">' + rpm + ' RPM</span>' +
+                    '</div>';
+            });
+            $('#fan-data').html(html);
         }
 
         function updatePlayerStats() {
@@ -752,6 +774,20 @@ if (isset($_GET['cpu'])) {
                                 <div class="fpp-gauge__label" id="tempLabel">CPU Temperature
                                     (<?php echo (isset($settings['temperatureInF']) && $settings['temperatureInF'] == 1) ? '°F' : '°C'; ?>)
                                 </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Fan Monitoring -->
+                <div class="row" id="fan-monitoring-row" style="display: none;">
+                    <div class="col-12">
+                        <div class="card compact-card">
+                            <div class="card-header">
+                                <h3><i class="fa-solid fa-fan"></i> Fan Monitoring</h3>
+                            </div>
+                            <div class="card-body">
+                                <div id="fan-data" class="fan-data-container"></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Add Fan Monitoring to System Health Page

### Summary

Adds automatic detection and display of attached cooling fan speeds on the Health and Status page. Fan sensors are discovered from the standard Linux hwmon sysfs interface (`/sys/class/hwmon/hwmon*/fan*_input`) and reported alongside existing temperature sensors via the system status API.

### Changes

**C++ — `src/sensors/Sensors.cpp`:**
- New `FanSensor` class that reads fan RPM from `fan*_input` sysfs files, following the same low-level I/O pattern as the existing `ThermalSensor` (O_RDONLY, lseek, read)
- New `DetectFanSensors()` method that iterates `/sys/class/hwmon/hwmonN/` devices, reads each device's `name` for a human-readable label, and creates a `FanSensor` for each `fan*_input` file found
- `DetectHWSensors()` now calls `DetectFanSensors()` at the end of thermal zone detection

**C++ — `src/sensors/Sensors.h`:**
- Added `DetectFanSensors()` public method declaration

**Web UI — `www/system-stats.php`:**
- Temperature gauge now finds the first sensor with `valueType === "Temperature"` via `Array.find()` instead of blindly reading `sensors[0]`, making it robust against other sensor types in the array
- New `updateFanData()` JavaScript function that filters sensors by `valueType === "FanSpeed"` and renders each fan's label and RPM value
- Fan monitoring card with fa-fan icon, hidden by default and shown only when fan sensors are detected

**CSS — `www/css/fpp-system-design.css`:**
- Added `.fan-data-container`, `.fan-entry`, `.fan-label`, `.fan-value` styles using existing design tokens

### Behavior

- Fan detection is always enabled and requires no configuration
- If no fans are present, the fan monitoring section is hidden and no new sensors appear in the API
- Fan RPM is reported through the existing `api/system/status` sensor API alongside temperature sensors
- The temperature gauge is unaffected — it explicitly looks for `Temperature`-typed sensors
- Works with any Linux hwmon-compatible fan controller (Pi 5 Active Cooler, PWM fan HATs with tachometer, etc.)
- Simple GPIO on/off fans without RPM feedback are correctly ignored (no `fan*_input` file exists)

### Additional Comments

This will show fan speeds on the system-stats page. This will work with all different types of fans. If a fan is not detected, there will be no fan monitoring appearing on the stats page.

This PR is to solve Issue #2571. On merge, please mark Fix Applied - Testing Required as I have limited hardware for testing this.