### PR TITLE
Bugfix: Filter out fan speed sensors from sensor updates

### DIFF
--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -5162,47 +5162,45 @@ var firstStatusLoad = 1;
 function updateSensorStatus () {
 	jsonStatus = lastStatusJSON;
 	if (jsonStatus.hasOwnProperty('sensors')) {
+		var tempSensors = jsonStatus.sensors.filter(function(s) {
+			return s.valueType === 'Temperature';
+		});
 		var sensorText = "<table id='sensorTable'>";
 		var outPos = 0;
 		var sensorType = '';
-		if (jsonStatus.sensors.length > 0) {
-			sensorType = jsonStatus.sensors[0].valueType;
+		if (tempSensors.length > 0) {
+			sensorType = tempSensors[0].valueType;
 		}
-		for (var i = 0; i < jsonStatus.sensors.length; i++) {
+		for (var i = 0; i < tempSensors.length; i++) {
 			if (
-				jsonStatus.sensors[i].valueType != sensorType &&
-				jsonStatus.sensors.length > 3 &&
+				tempSensors[i].valueType != sensorType &&
+				tempSensors.length > 3 &&
 				outPos % 2 == 1
 			) {
 				sensorText += '</tr>';
 				outPos++;
 			}
-			sensorType = jsonStatus.sensors[i].valueType;
-			if (jsonStatus.sensors.length < 4 || outPos % 2 == 0) {
+			sensorType = tempSensors[i].valueType;
+			if (tempSensors.length < 4 || outPos % 2 == 0) {
 				sensorText += '<tr>';
 			}
 			sensorText += '<td>';
-			sensorText += jsonStatus.sensors[i].label;
+			sensorText += tempSensors[i].label;
 			sensorText += '</td><td style="padding-right: 15px;"';
-			if (jsonStatus.sensors[i].valueType == 'Temperature') {
-				sensorText += " onclick='changeTemperatureUnit()'>";
-				var val = jsonStatus.sensors[i].value;
-				if (temperatureUnit) {
-					val *= 1.8;
-					val += 32;
-					sensorText += val.toFixed(1);
-					sensorText += 'F';
-				} else {
-					sensorText += val.toFixed(1);
-					sensorText += 'C';
-				}
+			sensorText += " onclick='changeTemperatureUnit()'>";
+			var val = tempSensors[i].value;
+			if (temperatureUnit) {
+				val *= 1.8;
+				val += 32;
+				sensorText += val.toFixed(1);
+				sensorText += 'F';
 			} else {
-				sensorText += '>';
-				sensorText += jsonStatus.sensors[i].formatted;
+				sensorText += val.toFixed(1);
+				sensorText += 'C';
 			}
 			sensorText += '</td>';
 
-			if (jsonStatus.sensors.length > 4 && outPos % 2 == 1) {
+			if (tempSensors.length > 4 && outPos % 2 == 1) {
 				sensorText += '<tr>';
 			}
 			outPos++;
@@ -9417,23 +9415,30 @@ function RefreshHeaderBar () {
 	}
 
 	if (data.sensors != undefined) {
+		var tempSensors = data.sensors.filter(function(s) {
+			return s.valueType === 'Temperature';
+		});
 		var sensors = [];
 		var tooltip = '';
+		// Tooltip shows all sensors (temperature + fans)
 		data.sensors.forEach(function (e) {
-			var icon = 'bolt';
-			var val = e.formatted;
-			if (e.valueType == 'Temperature') {
-				icon = 'thermometer-half';
-				// Use the same global variable as the main sensor display
-				if (typeof temperatureUnit !== 'undefined' && temperatureUnit) {
-					val = val * 1.8 + 32;
-					val = parseFloat(val).toFixed(2);
-					val += '&deg;F';
-				} else {
-					val += '&deg;C';
-				}
+			var tv = e.formatted;
+			if (e.valueType === 'Temperature' && typeof temperatureUnit !== 'undefined' && temperatureUnit) {
+				tv = (parseFloat(e.value) * 1.8 + 32).toFixed(2) + '&deg;F';
 			}
-			tooltip += '<b>' + e.label + '</b>' + val + '<br/>';
+			tooltip += '<b>' + e.label + '</b>' + tv + '<br/>';
+		});
+		// Header shows only temperature sensors
+		tempSensors.forEach(function (e) {
+			var icon = 'thermometer-half';
+			var val = e.formatted;
+			if (typeof temperatureUnit !== 'undefined' && temperatureUnit) {
+				val = val * 1.8 + 32;
+				val = parseFloat(val).toFixed(2);
+				val += '&deg;F';
+			} else {
+				val += '&deg;C';
+			}
 			row =
 				'<span class="sensorSpan hiddenSensor" onclick="RotateHeaderSensor(' +
 				(sensors.length + 1) +

--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -5162,45 +5162,50 @@ var firstStatusLoad = 1;
 function updateSensorStatus () {
 	jsonStatus = lastStatusJSON;
 	if (jsonStatus.hasOwnProperty('sensors')) {
-		var tempSensors = jsonStatus.sensors.filter(function(s) {
-			return s.valueType === 'Temperature';
+		var nonFanSensors = jsonStatus.sensors.filter(function(s) {
+			return s.valueType !== 'FanSpeed';
 		});
 		var sensorText = "<table id='sensorTable'>";
 		var outPos = 0;
 		var sensorType = '';
-		if (tempSensors.length > 0) {
-			sensorType = tempSensors[0].valueType;
+		if (nonFanSensors.length > 0) {
+			sensorType = nonFanSensors[0].valueType;
 		}
-		for (var i = 0; i < tempSensors.length; i++) {
+		for (var i = 0; i < nonFanSensors.length; i++) {
 			if (
-				tempSensors[i].valueType != sensorType &&
-				tempSensors.length > 3 &&
+				nonFanSensors[i].valueType != sensorType &&
+				nonFanSensors.length > 3 &&
 				outPos % 2 == 1
 			) {
 				sensorText += '</tr>';
 				outPos++;
 			}
-			sensorType = tempSensors[i].valueType;
-			if (tempSensors.length < 4 || outPos % 2 == 0) {
+			sensorType = nonFanSensors[i].valueType;
+			if (nonFanSensors.length < 4 || outPos % 2 == 0) {
 				sensorText += '<tr>';
 			}
 			sensorText += '<td>';
-			sensorText += tempSensors[i].label;
+			sensorText += nonFanSensors[i].label;
 			sensorText += '</td><td style="padding-right: 15px;"';
-			sensorText += " onclick='changeTemperatureUnit()'>";
-			var val = tempSensors[i].value;
-			if (temperatureUnit) {
-				val *= 1.8;
-				val += 32;
-				sensorText += val.toFixed(1);
-				sensorText += 'F';
+			if (nonFanSensors[i].valueType == 'Temperature') {
+				sensorText += " onclick='changeTemperatureUnit()'>";
+				var val = nonFanSensors[i].value;
+				if (temperatureUnit) {
+					val *= 1.8;
+					val += 32;
+					sensorText += val.toFixed(1);
+					sensorText += 'F';
+				} else {
+					sensorText += val.toFixed(1);
+					sensorText += 'C';
+				}
 			} else {
-				sensorText += val.toFixed(1);
-				sensorText += 'C';
+				sensorText += '>';
+				sensorText += nonFanSensors[i].formatted;
 			}
 			sensorText += '</td>';
 
-			if (tempSensors.length > 4 && outPos % 2 == 1) {
+			if (nonFanSensors.length > 4 && outPos % 2 == 1) {
 				sensorText += '<tr>';
 			}
 			outPos++;
@@ -9415,12 +9420,12 @@ function RefreshHeaderBar () {
 	}
 
 	if (data.sensors != undefined) {
-		var tempSensors = data.sensors.filter(function(s) {
-			return s.valueType === 'Temperature';
+		var nonFanSensors = data.sensors.filter(function(s) {
+			return s.valueType !== 'FanSpeed';
 		});
 		var sensors = [];
 		var tooltip = '';
-		// Tooltip shows all sensors (temperature + fans)
+		// Tooltip shows all sensors (including fans)
 		data.sensors.forEach(function (e) {
 			var tv = e.formatted;
 			if (e.valueType === 'Temperature' && typeof temperatureUnit !== 'undefined' && temperatureUnit) {
@@ -9428,16 +9433,19 @@ function RefreshHeaderBar () {
 			}
 			tooltip += '<b>' + e.label + '</b>' + tv + '<br/>';
 		});
-		// Header shows only temperature sensors
-		tempSensors.forEach(function (e) {
-			var icon = 'thermometer-half';
+		// Header rotating display excludes fan speed sensors
+		nonFanSensors.forEach(function (e) {
+			var icon = 'bolt';
 			var val = e.formatted;
-			if (typeof temperatureUnit !== 'undefined' && temperatureUnit) {
-				val = val * 1.8 + 32;
-				val = parseFloat(val).toFixed(2);
-				val += '&deg;F';
-			} else {
-				val += '&deg;C';
+			if (e.valueType == 'Temperature') {
+				icon = 'thermometer-half';
+				if (typeof temperatureUnit !== 'undefined' && temperatureUnit) {
+					val = val * 1.8 + 32;
+					val = parseFloat(val).toFixed(2);
+					val += '&deg;F';
+				} else {
+					val += '&deg;C';
+				}
 			}
 			row =
 				'<span class="sensorSpan hiddenSensor" onclick="RotateHeaderSensor(' +


### PR DESCRIPTION
This PR is a minor bug fix for a bug introduced from PR #2699.

The fan temp takes over the CPU temp on the header bar (see screenshot).
<img width="464" height="69" alt="Screenshot 2026-06-23 at 9 59 52 AM" src="https://github.com/user-attachments/assets/3eb9a259-9814-4cd6-9f6a-6cc82d3442a5" />

The CPU temperature should be displayed with fan info in the tool tip (fix - see screenshot).
<img width="410" height="162" alt="Screenshot 2026-06-23 at 10 00 35 AM" src="https://github.com/user-attachments/assets/25d4dbea-0232-45a4-a802-1d021bef73f6" />
