### PR TITLE
Fan On Temperature should respect localization settings

### DIFF
--- a/www/api/controllers/settings.php
+++ b/www/api/controllers/settings.php
@@ -87,6 +87,10 @@ function PutSetting()
     $value = file_get_contents('php://input');
     $setting = params('SettingName');
 
+    if ($setting == 'GPIOFanTemperature' && isset($settings['temperatureInF']) && $settings['temperatureInF'] == 1) {
+        $value = round(($value - 32) * 5 / 9);
+    }
+
     WriteSettingToFile($setting, $value);
 
     // Callers can pass ?skipApply=1 to persist the value WITHOUT running the

--- a/www/common.php
+++ b/www/common.php
@@ -732,6 +732,15 @@ function PrintSetting($setting, $callback = '', $options = array(), $plugin = ''
                 $step = isset($s['step']) ? $s['step'] : 1;
                 $default = isset($s['default']) ? $s['default'] : "0";
 
+                if ($setting == 'GPIOFanTemperature' && isset($settings['temperatureInF']) && $settings['temperatureInF'] == 1) {
+                    $origVal = isset($settings[$setting]) ? $settings[$setting] : $default;
+                    $settings[$setting] = round(($origVal * 9 / 5) + 32);
+                    $min = round(($min * 9 / 5) + 32);
+                    $max = round(($max * 9 / 5) + 32);
+                    $default = round(($default * 9 / 5) + 32);
+                    $suffix = ' F';
+                }
+
                 PrintSettingTextSaved($setting, $restart, $reboot, $max, $min, $plugin, $default, $callback, '', 'number', $s);
                 break;
             case 'modal':


### PR DESCRIPTION
## Respect Temperature Display Units for Fan On Temperature

### Problem

In FPP Settings → Localization, users can set "Temperature display units" to Fahrenheit. However, the **Fan On Temperature** field (under GPIO 14 Fan Control for Raspberry Pi) always displayed and stored values in Celsius with a hardcoded `" C"` suffix, ignoring the user's unit preference.

### Solution

The value is always stored as Celsius internally (matching the kernel device tree overlay expectation of millidegree Celsius). Conversion only happens in the UI layer — consistent with how sensor temperatures are handled elsewhere in FPP.

### Changes

**`www/common.php`** (`PrintSetting` — number case, lines 735–742)

When rendering the `GPIOFanTemperature` field and `temperatureInF` is set to Fahrenheit:
- Converts the stored Celsius value to Fahrenheit for display: `(value × 9/5) + 32`
- Adjusts `min`, `max`, and `default` to Fahrenheit equivalents (86–185°F)
- Overrides the suffix from `" C"` to `" F"`

In Celsius mode, the existing `" C"` suffix from `settings.json` is used unchanged.

**`www/api/controllers/settings.php`** (`PutSetting`, lines 90–92)

Before persisting a GPIOFanTemperature change, if `temperatureInF` is Fahrenheit:
- Converts the incoming value from Fahrenheit back to Celsius: `(value − 32) × 5/9`
- Ensures the settings file and the `/boot/config.txt` device tree overlay always receive Celsius

### Verification

- **Round-trip exactness**: All integer temperatures 30–85°C convert to Fahrenheit and back without precision loss
- **First-time setup**: Uses the default value (70°C / 158°F) correctly when the setting has not been saved yet
- **Celsius mode**: No conversion applied; behaves identically to the original code

### Additional Comments

This PR closes #2701.