### PR TITLE
Fix: BBB nightly image fails to boot on PocketBeagle (PB1/K8-PB)

### DIFF
--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -1918,16 +1918,9 @@ finalize_platform_beaglebone_black() {
 
     sed -i -e "s/#force_color_prompt=yes/force_color_prompt=yes/" /home/fpp/.bashrc
 
-    # adjust a bunch of settings in /boot/uEnv.txt
-    sed -i -e "s+^#enable_uboot_overlays=\(.*\)+enable_uboot_overlays=1+g"  /boot/uEnv.txt
-    sed -i -e "s+^#disable_uboot_overlay_video=\(.*\)+disable_uboot_overlay_video=1+g"  /boot/uEnv.txt
-    sed -i -e "s+#uboot_overlay_addr0=\(.*\)+uboot_overlay_addr0=/lib/firmware/fpp-base-overlay.dtb+g"  /boot/uEnv.txt
-    sed -i -e "s+#uboot_overlay_addr1=\(.*\)+uboot_overlay_addr1=/lib/firmware/fpp-cape-overlay.dtb+g"  /boot/uEnv.txt
-    sed -i -e "s+ quiet+ quiet rootwait+g"  /boot/uEnv.txt
-    sed -i -e "s+ net.ifnames=.+ +g"  /boot/uEnv.txt
-    sed -i -e "s+^uboot_overlay_pru=+#uboot_overlay_pru=+g"  /boot/uEnv.txt
-    echo "bootdelay=0" >> /boot/uEnv.txt
-    echo "#cmdline=init=/opt/fpp/SD/BBB-AutoFlash.sh" >> /boot/uEnv.txt
+    # uEnv.txt overlay configuration moved to configureBBB() in
+    # FPPINIT_Config.cpp so it can detect PocketBeagle at runtime
+    # and skip BBB-specific overlay loading.
 
     # remove the udev rules that create the SoftAp interface on the bbbw and bbggw
     rm -f /etc/udev/rules.d/*SoftAp*

--- a/src/boot/FPPINIT_Config.cpp
+++ b/src/boot/FPPINIT_Config.cpp
@@ -255,7 +255,34 @@ inline const std::string& mapBBBLedValue(const std::string& v) {
 void configureBBB() {
 #ifdef PLATFORM_BBB
     if (FileExists("/dev/mmcblk1")) {
-        // full size beagle, check the bootloader
+        // full size beagle, configure U-Boot overlays and check bootloader
+        // (PocketBeagle has no /dev/mmcblk1 so it takes the else-branch below)
+
+        // Configure uEnv.txt overlays at runtime so PocketBeagle is not
+        // affected by BBB-specific overlay loading (cape_eeprom, RTC, and
+        // wkup_m3 nodes don't exist in PocketBeagle's device tree, causing
+        // U-Boot to crash during phandle resolution).
+        int r = system(
+            "grep -qs '^enable_uboot_overlays=1' /boot/uEnv.txt 2>/dev/null"
+            " && exit 0;"
+            " sed -i"
+            " -e 's/^#enable_uboot_overlays=.*/enable_uboot_overlays=1/'"
+            " -e 's/^#disable_uboot_overlay_video=.*/disable_uboot_overlay_video=1/'"
+            " -e 's+#uboot_overlay_addr0=.*+uboot_overlay_addr0=/lib/firmware/fpp-base-overlay.dtb+'"
+            " -e 's+#uboot_overlay_addr1=.*+uboot_overlay_addr1=/lib/firmware/fpp-cape-overlay.dtb+'"
+            " -e 's/ quiet/ quiet rootwait/'"
+            " -e 's/ net\\.ifnames=.//'"
+            " -e 's/^uboot_overlay_pru=/#uboot_overlay_pru=/'"
+            " /boot/uEnv.txt 2>/dev/null || exit 0;"
+            " grep -q '^bootdelay=0' /boot/uEnv.txt 2>/dev/null"
+            " || echo 'bootdelay=0' >> /boot/uEnv.txt;"
+            " grep -q 'cmdline=init=/opt/fpp/SD/BBB-AutoFlash.sh' /boot/uEnv.txt 2>/dev/null"
+            " || echo '#cmdline=init=/opt/fpp/SD/BBB-AutoFlash.sh' >> /boot/uEnv.txt;"
+            " exit 1");
+        if (r != -1 && WIFEXITED(r) && WEXITSTATUS(r) == 1) {
+            setRawSetting("rebootFlag", "1");
+        }
+
         int fd = open("/dev/mmcblk1", O_RDONLY);
         lseek(fd, 393488, SEEK_SET);
         uint8_t buf[25];


### PR DESCRIPTION
## Fix: BBB nightly image fails to boot on PocketBeagle (PB1/K8-PB)

### Problem

The BBB nightly image (`FPP-vnightly-BBB.img.zip`) boots fine on BeagleBone Black (K8-B) but hangs early in boot on PocketBeagle (PB1/K8-PB). The symptom is 4 LEDs on briefly, then 2 LEDs solid — a U-Boot crash during device tree overlay application.

Burning the FPP 9.5.3 image to the same SD card boots on PB1 without issue, confirming this is a regression.

### Root Cause

The uEnv.txt overlay configuration (`finalize_platform_beaglebone_black()` in `SD/FPP_Install.sh`) is applied at image build time, with no runtime board detection. The `fpp-base-overlay.dtb` referenced by uEnv.txt disables several device tree nodes via phandle labels (`&cape_eeprom0-3`, `&rtc`, `&wkup_m3`, `&wkup_m3_ipc` in `capes/drivers/bbb/fpp-base-overlay.dts:29-50`).

These labels are defined in AM335x SoC headers but may not exist in PocketBeagle's compiled DTB (PocketBeagle lacks cape EEPROMs and has a different base DTS). When U-Boot attempts to resolve the phandles during overlay application and they're absent from PB's DTB, it crashes before the kernel loads.

### Fix

**Two files changed, zero files added.**

**`SD/FPP_Install.sh`** — Removed the 10 lines that unconditionally modify `/boot/uEnv.txt` during image build. The overlays are still compiled and installed to `/lib/firmware/` for later use, just not activated until runtime.

**`src/boot/FPPINIT_Config.cpp`** — Added an inline `system()` call inside the existing `if (FileExists("/dev/mmcblk1"))` branch of `configureBBB()` that applies the uEnv.txt overlay configuration at runtime, after the board model is known. The PocketBeagle path (`else` branch) never reaches this code.

The inline logic is:
- **Idempotent**: checks for `enable_uboot_overlays=1` in uEnv.txt and exits immediately if already configured
- **Error-safe**: all commands guarded with `2>/dev/null || exit 0` to silently skip if uEnv.txt is missing
- **Exit-code signaling**: returns 1 when changes are made, triggering the existing `rebootFlag` UI banner

### Production Safety

- **No platform bleed**: the new code compiles only under `#ifdef PLATFORM_BBB` — zero impact on Raspberry Pi, Debian, or other platforms
- **No automatic reboot**: `rebootFlag` only shows a UI banner; the user reboots at their convenience
- **Zero warnings**: compiles cleanly with `-Wall -Wextra -Wpedantic`
- **Full build verified**: `fppd`, `libfpp`, and `fpp` all link successfully

### Testing

| Scenario | Expected Behavior |
|----------|-------------------|
| BBB fresh image | Overlays configured by fppinit at first boot, active after user reboot |
| BBB existing install | Idempotency guard skips re-configuration |
| PB1 fresh BBB image | fppinit detects PB (no `/dev/mmcblk1`), skips overlay config, boots normally |
| PB1 upgrading from 9.5.3 | uEnv.txt already configured from build-time, idempotency guard skips re-apply |
| Direct hardware install | Overlay config deferred to first fppinit run (one boot cycle) |
| Other AM335x (BBG/BBGW) | Have `/dev/mmcblk1`, enter BBB branch, overlays configured as before |

### Additional Comments

This PR relates to issue #2707. After merging, please mark issue as "Fix Applied - Testing Required".
SD cards that were imaged previously for PocketBeagles with 10.x (since April 15, 2026) would have to be re-imaged with the latest build after the PR has been merged in order to resolve the kernel hanging during boot.