### PR TITLE
Feedback Fixes #2613 - about.php updates

### DIFF
--- a/www/about.php
+++ b/www/about.php
@@ -1423,7 +1423,7 @@
                         <h4 class="fpp-info-panel__title"><i class="fas fa-question-circle"></i> Frequently Asked
                             Questions</h4>
                         <div class="fpp-faq" id="upgradeFaq">
-                            <div class="fpp-faq__item">
+                            <div class="fpp-faq__item fpp-faq__item--open">
                                 <div class="fpp-faq__question">
                                     Which upgrade should I choose?
                                     <i class="fas fa-chevron-down"></i>

--- a/www/about.php
+++ b/www/about.php
@@ -1026,13 +1026,29 @@
         }
 
         function initFaqAccordion() {
-            document.querySelectorAll('.fpp-faq__item').forEach(item => {
+            var items = document.querySelectorAll('.fpp-faq__item');
+
+            // Drive max-height from the answer's actual scrollHeight so open/close
+            // animates to the real content height (no fixed-height clip).
+            function syncFaqHeight(item) {
+                var answer = item.querySelector('.fpp-faq__answer');
+                if (!answer) return;
+                answer.style.maxHeight = item.classList.contains('fpp-faq__item--open')
+                    ? answer.scrollHeight + 'px'
+                    : '0px';
+            }
+
+            items.forEach(function (item) {
                 item.querySelector('.fpp-faq__question').addEventListener('click', function () {
-                    const isOpen = item.classList.contains('fpp-faq__item--open');
-                    document.querySelectorAll('.fpp-faq__item').forEach(i => i.classList.remove('fpp-faq__item--open'));
+                    var isOpen = item.classList.contains('fpp-faq__item--open');
+                    items.forEach(function (i) { i.classList.remove('fpp-faq__item--open'); });
                     if (!isOpen) item.classList.add('fpp-faq__item--open');
+                    items.forEach(syncFaqHeight);
                 });
             });
+
+            // Initialize (the first item is open by default in the markup).
+            items.forEach(syncFaqHeight);
         }
 
         // Test mode support: append ?test=branch (or commit, both, uptodate, major/eol, osonly)

--- a/www/about.php
+++ b/www/about.php
@@ -261,6 +261,10 @@
                 $os.text('A new OS image is available. Recommended -- it includes a fresh FPP build.');
             } else if (osUpgradeAvailable) {
                 $os.text('A new OS image is available. Includes security patches and dependency updates.');
+            } else if (isEndOfLife) {
+                // EOL but no matching image is listed yet -- don't claim the OS is
+                // "current" (that contradicts the End of Life call to upgrade).
+                $os.text('An OS upgrade is required to reach a supported release, but no compatible image is listed for this board yet.');
             } else {
                 $os.text('OS is current. No new image available.');
             }
@@ -390,6 +394,16 @@
         var isEndOfLife = false;
 
         function UpdateVersionInfo(testMode) {
+            // Replace any still-shimmering async placeholders with a neutral "--"
+            // so a failed/partial status response can't leave them animating forever.
+            function clearVersionSkeletons() {
+                $('#osVersionValue, #osReleaseValue, #kernelValue, #osCurrentVersionBadge').each(function () {
+                    if ($(this).find('.fpp-skeleton').length) {
+                        $(this).text('--');
+                    }
+                });
+            }
+
             // Fetch system status for version info
             $.get('api/system/status', function (data) {
                 if (data.advancedView) {
@@ -433,7 +447,10 @@
 
                     $('#osVersionStatusBadge').show();
                 }
-            });
+                // These fields are populated only here; clear any that this
+                // response didn't fill so they don't shimmer indefinitely.
+                clearVersionSkeletons();
+            }).fail(clearVersionSkeletons);
 
             // Fetch unified update status
             var updateStatusUrl = 'api/system/updateStatus';
@@ -610,11 +627,7 @@
                 setVersionStatusDot('fppVersionStatusBadge', 'unknown', 'Unknown');
                 // Don't leave placeholders shimmering forever if status can't be
                 // fetched -- fall back to the neutral "--" for any unresolved field.
-                $('#osVersionValue, #osReleaseValue, #kernelValue, #osCurrentVersionBadge').each(function () {
-                    if ($(this).find('.fpp-skeleton').length) {
-                        $(this).text('--');
-                    }
-                });
+                clearVersionSkeletons();
             });
         }
 
@@ -1049,6 +1062,17 @@
 
             // Initialize (the first item is open by default in the markup).
             items.forEach(syncFaqHeight);
+
+            // Re-measure open answers on resize: a narrower viewport reflows the
+            // text taller, and a max-height frozen at the old scrollHeight would
+            // clip it (overflow is hidden). Debounced to avoid thrashing.
+            var faqResizeTimer = null;
+            window.addEventListener('resize', function () {
+                clearTimeout(faqResizeTimer);
+                faqResizeTimer = setTimeout(function () {
+                    items.forEach(syncFaqHeight);
+                }, 100);
+            });
         }
 
         // Test mode support: append ?test=branch (or commit, both, uptodate, major/eol, osonly)

--- a/www/about.php
+++ b/www/about.php
@@ -225,6 +225,10 @@
             $('#osCard')
                 .toggleClass('is-recommended', recommended === 'os')
                 .toggleClass('is-disabled', recommended !== 'os');
+            // Re-derive the engaged (un-faded) state after (re)coordinating, so a
+            // reset/repopulated dropdown can't leave the card un-faded with nothing
+            // selected.
+            syncOSCardEngaged();
         }
 
         // State-specific card subtitles, so each card describes what applies now
@@ -988,6 +992,18 @@
             // Selecting an image enables the (rebooting) OS upgrade even when no
             // upgrade was auto-detected, so keep the reboot warning in sync.
             updateOSRebootWarning();
+
+            syncOSCardEngaged();
+        }
+
+        // In the coordinated view the OS card may be faded back (is-disabled) when
+        // it isn't the recommended path. Once the user actually picks an image, the
+        // card is "engaged": it -- and its Upgrade button -- return to full opacity
+        // and read as normal/clickable. Derived purely from the current selection
+        // so a repopulated/reset dropdown can't leave the card falsely un-faded.
+        function syncOSCardEngaged() {
+            var os = $('#osSelect').val();
+            $('#osCard').toggleClass('is-engaged', os !== '' && os != null);
         }
 
         function initFaqAccordion() {

--- a/www/about.php
+++ b/www/about.php
@@ -608,6 +608,13 @@
                 checkUpgradeRecommendation();
             }).fail(function () {
                 setVersionStatusDot('fppVersionStatusBadge', 'unknown', 'Unknown');
+                // Don't leave placeholders shimmering forever if status can't be
+                // fetched -- fall back to the neutral "--" for any unresolved field.
+                $('#osVersionValue, #osReleaseValue, #kernelValue, #osCurrentVersionBadge').each(function () {
+                    if ($(this).find('.fpp-skeleton').length) {
+                        $(this).text('--');
+                    }
+                });
             });
         }
 
@@ -1119,7 +1126,7 @@
                             <div class="fpp-row">
                                 <span class="fpp-row__label">OS Version:</span>
                                 <span class="fpp-row__value">
-                                    <span id="osVersionValue">--</span>
+                                    <span id="osVersionValue"><span class="fpp-skeleton" aria-hidden="true"></span></span>
                                     <span id="osVersionStatusBadge" class="fpp-upd-dot fpp-upd-dot--ok"
                                         style="display: none;">Up to Date</span>
                                 </span>
@@ -1130,7 +1137,7 @@
                         <div class="col-md-4 fpp-col-divider">
                             <div class="fpp-row">
                                 <span class="fpp-row__label">OS Build:</span>
-                                <span class="fpp-row__value" id="osReleaseValue">--</span>
+                                <span class="fpp-row__value" id="osReleaseValue"><span class="fpp-skeleton" aria-hidden="true"></span></span>
                             </div>
                             <div class="fpp-row">
                                 <span class="fpp-row__label">Platform:</span>
@@ -1154,7 +1161,7 @@
                             <?php } ?>
                             <div class="fpp-row">
                                 <span class="fpp-row__label">Kernel:</span>
-                                <span class="fpp-row__value" id="kernelValue">--</span>
+                                <span class="fpp-row__value" id="kernelValue"><span class="fpp-skeleton" aria-hidden="true"></span></span>
                             </div>
                         </div>
                     </div>
@@ -1330,7 +1337,7 @@
                                 </div>
                                 <div class="fpp-card__header-status">
                                     <span class="fpp-card__header-status-label">Current OS</span>
-                                    <span class="fpp-tag" id="osCurrentVersionBadge">--</span>
+                                    <span class="fpp-tag" id="osCurrentVersionBadge"><span class="fpp-skeleton" aria-hidden="true"></span></span>
                                 </div>
                             </div>
 

--- a/www/about.php
+++ b/www/about.php
@@ -173,39 +173,104 @@
             });
         }
 
-        // Keep OS version pills (status badge + current-version pill in the
-        // Upgrade OS card) in sync with the detected OS upgrade state so they
-        // don't contradict the banners/recommendation card.
-        function updateOSVersionStatusBadge() {
-            var $statusBadge = $('#osVersionStatusBadge');
-            var $currentBadge = $('#osCurrentVersionBadge');
-            var statusClass, statusText;
+        // Set a quiet status dot (.fpp-upd-dot) on a version-info row.
+        //   kind: 'ok' (up to date) | 'update' (available) | 'required' | 'unknown'
+        function setVersionStatusDot(id, kind, text) {
+            var cls = 'fpp-upd-dot';
+            if (kind === 'ok' || kind === 'unknown') {
+                cls += ' fpp-upd-dot--ok';
+            } else if (kind === 'required') {
+                cls += ' fpp-upd-dot--required';
+            }
+            // 'update' -> base (amber) dot
+            $('#' + id).attr('class', cls).text(text);
+        }
 
+        // Keep the OS version status dot in sync with the detected OS upgrade
+        // state so it doesn't contradict the banners/recommendation card. The
+        // current-OS pill in the card header stays neutral (version text only).
+        function updateOSVersionStatusBadge() {
             if (isMajorVersionUpgrade) {
-                statusClass = 'text-bg-warning';
-                statusText = 'Upgrade Required';
+                setVersionStatusDot('osVersionStatusBadge', 'required', 'Upgrade Required');
             } else if (osUpgradeAvailable) {
-                statusClass = 'text-bg-warning';
-                statusText = 'Upgrade Available';
+                setVersionStatusDot('osVersionStatusBadge', 'update', 'Upgrade Available');
             } else {
-                statusClass = 'text-bg-success';
-                statusText = 'Up to Date';
+                setVersionStatusDot('osVersionStatusBadge', 'ok', 'Up to Date');
+            }
+        }
+
+        // Single source of truth for which upgrade path is recommended, so the
+        // status dot, subtitles, button styling, and card coordination can't
+        // drift out of sync. Returns 'fpp' | 'os' | null.
+        //   - Major version upgrades and any available OS upgrade -> 'os'
+        //     (the OS image ships a fresh FPP, so an FPP update first is wasted).
+        //   - FPP update available with OS current -> 'fpp'.
+        function getRecommendedPath() {
+            if (isMajorVersionUpgrade || osUpgradeAvailable) {
+                return 'os';
+            }
+            if (fppUpdateAvailable) {
+                return 'fpp';
+            }
+            return null;
+        }
+
+        // Coordinated semantic layout: highlight the recommended card in amber
+        // end-to-end and fade the card that doesn't apply in the current state.
+        //   recommended: 'fpp' | 'os' | null
+        function setCoordinatedCards(recommended) {
+            $('#fppCard')
+                .toggleClass('is-recommended', recommended === 'fpp')
+                .toggleClass('is-disabled', recommended !== 'fpp');
+            $('#osCard')
+                .toggleClass('is-recommended', recommended === 'os')
+                .toggleClass('is-disabled', recommended !== 'os');
+        }
+
+        // State-specific card subtitles, so each card describes what applies now
+        // instead of a generic line (e.g. the OS card reads "OS is current" while
+        // an FPP update is the recommended path).
+        function updateCardSubtitles() {
+            var $fpp = $('#fppCardSubtitle');
+            if (isMajorVersionUpgrade) {
+                $fpp.text('Cannot upgrade across major versions from here. Use the OS upgrade instead.');
+            } else if (fppUpdateAvailable && osUpgradeAvailable) {
+                $fpp.text('An FPP update is available, but the OS upgrade below already includes a fresh FPP build.');
+            } else if (fppUpdateAvailable && branchUpgradeData && branchUpgradeData.branchUpgradeVersion) {
+                $fpp.text('FPP ' + branchUpgradeData.branchUpgradeVersion + ' is available. Safe and quick (2-5 min).');
+            } else if (fppUpdateAvailable) {
+                $fpp.text('New commits are available on your current branch. Safe and quick.');
+            } else if (isEndOfLife) {
+                // Current major version is unsupported and no in-branch update is
+                // offered -- don't claim "up to date"; the only path is an OS upgrade.
+                $fpp.text('This version has reached End of Life. Upgrade the OS to a supported release.');
+            } else {
+                $fpp.text('FPP is up to date. No new commits or releases available.');
             }
 
-            $statusBadge.removeClass('text-bg-success text-bg-secondary text-bg-warning')
-                .addClass(statusClass).text(statusText);
-            // Current-OS pill keeps its version text but mirrors the status color.
-            $currentBadge.removeClass('text-bg-success text-bg-secondary text-bg-warning')
-                .addClass(statusClass);
+            var $os = $('#osCardSubtitle');
+            if (isMajorVersionUpgrade) {
+                var majorTarget = (branchUpgradeData && branchUpgradeData.branchUpgradeVersion)
+                    ? 'FPP ' + branchUpgradeData.branchUpgradeVersion : 'the new major version';
+                $os.text('Required to install ' + majorTarget + '. Your settings and media are preserved.');
+            } else if (fppUpdateAvailable && osUpgradeAvailable) {
+                $os.text('A new OS image is available. Recommended -- it includes a fresh FPP build.');
+            } else if (osUpgradeAvailable) {
+                $os.text('A new OS image is available. Includes security patches and dependency updates.');
+            } else {
+                $os.text('OS is current. No new image available.');
+            }
         }
 
         // Keep the FPP/OS action buttons styled consistently with availability:
         //   updates available -> yellow (warning), no updates -> gray (secondary).
         function updateActionButtonStyles() {
             var $fpp = $('#fppUpdateButton');
-            // Major version upgrade forces use of OS upgrade, so the FPP button
-            // is inert -- show it gray to match its disabled state.
-            if (fppUpdateAvailable && !isMajorVersionUpgrade) {
+            // Amber (recommended) only when the FPP update is the recommended path.
+            // Major upgrades force the OS route, and when an OS upgrade is also
+            // available we recommend that instead -- so the FPP button stays gray
+            // to match its de-emphasized card in those cases.
+            if (getRecommendedPath() === 'fpp') {
                 $fpp.removeClass('fpp-btn--success fpp-btn--secondary').addClass('fpp-btn--warning');
             } else {
                 $fpp.removeClass('fpp-btn--success fpp-btn--warning').addClass('fpp-btn--secondary');
@@ -219,23 +284,24 @@
             }
         }
 
-        // Check upgrade scenarios and show appropriate banners
+        // Check upgrade scenarios, pick the recommended path, and coordinate the
+        // banners + cards around it (amber flows from the recommendation banner
+        // into the recommended card).
         function checkUpgradeRecommendation() {
             updateOSVersionStatusBadge();
             updateActionButtonStyles();
 
-            // Major FPP version upgrades: OS banner already configured in UpdateVersionInfo(), no separate recommendation needed
+            var recommended = getRecommendedPath(); // 'fpp' | 'os' | null
+
             if (isMajorVersionUpgrade) {
+                // Major version upgrades REQUIRE an OS upgrade. The OS banner is
+                // already configured in UpdateVersionInfo(); recommend OS here.
                 $('#upgradeRecommendationBanner').hide();
                 $('#fppRecommendedBadge').hide();
-                $('#osRecommendedBadge').hide();
-                return;
-            }
-
-            if (fppUpdateAvailable && osUpgradeAvailable) {
-                // Both FPP update and OS upgrade available (non-major version).
-                // The OS image ships with a fresh FPP, so doing the FPP update
-                // first is wasted work -- recommend the OS upgrade instead.
+                $('#osRecommendedBadge').show();
+            } else if (fppUpdateAvailable && osUpgradeAvailable) {
+                // Both available (non-major). The OS image ships with a fresh FPP,
+                // so an FPP update first is wasted work -- recommend the OS upgrade.
                 $('#upgradeRecommendationTitle').text('Recommended: Upgrade OS First');
                 $('#upgradeRecommendationMessage').text(
                     'Both a software update and OS upgrade are available. We recommend the ' +
@@ -247,12 +313,11 @@
                 $('#upgradeRecommendationBanner').show();
                 $('#osUpdateBanner').hide();
                 $('#fppUpdateBanner').hide();
-            } else if (!fppUpdateAvailable && osUpgradeAvailable) {
-                // FPP is up to date, but OS upgrade available
+            } else if (osUpgradeAvailable) {
+                // FPP is up to date, but an OS upgrade is available.
                 $('#upgradeRecommendationBanner').hide();
                 $('#fppRecommendedBadge').hide();
-                $('#osRecommendedBadge').hide();
-                // Show OS banner
+                $('#osRecommendedBadge').show();
                 $('#osUpdateBanner')
                     .removeClass('fpp-banner--success')
                     .addClass('fpp-banner--warning')
@@ -262,12 +327,32 @@
                     'A newer OS version is available. OS upgrades include security patches, new hardware support, and system improvements. Always backup first!'
                 );
                 $('#osUpdateBanner .fpp-banner__icon i').removeClass('fa-arrow-circle-up').addClass('fa-exclamation-triangle');
+            } else if (fppUpdateAvailable) {
+                // FPP update available, OS current -- FPP update is the recommended path.
+                $('#upgradeRecommendationBanner').hide();
+                $('#osRecommendedBadge').hide();
+                $('#fppRecommendedBadge').show();
+                $('#osUpdateBanner').hide();
             } else {
+                // Everything up to date.
                 $('#upgradeRecommendationBanner').hide();
                 $('#fppRecommendedBadge').hide();
                 $('#osRecommendedBadge').hide();
                 $('#osUpdateBanner').hide();
             }
+
+            setCoordinatedCards(recommended);
+            updateCardSubtitles();
+            updateOSRebootWarning();
+        }
+
+        // Reboot warning: show it whenever an OS upgrade is the action at hand --
+        // either an upgrade is detected, or the user has manually selected an image
+        // (advanced "Show All Platforms"/"Show Legacy OS" flow enables the upgrade
+        // button independently of osUpgradeAvailable).
+        function updateOSRebootWarning() {
+            var imageSelected = $('#osSelect').val() !== '' && $('#osSelect').val() != null;
+            $('#osRebootWarning').toggle(!!osUpgradeAvailable || imageSelected);
         }
 
         function GetGitOriginLog() {
@@ -373,6 +458,8 @@
 
                 // Hide all standard view states
                 $('#fppVersionStandardBranchUpgrade, #fppVersionStandardCommitUpdate, #fppVersionStandardCurrent').hide();
+                // Reset the major-version callout; re-shown only on the major path below.
+                $('#fppMajorCallout').hide();
 
                 // Check for End of Life status
                 isEndOfLife = updateData.isEndOfLife || false;
@@ -393,13 +480,13 @@
 
                     if (isMajorVersionUpgrade) {
                         // Major version upgrades REQUIRE OS upgrade
-                        $('#gitUpdateBadge').text('Requires OS Upgrade').show();
+                        $('#fppMajorCallout').show();
                         $('#fppUpdateBanner').hide();
 
-                        // Show OS banner
+                        // Show OS banner (amber = the recommended path)
                         $('#osUpdateBanner')
-                            .removeClass('fpp-banner--warning')
-                            .addClass('fpp-banner--success')
+                            .removeClass('fpp-banner--success')
+                            .addClass('fpp-banner--warning')
                             .show();
                         $('#osUpdateBanner .fpp-banner__title').text('FPP ' + updateData.branchUpgradeVersion + ' Available - OS Upgrade Required');
                         $('#osUpdateBanner .fpp-banner__message').html(
@@ -408,7 +495,7 @@
                         );
                         $('#osUpdateBanner .fpp-banner__icon i').removeClass('fa-exclamation-triangle').addClass('fa-arrow-circle-up');
 
-                        $('#fppVersionStatusBadge').removeClass('text-bg-secondary text-bg-success').addClass('text-bg-warning').text('OS Upgrade Required');
+                        setVersionStatusDot('fppVersionStatusBadge', 'required', 'OS Upgrade Required');
                         // Signal that OS upgrade path should be used
                         osUpgradeAvailable = true;
 
@@ -416,7 +503,7 @@
                         $('#fppVersionStandardBranchUpgrade').show();
                         $('#fppTargetVersion').text('FPP ' + updateData.branchUpgradeVersion);
                         // Add visual indication that this requires OS upgrade
-                        $('#fppVersionStandardBranchUpgrade .badge').text('Requires OS Upgrade').removeClass('text-bg-warning').addClass('text-bg-primary');
+                        setVersionStatusDot('fppStandardBranchDot', 'required', 'Requires OS Upgrade');
 
                         // Advanced view
                         $('#fppVersionIndicator').show();
@@ -429,13 +516,14 @@
                         $('#fppUpdateButtonText').text('Use OS Upgrade');
                     } else {
                         // Minor version branch upgrade
-                        $('#gitUpdateBadge').text('Upgrade to ' + updateData.branchUpgradeTarget).show();
                         $('#fppUpdateBanner').show();
-                        $('#fppVersionStatusBadge').removeClass('text-bg-secondary text-bg-success').addClass('text-bg-warning').text('Upgrade Available');
+                        setVersionStatusDot('fppVersionStatusBadge', 'update', 'Upgrade Available');
 
                         // Standard view: show branch upgrade
                         $('#fppVersionStandardBranchUpgrade').show();
                         $('#fppTargetVersion').text('FPP ' + updateData.branchUpgradeVersion);
+                        // Reset the shared dot (major path sets it to "Requires OS Upgrade").
+                        setVersionStatusDot('fppStandardBranchDot', 'update', 'Update available');
 
                         $('#fppVersionIndicator')
                             .attr('onclick', 'HandleFPPUpdate();')
@@ -458,9 +546,8 @@
                     isMajorVersionUpgrade = false;
 
                     $('#remoteGitShort').text(updateData.remoteCommit.substring(0, 9));
-                    $('#gitUpdateBadge').text('Update Available').show();
                     $('#fppUpdateBanner').show();
-                    $('#fppVersionStatusBadge').removeClass('text-bg-secondary text-bg-success').addClass('text-bg-warning').text('Update Available');
+                    setVersionStatusDot('fppVersionStatusBadge', 'update', 'Update Available');
 
                     // Standard view: show commit update (no version arrow)
                     $('#fppVersionStandardCommitUpdate').show();
@@ -492,11 +579,10 @@
                     fppUpdateAvailable = false;
                     isMajorVersionUpgrade = false;
 
-                    $('#gitUpdateBadge').hide();
                     $('#fppUpdateBanner').hide();
                     // Don't hide OS banner here - let checkUpgradeRecommendation() handle it
                     // based on whether osUpgradeAvailable is set
-                    $('#fppVersionStatusBadge').removeClass('text-bg-secondary text-bg-warning').addClass('text-bg-success').text('Up to Date');
+                    setVersionStatusDot('fppVersionStatusBadge', 'ok', 'Up to Date');
 
                     // When up to date: disable button for basic users, keep enabled for advanced
                     if (isAdvancedView) {
@@ -517,7 +603,7 @@
 
                 checkUpgradeRecommendation();
             }).fail(function () {
-                $('#fppVersionStatusBadge').removeClass('text-bg-secondary text-bg-success text-bg-warning').addClass('text-bg-secondary').text('Unknown');
+                setVersionStatusDot('fppVersionStatusBadge', 'unknown', 'Unknown');
             });
         }
 
@@ -891,6 +977,9 @@
                     $('#osDownloadButton').attr('disabled', 'disabled');
                 }
             }
+            // Selecting an image enables the (rebooting) OS upgrade even when no
+            // upgrade was auto-detected, so keep the reboot warning in sync.
+            updateOSRebootWarning();
         }
 
         function initFaqAccordion() {
@@ -929,27 +1018,30 @@
             <div class="pageContent">
 
                 <!-- Update Banners (conditionally shown) -->
-                <div id="eolBanner" class="fpp-banner fpp-banner--danger" style="display: none;">
+
+                <!-- End of Life: slim severity strip so it does not compete with the
+                     primary recommendation banner below. -->
+                <div id="eolBanner" class="fpp-banner fpp-banner--danger fpp-banner--strip" style="display: none;">
                     <div class="fpp-banner__icon">
                         <i class="fas fa-exclamation-circle"></i>
                     </div>
                     <div class="fpp-banner__content">
-                        <div class="fpp-banner__title">End of Life Version</div>
                         <p class="fpp-banner__message">
-                            You are running FPP <span id="eolCurrentVersion"></span>, which has reached End of Life.
-                            This version no longer receives bug fixes or security updates.
-                            Please upgrade to FPP <span id="eolLatestVersion"></span> via OS Upgrade to continue
-                            receiving support.
+                            <strong>End of Life</strong> &middot; FPP <span id="eolCurrentVersion"></span> no longer
+                            receives bug fixes or security updates. Upgrade to FPP <span id="eolLatestVersion"></span>
+                            via OS Upgrade to continue receiving support.
                         </p>
                     </div>
                 </div>
 
-                <div id="fppUpdateBanner" class="fpp-banner fpp-banner--success" style="display: none;">
+                <!-- FPP software update available. Amber is the recommendation color in this
+                     coordinated layout, matching the recommended card below. -->
+                <div id="fppUpdateBanner" class="fpp-banner fpp-banner--warning" style="display: none;">
                     <div class="fpp-banner__icon">
-                        <i class="fas fa-check-circle"></i>
+                        <i class="fas fa-arrow-circle-up"></i>
                     </div>
                     <div class="fpp-banner__content">
-                        <div class="fpp-banner__title">FPP Software Update Available!</div>
+                        <div class="fpp-banner__title">FPP Software Update Available</div>
                         <p class="fpp-banner__message">A new version of the FPP software is ready to install. Updates
                             typically complete in under 5 minutes and keep all your settings.</p>
                     </div>
@@ -966,8 +1058,9 @@
                     </div>
                 </div>
 
-                <!-- Upgrade Path Recommendation Banner (shown when both updates available) -->
-                <div id="upgradeRecommendationBanner" class="fpp-banner fpp-banner--info" style="display: none;">
+                <!-- Upgrade Path Recommendation Banner (shown when both updates available).
+                     Amber flows into the recommended card below. -->
+                <div id="upgradeRecommendationBanner" class="fpp-banner fpp-banner--warning" style="display: none;">
                     <div class="fpp-banner__icon">
                         <i class="fas fa-lightbulb"></i>
                     </div>
@@ -995,17 +1088,16 @@
                             <div class="fpp-row">
                                 <span class="fpp-row__label">FPP Version:</span>
                                 <span class="fpp-row__value">
-                                    <span id="fppVersionStatusBadge"
-                                        class="badge text-bg-secondary">Checking...</span>
                                     <span id="fppVersionValue"><?= $fppVersion ?></span>
+                                    <span id="fppVersionStatusBadge" class="fpp-upd-dot">Checking...</span>
                                 </span>
                             </div>
                             <div class="fpp-row">
                                 <span class="fpp-row__label">OS Version:</span>
                                 <span class="fpp-row__value">
-                                    <span id="osVersionStatusBadge" class="badge text-bg-success"
-                                        style="display: none;">Up to Date</span>
                                     <span id="osVersionValue">--</span>
+                                    <span id="osVersionStatusBadge" class="fpp-upd-dot fpp-upd-dot--ok"
+                                        style="display: none;">Up to Date</span>
                                 </span>
                             </div>
 
@@ -1048,22 +1140,27 @@
                 <div class="row">
                     <!-- FPP Software Update -->
                     <div class="col-xl-6 fpp-col-flex">
-                        <div class="card fpp-card fpp-card--accent fpp-card--accent-success fpp-card--flex">
+                        <div id="fppCard" class="card fpp-card fpp-card--accent fpp-card--accent-neutral fpp-card--flex">
                             <div class="fpp-card__header">
-                                <div class="fpp-card__icon fpp-card__icon--success">
+                                <div class="fpp-card__icon fpp-card__icon--neutral">
                                     <i class="fas fa-sync-alt"></i>
                                 </div>
                                 <div>
                                     <h3 class="fpp-card__title">
                                         Update FPP Software
-                                        <span id="gitUpdateBadge" class="badge text-bg-success text-bg-sm"
-                                            style="display: none;">Update Available</span>
-                                        <span id="fppRecommendedBadge" class="badge text-bg-primary text-bg-sm"
+                                        <span id="fppRecommendedBadge" class="fpp-tag fpp-tag--recommended"
                                             style="display: none;">Recommended</span>
                                     </h3>
-                                    <p class="fpp-card__subtitle">Get the latest bug fixes and features. This is safe
-                                        and quick.</p>
+                                    <p class="fpp-card__subtitle" id="fppCardSubtitle">Get the latest bug fixes and
+                                        features. This is safe and quick.</p>
                                 </div>
+                            </div>
+
+                            <!-- Shown only for major-version upgrades, which cannot be applied here -->
+                            <div id="fppMajorCallout" class="fpp-major-callout" style="display: none;">
+                                <i class="fas fa-info-circle"></i>
+                                <span>Major version upgrades cannot be installed via FPP update. Use the
+                                    <strong>OS upgrade</strong> instead.</span>
                             </div>
 
                             <?php $advancedInfoCollapse = isset($settings['uiLevel']) && $settings['uiLevel'] >= 1; ?>
@@ -1101,7 +1198,7 @@
                                     <span class="fpp-version-indicator__current"><?= $fppVersionDisplay ?></span>
                                     <i class="fas fa-arrow-right fpp-version-indicator__arrow"></i>
                                     <span class="fpp-version-indicator__to" id="fppTargetVersion">Latest</span>
-                                    <span class="badge text-bg-warning text-bg-sm">Upgrade Available</span>
+                                    <span id="fppStandardBranchDot" class="fpp-upd-dot">Update available</span>
                                     <span
                                         class="fpp-version-indicator__label fpp-version-indicator__label--subtle">Click
                                         to see release notes</span>
@@ -1111,7 +1208,7 @@
                                 <div id="fppVersionStandardCommitUpdate" class="fpp-version-indicator"
                                     style="display: none;">
                                     <span class="fpp-version-indicator__current"><?= $fppVersionDisplay ?></span>
-                                    <span class="badge text-bg-success text-bg-sm">Update Available</span>
+                                    <span class="fpp-upd-dot">Update available</span>
                                     <span
                                         class="fpp-version-indicator__label fpp-version-indicator__label--subtle"><span
                                             id="commitCountStandard"></span> updates ready to install</span>
@@ -1182,7 +1279,7 @@
                                     }
                                     ?>
                                     <div class="fpp-advanced-options">
-                                        <span class="badge text-bg-primary">Adv</span>
+                                        <span class="fpp-tag fpp-tag--adv">Adv</span>
                                         <span>Source:</span>
                                         <?php PrintSettingSelect("FPP Upgrade Source", "UpgradeSource", 0, 0, "github.com", $upgradeSources); ?>
                                     </div>
@@ -1193,27 +1290,27 @@
 
                     <!-- Operating System Upgrade -->
                     <div class="col-xl-6 fpp-col-flex">
-                        <div class="card fpp-card fpp-card--accent fpp-card--accent-warning fpp-card--flex">
+                        <div id="osCard" class="card fpp-card fpp-card--accent fpp-card--accent-neutral fpp-card--flex">
                             <div class="fpp-card__header">
-                                <div class="fpp-card__icon fpp-card__icon--warning">
+                                <div class="fpp-card__icon fpp-card__icon--neutral">
                                     <i class="fas fa-hdd"></i>
                                 </div>
                                 <div>
                                     <h3 class="fpp-card__title">
                                         Upgrade Operating System
-                                        <span id="osRecommendedBadge" class="badge text-bg-primary text-bg-sm"
+                                        <span id="osRecommendedBadge" class="fpp-tag fpp-tag--recommended"
                                             style="display: none;">Recommended</span>
                                     </h3>
-                                    <p class="fpp-card__subtitle">Upgrade the entire FPP operating system with a new
-                                        version</p>
+                                    <p class="fpp-card__subtitle" id="osCardSubtitle">Upgrade the entire FPP operating
+                                        system with a new version.</p>
                                 </div>
                                 <div class="fpp-card__header-status">
                                     <span class="fpp-card__header-status-label">Current OS</span>
-                                    <span class="badge text-bg-secondary" id="osCurrentVersionBadge">--</span>
+                                    <span class="fpp-tag" id="osCurrentVersionBadge">--</span>
                                 </div>
                             </div>
 
-                            <?php if ($advancedInfoCollapse) { ?><details class="fpp-info-collapsible">
+                            <?php if ($advancedInfoCollapse) { ?><details class="fpp-info-collapsible" open>
                                 <summary class="fpp-info-collapsible__summary">
                                     <span><i class="fas fa-info-circle"></i> When to use &amp; What it does</span>
                                     <i class="fas fa-chevron-down fpp-info-collapsible__chevron"></i>
@@ -1228,27 +1325,28 @@
                                         <li>Experiencing OS issues</li>
                                         <li>Applying latest OS security patches</li>
                                     </ul>
-                                    <div class="fpp-alert fpp-alert--warning fpp-alert--compact"
-                                        style="margin-top: var(--fpp-sp-md); margin-bottom: var(--fpp-sp-sm);">
-                                        <i class="fas fa-exclamation-triangle"></i>
-                                        <span><strong>Warning:</strong> OS upgrade will reboot your system. Ensure no
-                                            shows are running.</span>
-                                    </div>
                                 </div>
                                 <div class="fpp-info-box fpp-info-box--info">
                                     <div class="fpp-info-box__title"><i class="fas fa-info-circle"></i> What it does
                                     </div>
                                     <p>Downloads a complete OS image and updates your current OS. Your media files are
                                         preserved, but backing up your configuration is strongly recommended.</p>
-                                    <span class="fpp-text-info-dark fpp-note"><strong>Important:</strong> This takes
+                                    <span class="fpp-note"><strong>Important:</strong> This takes
                                         15-30+ minutes and requires a reboot. <a href="backup.php">Backup
                                             first!</a></span>
-                                    <span class="fpp-text-info-dark fpp-note"><strong>Architecture Note:</strong>
+                                    <span class="fpp-note"><strong>Architecture Note:</strong>
                                         Switching between 32-bit and 64-bit is not supported from this screen. To
                                         change architectures, flash a fresh image.</span>
                                 </div>
                             </div>
                             <?php if ($advancedInfoCollapse) { ?></details><?php } ?>
+
+                            <!-- Reboot warning: shown only when an OS upgrade is the relevant action -->
+                            <div id="osRebootWarning" class="fpp-inline-warn" style="display: none;">
+                                <i class="fas fa-exclamation-triangle"></i>
+                                <span><strong>Warning:</strong> OS upgrade will reboot your system. Ensure no shows are
+                                    running.</span>
+                            </div>
 
                             <!-- Legacy OS warning (shown when checkbox is checked) -->
                             <div id="legacyOSWarning"
@@ -1267,6 +1365,9 @@
                                     disabled>
                                     <i class="fas fa-arrow-up"></i> Upgrade OS
                                 </button>
+                                <a class="fpp-btn fpp-btn--outline" href="backup.php">
+                                    <i class="fas fa-shield-alt"></i> Backup First
+                                </a>
                                 <button class="fpp-btn fpp-btn--secondary" id="osDownloadButton" onclick="DownloadOS();"
                                     disabled>
                                     <i class="fas fa-cloud-download-alt"></i> Download Only
@@ -1281,14 +1382,14 @@
                                 <div class="fpp-checkbox-options">
                                     <label class="fpp-checkbox-option">
                                         <input type="checkbox" id="allPlatforms" onChange="PopulateOSSelect();">
-                                        <span class="badge text-bg-primary">Adv</span>
+                                        <span class="fpp-tag fpp-tag--adv">Adv</span>
                                         Show All Platforms
                                         <img title='Show both BBB & Pi downloads' src='images/redesign/help-icon.svg'
                                             class='icon-help'>
                                     </label>
                                     <label class="fpp-checkbox-option">
                                         <input type="checkbox" id="LegacyOS" onChange="PopulateOSSelect();">
-                                        <span class="badge text-bg-primary">Adv</span>
+                                        <span class="fpp-tag fpp-tag--adv">Adv</span>
                                         Show Legacy OS
                                         <img title='Include historic OS releases in listing'
                                             src='images/redesign/help-icon.svg' class='icon-help'>
@@ -1311,11 +1412,13 @@
                 <?php if (isset($settings['uiLevel']) && $settings['uiLevel'] >= 1) { ?>
                     <!-- Revert to Previous Commit Card -->
                     <div class="card fpp-card fpp-card--accent fpp-card--accent-neutral fpp-card--compact fpp-card--inline">
+                        <div class="fpp-card__icon fpp-card__icon--neutral">
+                            <i class="fas fa-history"></i>
+                        </div>
                         <div class="fpp-card__content">
                             <h3 class="fpp-card__title">
-                                <i class="fas fa-history"></i>
                                 Revert to Previous Commit
-                                <span class="badge text-bg-secondary">Advanced</span>
+                                <span class="fpp-tag">Advanced</span>
                             </h3>
                             <p class="fpp-card__subtitle">Need to roll back changes? Use the changelog to revert to a
                                 previous git commit while keeping your configuration.</p>

--- a/www/about.php
+++ b/www/about.php
@@ -777,12 +777,14 @@
                         osUpgradeAvailable = checkForNewerOS();
                     }
                     checkUpgradeRecommendation();
+                    updateOSNoImages();
                 }).fail(function () {
                     // API failed - still show any locally downloaded OS files
                     if (!forceOsUpgradeTest) {
                         osUpgradeAvailable = checkForNewerOS();
                     }
                     checkUpgradeRecommendation();
+                    updateOSNoImages();
                 });
 
             <?php } ?>
@@ -1011,6 +1013,16 @@
         function syncOSCardEngaged() {
             var os = $('#osSelect').val();
             $('#osCard').toggleClass('is-engaged', os !== '' && os != null);
+        }
+
+        // Show an explanatory note when the dropdown has no selectable image (only
+        // the placeholder), so a blank select reads as "nothing available for this
+        // platform yet" instead of looking broken.
+        function updateOSNoImages() {
+            var selectable = $('#osSelect option').filter(function () {
+                return this.value !== '';
+            }).length;
+            $('#osNoImages').toggle(selectable === 0);
         }
 
         function initFaqAccordion() {
@@ -1407,6 +1419,16 @@
                                     onclick="ViewOSReleaseNotes();" disabled>
                                     <i class="fas fa-file-alt"></i> Release Notes
                                 </button>
+                            </div>
+
+                            <!-- Empty state: shown when no OS image matches this platform, so a
+                                 blank dropdown reads as an explanation instead of a dead end. -->
+                            <div id="osNoImages"
+                                class="fpp-alert fpp-alert--info fpp-alert--compact fpp-alert--mb-md"
+                                style="display: none;">
+                                <i class="fas fa-info-circle"></i>
+                                <span>No compatible OS image was found for this platform right now. New
+                                    images appear here once a release is available for your board.</span>
                             </div>
 
                             <?php if (isset($settings['uiLevel']) && $settings['uiLevel'] >= 1) { ?>

--- a/www/about.php
+++ b/www/about.php
@@ -681,6 +681,7 @@
 
                 $.get(allPlatforms, function (data) {
                     var devMode = (settings['uiLevel'] && (parseInt(settings['uiLevel']) == 3));
+                    var isAdvanced = (settings['uiLevel'] && (parseInt(settings['uiLevel']) >= 1));
                     var showLegacy = $('#LegacyOS').is(':checked');
                     // Regex to match versions below 9.0 (With N-1 - update this yearly)
                     var legacyVersionRegex = /[-_]v?[0-8]\./i;
@@ -703,9 +704,16 @@
                                 continue;
                             }
 
-                            // Only show nightly OS builds in Dev mode
-                            var isNightlyBuild = file["prerelease"] === true;
+                            // Nightly builds are bleeding-edge -- Developer mode only.
+                            // Other prereleases (alpha/beta) are fine in Advanced+.
+                            // GitHub flags alpha/beta AND nightly as prerelease, so
+                            // distinguish nightly by name rather than the flag alone.
+                            var isNightlyBuild = /nightly/i.test(file["filename"]);
                             if (isNightlyBuild && !devMode) {
+                                continue;
+                            }
+                            var isPrerelease = file["prerelease"] === true;
+                            if (isPrerelease && !isNightlyBuild && !isAdvanced) {
                                 continue;
                             }
 

--- a/www/changelog.php
+++ b/www/changelog.php
@@ -1,113 +1,169 @@
 <!DOCTYPE html>
 <html lang="en">
-<?php
-include 'common/htmlMeta.inc';
-require_once 'config.php';
-require_once 'common.php';
-
-
-//ini_set('display_errors', 'On');
-error_reporting(E_ALL);
-
-$fpp_version = "v" . getFPPVersion();
-
-$limit = 200;
-if (isset($_GET['limit']))
-    $limit = intval($_GET['limit']);
-
-$logCmd = "git --git-dir=" . dirname(dirname(__FILE__)) . "/.git/ log --pretty=format:'%h - %<|(30)%an - %<|(46)%ai - %s%d' | cut -c1-140 | head -$limit";
-
-$git_log = "";
-
-$currentVersion = "";
-if ($uiLevel >= 1) {
-    $currentBranch = "";
-    $cmd = "git --git-dir=" . dirname(dirname(__FILE__)) . "/.git/ branch -a | grep '^*' | awk '{print \$2}' | sed -e 's/[^a-zA-Z0-9\.]*//'";
-    exec($cmd, $output, $return_val);
-    if ($return_val == 0) {
-        $currentBranch = $output[0];
-    }
-    unset($output);
-
-    $output = "";
-    if ($currentBranch != 'HEAD') {
-        $cmd = $logCmd . " | tee -a " . $mediaDirectory . "/tmp/gitlog";
-        exec($cmd, $output, $return_val);
-    } else {
-        $cmd = "cat " . $mediaDirectory . "/tmp/gitlog";
-        exec($cmd, $output, $return_val);
-    }
-
-    $cmd = "git --git-dir=" . dirname(dirname(__FILE__)) . "/.git/ log | head -1 | awk '{print \$2}'";
-    exec($cmd, $output2, $return_val);
-    $currentVersion = $output2[0];
-
-    if ($return_val == 0) {
-        foreach ($output as $line) {
-            $line = htmlspecialchars($line);
-            $thisVersion = preg_replace('/^([a-zA-Z0-9-]+).*/', '$1', $line);
-            $line = preg_replace('/^([a-zA-Z0-9-]+)/', "<a href='#' onClick='DisplayVersionOptions(\"$1\"); return false;'>$1</a>", $line);
-
-            if (str_starts_with($currentVersion, $thisVersion)) {
-                $git_log .= "--> " . $line . '<br/>';
-            } else {
-                $git_log .= "    " . $line . '<br/>';
-            }
-        }
-    }
-    unset($output);
-} else {
-    exec($logCmd, $output, $return_val);
-    $git_log = implode('<br/>', $output);
-}
-unset($output);
-
-?>
 
 <head>
-    <?php include 'common/menuHead.inc'; ?>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <?php
+    include 'common/htmlMeta.inc';
+    require_once 'config.php';
+    require_once 'common.php';
+    include 'common/menuHead.inc';
+
+    $limit = 200;
+if (isset($_GET['limit'])) {
+    $limit = intval($_GET['limit']);
+    // Clamp to a sane range: a zero/negative limit would build "head -0"/"head --5"
+    // and silently yield an empty log instead of history.
+    if ($limit < 1 || $limit > 2000)
+        $limit = 200;
+}
+
+$gitDir = dirname(dirname(__FILE__)) . "/.git/";
+
+// Unit-separator (0x1f) delimited fields so PHP can split reliably:
+//   hash \x1f author \x1f author-date \x1f subject
+$logFormat = '%h%x1f%an%x1f%ai%x1f%s';
+$logCmd = "git --git-dir=" . $gitDir . " log --pretty=format:'" . $logFormat . "' | head -" . $limit;
+
+// Full SHA of the checked-out commit, so we can flag the "Current" row.
+$currentVersion = "";
+exec("git --git-dir=" . $gitDir . " rev-parse HEAD 2>/dev/null", $headOut, $rv);
+if ($rv == 0 && isset($headOut[0])) {
+    $currentVersion = trim($headOut[0]);
+}
+unset($headOut);
+
+// Current branch name ("HEAD" when detached, e.g. after a revert).
+$currentBranch = "";
+exec("git --git-dir=" . $gitDir . " rev-parse --abbrev-ref HEAD 2>/dev/null", $brOut, $rv);
+if ($rv == 0 && isset($brOut[0])) {
+    $currentBranch = trim($brOut[0]);
+}
+unset($brOut);
+
+$clickable = ($uiLevel >= 1);
+
+// Fetch the log. On a real branch we cache it to disk so a detached HEAD
+// (post-revert) can still show the full branch history instead of only the
+// commits up to the reverted point. The cache filename is versioned so a stale
+// cache written by an older FPP (different log format) is never misparsed.
+$cacheFile = $mediaDirectory . "/tmp/changelog-cache";
+$lines = array();
+if ($clickable) {
+    if ($currentBranch != 'HEAD') {
+        exec($logCmd . " | tee " . $cacheFile, $lines, $rv);
+    } else {
+        exec("cat " . $cacheFile . " 2>/dev/null", $lines, $rv);
+        // No (new-format) cache yet -- e.g. reverted right after an upgrade before
+        // ever loading this page on a branch. Fall back to a live log so we show
+        // history up to the current point rather than an empty page.
+        if (count($lines) == 0) {
+            exec($logCmd, $lines, $rv);
+        }
+    }
+} else {
+    exec($logCmd, $lines, $rv);
+}
+
+// Build the commit rows.
+$commitRows = "";
+$commitCount = 0;
+foreach ($lines as $line) {
+    if (trim($line) === "")
+        continue;
+    $parts = explode("\x1f", $line);
+    if (count($parts) < 4)
+        continue;
+
+    list($hash, $author, $adate, $subject) = $parts;
+    $hashEsc = htmlspecialchars($hash);
+    $shortHash = htmlspecialchars(substr($hash, 0, 7));
+    $authorEsc = htmlspecialchars($author);
+    $subjectEsc = htmlspecialchars($subject);
+    $dateShort = htmlspecialchars(substr(trim($adate), 0, 10));
+    $isCurrent = ($currentVersion !== "" && str_starts_with($currentVersion, $hash));
+    $commitCount++;
+
+    $rowClass = "fpp-commit";
+    if ($clickable)
+        $rowClass .= " fpp-commit--clickable";
+    if ($isCurrent)
+        $rowClass .= " fpp-commit--current";
+
+    // Row carries its data so the modal can show the message without escaping
+    // it into inline handlers. htmlspecialchars escapes quotes for attributes.
+    $dataAttrs = ' data-sha="' . $hashEsc . '" data-msg="' . $subjectEsc . '"';
+    $onclick = $clickable ? ' onclick="openVersionModalFromRow(this);"' : "";
+
+    $currentBadge = $isCurrent
+        ? ' <span class="badge rounded-pill text-bg-success ms-2"><i class="fas fa-circle-dot"></i> Current</span>'
+        : '';
+
+    $actions = "";
+    if ($clickable) {
+        $actions = '<div class="fpp-commit__actions" onclick="event.stopPropagation();">'
+            . '<a class="fpp-commit__action" href="https://github.com/FalconChristmas/fpp/commit/' . $hashEsc . '" target="_blank" title="View change on GitHub"><i class="fas fa-up-right-from-square"></i></a>'
+            . '<span class="fpp-commit__action" title="Revert to this version" onclick="event.stopPropagation(); openVersionModalFromRow(this.closest(\'.fpp-commit\'));"><i class="fas fa-clock-rotate-left"></i></span>'
+            . '</div>';
+    }
+
+    $commitRows .= '<div class="' . $rowClass . '"' . $dataAttrs . $onclick . '>'
+        . '<i class="fas fa-user-circle fpp-commit__avatar"></i>'
+        . '<div class="fpp-commit__body">'
+        . '<div class="fpp-commit__msg"><span class="fpp-commit__subject">' . $subjectEsc . '</span>' . $currentBadge . '</div>'
+        . '<div class="fpp-commit__meta"><span class="fpp-sha-chip">' . $shortHash . '</span>'
+        . ' &nbsp;&middot;&nbsp; ' . $authorEsc
+        . ' &nbsp;&middot;&nbsp; committed ' . $dateShort . '</div>'
+        . '</div>'
+        . $actions
+        . '</div>';
+}
+unset($lines);
+    ?>
     <title>FPP - ChangeLog</title>
     <script>
-        function CloseUpgradeDialog() {
-            $('#upgradePopup').fppDialog('close');
-            location.reload();
+        // Selected commit for the version modal's Revert action.
+        var clSelectedVersion = null;
+
+        function openVersionModalFromRow(rowEl) {
+            if (!rowEl) return;
+            openVersionModal(rowEl.getAttribute('data-sha'), rowEl.getAttribute('data-msg'));
         }
 
-        function UpgradeDone() {
-            $('#closeDialogButton').show();
+        function openVersionModal(version, message) {
+            clSelectedVersion = version;
+            $('#versionModalSha').text(version);
+            $('#versionModalMsg').text(message || '');
+            $('#versionModalGithub').attr('href', 'https://github.com/FalconChristmas/fpp/commit/' + version);
+            bootstrap.Modal.getOrCreateInstance(document.getElementById('versionModal')).show();
         }
 
-        function DisplayVersionOptions(version) {
-            $('#dialog-confirm').fppDialog({
-                resizeable: false,
-                width: 400,
-                modal: true,
-                buttons: {
-                    "View Change": {
-                        class: 'btn-success', click: function () {
-                            $(this).fppDialog("close");
-                            let url = "https://github.com/FalconChristmas/fpp/commit/" + version
-                            window.open(url, '_blank').focus();
-                        }
-                    },
-                    "Revert to this Change": {
-                        click: function () {
-                            $(this).fppDialog("close");
-                            GitCheckoutVersion(version)
-                        }
-                    }
-                }
-            });
+        function RevertToSelectedVersion() {
+            bootstrap.Modal.getInstance(document.getElementById('versionModal')).hide();
+            GitCheckoutVersion(clSelectedVersion);
         }
 
         function GitCheckoutVersion(version) {
-            $('#upgradePopup').fppDialog({ height: 600, width: 900, title: "Switching to version: " + version, dialogClass: 'no-close' });
-            $('#upgradePopup').fppDialog("moveToTop");
-            $('#upgradeText').html('');
+            // Modern streaming dialog (matches about.php); its Close button
+            // handles CloseModalDialog + page reload for us.
+            DisplayProgressDialog('gitCheckout', 'Switching to version: ' + version);
+            StreamURL('gitCheckoutVersion.php?wrapped=1&version=' + version, 'gitCheckoutText', 'GitCheckoutDone');
+        }
 
-            StreamURL('gitCheckoutVersion.php?wrapped=1&version=' + version, 'upgradeText', 'UpgradeDone');
+        function GitCheckoutDone() {
+            $('#gitCheckoutCloseButton').prop('disabled', false);
+            EnableModalDialogCloseButton('gitCheckout');
+        }
 
+        // Live filter over the rendered commit rows (message, author, or SHA).
+        function filterCommits() {
+            var q = $('#commitFilter').val().toLowerCase();
+            var shown = 0;
+            $('#commitList .fpp-commit').each(function () {
+                var hit = $(this).text().toLowerCase().indexOf(q) !== -1;
+                $(this).toggle(hit);
+                if (hit) shown++;
+            });
+            $('#shownCount').text(shown);
         }
     </script>
 </head>
@@ -117,31 +173,99 @@ unset($output);
         <?php
         $activeParentMenuItem = 'help';
         include 'menu.inc'; ?>
-        <div class="mainContainer container">
+        <div class="mainContainer">
             <h1 class="title">ChangeLog</h1>
             <div class="pageContent">
-                <?
-                if ($uiLevel >= 1) {
-                    echo "<b>Click a SHA1 hash to jump to that previous version of code</b><br>";
-                }
-                ?>
-                <pre><?
-                if ($uiLevel >= 1) {
-                    echo "    <a href='#' onClick='DisplayVersionOptions(\"HEAD\"); return false;'>HEAD</a>     - (Pull in changes and switch to latest version in this branch)\n";
-                }
-                ?><? echo $git_log; ?></pre>
+
+                <?php if ($clickable) { ?>
+                    <!-- Advanced users can revert; explain what clicking a commit does. -->
+                    <div class="fpp-banner fpp-banner--info mb-3">
+                        <div class="fpp-banner__icon"><i class="fas fa-hand-pointer"></i></div>
+                        <div class="fpp-banner__content">
+                            <div class="fpp-banner__title">Jump to any version</div>
+                            <p class="fpp-banner__message">
+                                Click a commit to view its exact changes on GitHub or roll your system
+                                back to that point &mdash; your configuration and media are preserved.
+                                The highlighted row is the version you're running now.
+                            </p>
+                        </div>
+                    </div>
+                <?php } ?>
+
+                <div class="card fpp-card p-0 overflow-hidden">
+
+                    <!-- Toolbar: live filter + current branch -->
+                    <div class="d-flex flex-wrap align-items-center gap-3 p-3 border-bottom">
+                        <div class="input-group flex-grow-1" style="min-width: 220px;">
+                            <span class="input-group-text"><i class="fas fa-search"></i></span>
+                            <input type="text" id="commitFilter" class="form-control"
+                                placeholder="Filter by message, author, or SHA&hellip;" oninput="filterCommits();">
+                        </div>
+                        <?php if ($currentBranch != "") { ?>
+                            <span class="fpp-text-muted d-inline-flex align-items-center gap-1 text-nowrap">
+                                <i class="fas fa-code-branch"></i> Branch: <strong><?= htmlspecialchars($currentBranch) ?></strong>
+                            </span>
+                        <?php } ?>
+                        <?php if ($clickable) { ?>
+                            <!-- Pull in changes and switch to the latest commit on this branch.
+                                 Also lets a reverted (detached) system return to the branch tip. -->
+                            <button type="button" class="fpp-btn fpp-btn--outline text-nowrap"
+                                title="Pull in changes and switch to the latest version on this branch"
+                                onclick="GitCheckoutVersion('HEAD');">
+                                <i class="fas fa-cloud-arrow-down"></i> Update to Latest
+                            </button>
+                        <?php } ?>
+                    </div>
+
+                    <!-- Commit list -->
+                    <div id="commitList">
+                        <?php
+                        if ($commitCount > 0) {
+                            echo $commitRows;
+                        } else {
+                            echo '<div class="p-4 text-center fpp-text-muted">No commit history available.</div>';
+                        }
+                        ?>
+                    </div>
+
+                    <div class="p-3 border-top">
+                        <span class="fpp-text-muted">Showing <strong id="shownCount"><?= $commitCount ?></strong>
+                            commit<?= $commitCount == 1 ? '' : 's' ?><?php if ($commitCount >= $limit) echo ' (limited to ' . $limit . ')'; ?></span>
+                    </div>
+                </div>
+
             </div>
         </div>
-        <?php include 'common/footer.inc'; ?>
     </div>
-    <div id="dialog-confirm" style="display: none">
-        What action would you like to take?
-    </div>
-    <div id='upgradePopup' title='Switch Version' style="display: none">
-        <textarea style='width: 99%; height: 94%;' disabled id='upgradeText' title="Upgrade Text">
-    </textarea>
-        <input id='closeDialogButton' type='button' class='buttons' value='Close' onClick='CloseUpgradeDialog();'
-            style='display: none;'>
+    <?php include 'common/footer.inc'; ?>
+
+    <!-- Version options modal (shown when a commit row is clicked) -->
+    <div class="modal fade" id="versionModal" tabindex="-1" aria-hidden="true">
+        <!-- modal-m: FPP sizes modals via .modal-X .modal-content max-width
+             (fpp.css forces .modal-dialog nearly full width on desktop). -->
+        <div class="modal-dialog modal-dialog-centered modal-m">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title d-flex align-items-center gap-2">
+                        <i class="fas fa-code-commit"></i> Commit
+                        <span class="fpp-sha-chip" id="versionModalSha"></span>
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-3" id="versionModalMsg"></p>
+                    <p class="fpp-text-muted mb-0">What would you like to do with this version?</p>
+                </div>
+                <div class="modal-footer">
+                    <a class="fpp-btn fpp-btn--outline" id="versionModalGithub" href="#" target="_blank">
+                        <i class="fas fa-up-right-from-square"></i> View change on GitHub
+                    </a>
+                    <button type="button" class="fpp-btn fpp-btn--warning" onclick="RevertToSelectedVersion();">
+                        <i class="fas fa-clock-rotate-left"></i> Revert to this version
+                    </button>
+                </div>
+            </div>
+        </div>
     </div>
 </body>
 

--- a/www/css/fpp-dark.css
+++ b/www/css/fpp-dark.css
@@ -469,15 +469,10 @@
     color: #fbbf24;
 }
 
-/* FAQ accordion */
+/* FAQ accordion: flat divider list (matches the light-theme restyle) rather
+   than carded rows -- only the bottom divider is themed. */
 [data-bs-theme="dark"] .fpp-faq__item {
-    background: var(--bs-secondary-bg);
-    border-color: var(--bs-border-color);
-}
-
-[data-bs-theme="dark"] .fpp-faq__item--open {
-    border-color: var(--bs-primary);
-    background: var(--bs-tertiary-bg);
+    border-bottom-color: var(--bs-border-color);
 }
 
 /* ------------------------------------------------------------- */

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -1987,6 +1987,16 @@
 	background: var(--fpp-border-dark);
 }
 
+/* Once the user actively engages a faded (non-recommended) card -- e.g. picks an
+   OS image from the dropdown to reinstall -- restore full opacity so its controls,
+   especially the action button, read as normal and clickable rather than dimmed.
+   Parent opacity can't be raised by a child, so the lift has to happen here on the
+   card. The accent bar stays neutral, so the card is "usable" without being
+   promoted to the amber "recommended" treatment. */
+.fpp-card.is-disabled.is-engaged {
+	opacity: 1;
+}
+
 /* ==========================================================================
    UPDATE STATUS DOT
    Quiet inline "update available" indicator — reads as status next to a value

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -2693,3 +2693,118 @@
 	font-weight: var(--fpp-fw-bold);
 	color: var(--fpp-text-primary);
 }
+
+/* ==========================================================================
+   CHANGELOG / COMMIT LIST
+   A flex-row commit history (used by changelog.php). Each row is one commit:
+   avatar | message + meta | hover actions. No table columns to misalign.
+   ========================================================================== */
+.fpp-commit {
+	display: flex;
+	align-items: center;
+	gap: var(--fpp-sp-md);
+	padding: 12px 16px;
+	border-bottom: 1px solid var(--fpp-border-light);
+	transition: background var(--fpp-transition-fast);
+}
+
+.fpp-commit:last-child {
+	border-bottom: none;
+}
+
+.fpp-commit--clickable {
+	cursor: pointer;
+}
+
+.fpp-commit--clickable:hover {
+	background: var(--fpp-bg-hover);
+}
+
+/* Currently checked-out commit: success left-rail + subtle tint */
+.fpp-commit--current {
+	background: var(--fpp-success-light);
+	box-shadow: inset 3px 0 0 0 var(--bs-success);
+}
+
+.fpp-commit--current.fpp-commit--clickable:hover {
+	background: var(--fpp-success-light);
+}
+
+.fpp-commit__avatar {
+	flex-shrink: 0;
+	font-size: 1.6rem;
+	color: var(--fpp-text-muted);
+}
+
+.fpp-commit__body {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.fpp-commit__msg {
+	display: flex;
+	align-items: center;
+	gap: var(--fpp-sp-sm);
+	min-width: 0;
+	color: var(--fpp-text-primary);
+	font-weight: var(--fpp-fw-semibold);
+}
+
+/* Only the subject text ellipsizes; the "Current" badge stays a full-size
+   sibling so a long subject can't clip the active-version indicator. */
+.fpp-commit__subject {
+	min-width: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.fpp-commit__msg .badge {
+	flex-shrink: 0;
+}
+
+.fpp-commit__meta {
+	font-size: var(--fpp-fs-sm);
+	color: var(--fpp-text-muted);
+	margin-top: 2px;
+}
+
+.fpp-sha-chip {
+	font-family: var(--bs-font-monospace, monospace);
+	padding: 1px 7px;
+	border-radius: var(--fpp-radius-sm);
+	background: var(--fpp-bg-disabled);
+	color: var(--fpp-text-secondary);
+}
+
+/* Right-side actions: quiet until row hover, so they don't clutter the log */
+.fpp-commit__actions {
+	flex-shrink: 0;
+	display: flex;
+	gap: 4px;
+	opacity: 0;
+	transition: opacity var(--fpp-transition-fast);
+}
+
+.fpp-commit:hover .fpp-commit__actions {
+	opacity: 1;
+}
+
+.fpp-commit__action {
+	width: 32px;
+	height: 32px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: var(--fpp-radius-md);
+	color: var(--fpp-text-secondary);
+	border: 1px solid var(--fpp-border);
+	background: var(--fpp-bg-card);
+	cursor: pointer;
+}
+
+.fpp-commit__action:hover {
+	color: var(--fpp-text-primary);
+	border-color: var(--fpp-border-dark);
+	text-decoration: none;
+}

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -1650,21 +1650,16 @@
 	transform: rotate(180deg);
 }
 
-/* Grid-based reveal (0fr -> 1fr) rather than a fixed max-height, so answers of
-   any length expand fully without a magic-number clip and animate evenly. */
+/* Collapsed by default; the accordion JS animates max-height to the answer's
+   exact scrollHeight on open, so answers of any length expand fully without a
+   magic-number clip and the timing matches the real content height. */
 .fpp-faq__answer {
-	display: grid;
-	grid-template-rows: 0fr;
-	transition: grid-template-rows var(--fpp-transition-normal);
-}
-
-.fpp-faq__item--open .fpp-faq__answer {
-	grid-template-rows: 1fr;
+	max-height: 0;
+	overflow: hidden;
+	transition: max-height var(--fpp-transition-normal);
 }
 
 .fpp-faq__answer-inner {
-	overflow: hidden;
-	min-height: 0;
 	padding: 0 0 var(--fpp-sp-sm) 0;
 	font-size: 13.5px;
 	color: var(--fpp-text-secondary);

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -1166,12 +1166,11 @@
 	color: #003087;
 	border: none;
 	border-radius: var(--fpp-radius-pill);
-	padding: 8px var(--fpp-sp-xl);
-	font-size: var(--fpp-fs-base);
+	padding: 7px 16px;
+	font-size: 13px;
 	font-weight: var(--fpp-fw-bold);
 	cursor: pointer;
 	transition: all var(--fpp-transition-fast);
-	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
 	text-decoration: none;
 }
 
@@ -1214,53 +1213,26 @@
    ========================================================================== */
 .fpp-banner {
 	display: flex;
-	align-items: center;
-	gap: var(--fpp-sp-md);
-	padding: var(--fpp-sp-sm) var(--fpp-sp-lg);
+	align-items: flex-start;
+	gap: 14px;
+	padding: 14px 18px;
+	border: 1px solid var(--fpp-border);
 	border-radius: var(--fpp-radius-lg);
-	margin-bottom: var(--fpp-sp-md);
-}
-
-.fpp-banner--success {
-	background: linear-gradient(
-		135deg,
-		var(--bs-success) 0%,
-		var(--fpp-success-dark) 100%
-	);
-	color: white;
-}
-
-.fpp-banner--warning {
-	background: linear-gradient(
-		135deg,
-		var(--bs-danger) 0%,
-		var(--fpp-danger-dark) 100%
-	);
-	color: white;
-}
-
-.fpp-banner--info {
-	background: var(--fpp-success-light);
-	border: 1px solid var(--bs-success);
-	color: var(--fpp-text-primary);
-}
-
-.fpp-banner--danger {
-	background: linear-gradient(135deg, #b91c1c 0%, #7f1d1d 100%);
-	color: white;
-	border: 2px solid #450a0a;
+	background: var(--fpp-bg-card);
+	margin-bottom: 12px;
 }
 
 .fpp-banner__icon {
-	width: 32px;
-	height: 32px;
-	border-radius: var(--fpp-radius-xl);
+	width: 36px;
+	height: 36px;
+	border-radius: var(--fpp-radius-lg);
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	font-size: 1rem;
 	flex-shrink: 0;
-	background: rgba(255, 255, 255, 0.2);
+	background: var(--fpp-bg-disabled);
+	color: var(--fpp-text-secondary);
 }
 
 .fpp-banner__content {
@@ -1268,14 +1240,93 @@
 }
 
 .fpp-banner__title {
+	font-size: 15px;
 	font-weight: var(--fpp-fw-semibold);
-	margin-bottom: var(--fpp-sp-xs);
+	margin-bottom: 2px;
+	color: var(--fpp-text-primary);
 }
 
 .fpp-banner__message {
 	margin: 0;
-	opacity: 0.9;
-	font-size: var(--fpp-fs-base);
+	font-size: 13.5px;
+	color: var(--fpp-text-secondary);
+	line-height: 1.5;
+}
+
+/* Variants: soft tinted surface + a matching solid icon tile. */
+.fpp-banner--danger {
+	background: var(--fpp-danger-light);
+	border-color: var(--bs-danger);
+}
+
+.fpp-banner--danger .fpp-banner__icon {
+	background: var(--bs-danger);
+	color: #fff;
+}
+
+.fpp-banner--danger .fpp-banner__title {
+	color: var(--fpp-danger-dark);
+}
+
+/* Warning is the recommendation color in the coordinated upgrade layout. */
+.fpp-banner--warning {
+	background: var(--fpp-warning-light);
+	border-color: var(--bs-warning);
+}
+
+.fpp-banner--warning .fpp-banner__icon {
+	background: var(--bs-warning);
+	color: #000;
+}
+
+.fpp-banner--warning .fpp-banner__title {
+	color: var(--fpp-warning-text);
+}
+
+.fpp-banner--success {
+	background: var(--fpp-success-light);
+	border-color: var(--bs-success);
+}
+
+.fpp-banner--success .fpp-banner__icon {
+	background: var(--bs-success);
+	color: #fff;
+}
+
+.fpp-banner--success .fpp-banner__title {
+	color: var(--fpp-success-text);
+}
+
+.fpp-banner--info {
+	background: var(--fpp-info-light);
+	border-color: var(--fpp-info);
+}
+
+.fpp-banner--info .fpp-banner__icon {
+	background: var(--fpp-info);
+	color: #fff;
+}
+
+/* Slim single-line strip modifier — for a secondary severity note (e.g. the
+   End-of-Life alert) that needs its own color but must not compete with the
+   primary recommendation banner. */
+.fpp-banner--strip {
+	align-items: center;
+	gap: 10px;
+	padding: 8px 14px;
+}
+
+.fpp-banner--strip .fpp-banner__icon {
+	width: 24px;
+	height: 24px;
+	font-size: 12px;
+	border-radius: var(--fpp-radius-md);
+}
+
+.fpp-banner--strip .fpp-banner__message {
+	font-size: 13px;
+	line-height: 1.4;
+	color: var(--fpp-text-primary);
 }
 
 /* ==========================================================================
@@ -1446,8 +1497,8 @@
 	align-items: center;
 	gap: var(--fpp-sp-md);
 	padding: var(--fpp-sp-sm) var(--fpp-sp-md);
-	background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
-	border: 1px solid #86efac;
+	background: var(--fpp-bg-page);
+	border: 1px solid var(--fpp-border-light);
 	border-radius: var(--fpp-radius-lg);
 	margin-bottom: var(--fpp-sp-md);
 	font-family: var(--fpp-font-mono);
@@ -1468,21 +1519,19 @@
 }
 
 .fpp-version-indicator__to {
-	color: var(--bs-success);
+	color: var(--fpp-text-primary);
 	font-weight: var(--fpp-fw-semibold);
-	border: 1px solid #86efac;
+	border: 1px solid var(--fpp-border);
 }
 
 .fpp-version-indicator__arrow {
-	color: var(--bs-success);
+	color: var(--fpp-text-muted);
 	font-size: 1.1rem;
 }
 
 .fpp-version-indicator__label {
 	font-size: var(--fpp-fs-sm);
-	font-weight: var(--fpp-fw-semibold);
-	text-transform: uppercase;
-	letter-spacing: 0.05em;
+	font-weight: var(--fpp-fw-medium);
 	color: var(--fpp-text-muted);
 	margin-left: auto;
 }
@@ -1498,14 +1547,14 @@
 }
 
 .fpp-version-indicator--clickable:hover {
-	background: linear-gradient(135deg, #dcfce7 0%, #bbf7d0 100%);
-	border-color: #4ade80;
+	background: var(--fpp-bg-hover);
+	border-color: var(--fpp-border-dark);
 	transform: translateY(-1px);
-	box-shadow: 0 2px 8px rgba(34, 197, 94, 0.2);
+	box-shadow: var(--fpp-shadow-sm);
 }
 
 .fpp-version-indicator--clickable:hover .fpp-version-indicator__label {
-	color: var(--bs-success);
+	color: var(--fpp-text-primary);
 }
 
 .fpp-version-indicator--clickable:active {
@@ -1692,15 +1741,8 @@
 .fpp-card {
 	border: 1px solid var(--fpp-border);
 	border-radius: var(--fpp-radius-lg);
-	box-shadow: var(--fpp-shadow-sm);
-	padding: var(--fpp-sp-md);
-	margin-bottom: var(--fpp-sp-md);
-	transition: all var(--fpp-transition-normal);
-}
-
-.fpp-card:hover {
-	box-shadow: var(--fpp-shadow-md);
-	transform: translateY(-2px);
+	padding: 22px 24px;
+	margin-bottom: 18px;
 }
 
 .fpp-card__header {
@@ -1736,11 +1778,6 @@
 	justify-content: center;
 	font-size: 1.1rem;
 	flex-shrink: 0;
-	transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.fpp-card:hover .fpp-card__icon {
-	transform: scale(1.08);
 }
 
 .fpp-card__icon--success {
@@ -1764,9 +1801,9 @@
 }
 
 .fpp-card__title {
-	font-size: var(--fpp-fs-xl);
+	font-size: 18px;
 	font-weight: var(--fpp-fw-semibold);
-	margin: 0 0 var(--fpp-sp-xs) 0;
+	margin: 0 0 4px 0;
 	display: flex;
 	align-items: center;
 	gap: var(--fpp-sp-sm);
@@ -1774,8 +1811,8 @@
 }
 
 .fpp-card__subtitle {
-	font-size: var(--fpp-fs-base);
-	color: var(--fpp-text-muted);
+	font-size: var(--fpp-fs-sm);
+	color: var(--fpp-text-secondary);
 	margin: 0;
 }
 
@@ -1804,13 +1841,8 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	width: 4px;
-	height: 100%;
-	transition: width var(--fpp-transition-normal);
-}
-
-.fpp-card--accent:hover::before {
 	width: 6px;
+	height: 100%;
 }
 
 .fpp-card--accent-success::before {
@@ -1919,6 +1951,156 @@
 }
 
 /* ==========================================================================
+   COORDINATED CARD STATES
+   Drive the "coordinated semantic" upgrade layout: the recommended card adopts
+   the amber recommendation color end-to-end (accent bar + icon tile), while the
+   card that doesn't apply in the current state fades back. Toggled from JS.
+   ========================================================================== */
+.fpp-card.is-recommended.fpp-card--accent::before {
+	background: var(--bs-warning);
+}
+
+.fpp-card.is-recommended .fpp-card__icon {
+	background: var(--fpp-warning-light);
+	color: var(--bs-warning);
+}
+
+/* Coordinated: the "What it does" info tile shares the recommended card's amber
+   family instead of its default blue, so the color flows through the card. */
+.fpp-card.is-recommended .fpp-info-box--info {
+	background: var(--fpp-warning-light);
+	border-color: var(--fpp-warning-dark);
+}
+
+.fpp-card.is-recommended .fpp-info-box--info .fpp-info-box__title {
+	color: var(--fpp-warning-text);
+}
+
+/* The card that doesn't apply in the current state fades back. A flat opacity
+   is used deliberately: FPP's --fpp-text-muted token is nearly black, so muting
+   individual text colors would not read as "disabled". */
+.fpp-card.is-disabled {
+	opacity: 0.55;
+}
+
+.fpp-card.is-disabled.fpp-card--accent::before {
+	background: var(--fpp-border-dark);
+}
+
+/* ==========================================================================
+   UPDATE STATUS DOT
+   Quiet inline "update available" indicator — reads as status next to a value
+   without the weight of a full badge.
+   ========================================================================== */
+.fpp-upd-dot {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--fpp-sp-icon);
+	color: var(--fpp-text-muted);
+	font-size: var(--fpp-fs-sm);
+	font-weight: var(--fpp-fw-medium);
+}
+
+.fpp-upd-dot::before {
+	content: '';
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--bs-warning);
+	flex-shrink: 0;
+}
+
+.fpp-upd-dot--ok::before {
+	background: var(--fpp-gray);
+}
+
+.fpp-upd-dot--required::before {
+	background: var(--bs-danger);
+}
+
+.fpp-upd-dot--required {
+	color: var(--fpp-danger-dark);
+	font-weight: var(--fpp-fw-semibold);
+}
+
+/* ==========================================================================
+   QUIET TAGS
+   Low-key pill labels ("Advanced", "Adv", current-version) -- deliberately
+   softer than a solid Bootstrap .badge so they read as metadata, not alerts.
+   ========================================================================== */
+.fpp-tag {
+	display: inline-flex;
+	align-items: center;
+	padding: 2px 8px;
+	border-radius: var(--fpp-radius-sm);
+	font-size: 10.5px;
+	font-weight: var(--fpp-fw-bold);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	background: var(--fpp-border-light);
+	color: var(--fpp-text-muted);
+}
+
+/* Advanced-feature marker: quiet, italic, mixed-case. */
+.fpp-tag--adv {
+	font-style: italic;
+	text-transform: none;
+	letter-spacing: 0.02em;
+	font-weight: var(--fpp-fw-semibold);
+}
+
+/* Recommended marker: amber, matching the coordinated recommendation color. */
+.fpp-tag--recommended {
+	background: var(--bs-warning);
+	color: #000;
+}
+
+/* ==========================================================================
+   MAJOR-VERSION CALLOUT
+   Inline danger notice inside a card (e.g. "major version requires OS upgrade").
+   ========================================================================== */
+.fpp-major-callout {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--fpp-sp-sm);
+	padding: var(--fpp-sp-sm) var(--fpp-sp-md);
+	background: var(--fpp-danger-light);
+	border: 1px solid var(--bs-danger);
+	border-radius: var(--fpp-radius-md);
+	font-size: var(--fpp-fs-sm);
+	color: var(--fpp-danger-dark);
+	margin-bottom: var(--fpp-sp-md);
+}
+
+.fpp-major-callout i {
+	margin-top: 2px;
+	flex-shrink: 0;
+}
+
+/* ==========================================================================
+   INLINE WARNING STRIP
+   A left-accent note inside a card -- lighter than a full .fpp-alert box, so it
+   sits below content without competing (e.g. the OS reboot warning).
+   ========================================================================== */
+.fpp-inline-warn {
+	display: flex;
+	gap: var(--fpp-sp-sm);
+	padding: var(--fpp-sp-sm) 12px;
+	background: var(--fpp-warning-light);
+	border-left: 3px solid var(--bs-warning);
+	border-radius: var(--fpp-radius-sm);
+	font-size: var(--fpp-fs-sm);
+	color: var(--fpp-warning-text);
+	margin-bottom: var(--fpp-sp-md);
+}
+
+.fpp-inline-warn i {
+	color: var(--fpp-warning-dark);
+	margin-top: 2px;
+	flex-shrink: 0;
+}
+
+/* ==========================================================================
    FPP BUTTON COMPONENT
    Consistent button styling with variants
    ========================================================================== */
@@ -1997,11 +2179,10 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	padding: var(--fpp-sp-sm) 0;
+	padding: 8px 0;
 	border-bottom: 1px solid var(--fpp-border-light);
 	font-size: var(--fpp-fs-base);
-	gap: var(--fpp-sp-md);
-	min-height: 36px;
+	gap: 12px;
 }
 
 .fpp-row:last-child {
@@ -2010,6 +2191,7 @@
 
 .fpp-row__label {
 	color: var(--fpp-text-muted);
+	font-weight: var(--fpp-fw-medium);
 	flex-shrink: 0;
 }
 
@@ -2018,6 +2200,11 @@
 	color: var(--fpp-text-primary);
 	text-align: right;
 	word-break: break-word;
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+	justify-content: flex-end;
 }
 
 .fpp-row__value a {
@@ -2092,12 +2279,11 @@
 	background: var(--fpp-bg-card);
 	border: 1px solid var(--fpp-border);
 	border-radius: var(--fpp-radius-lg);
-	padding: var(--fpp-sp-md);
-	box-shadow: var(--fpp-shadow-sm);
+	padding: 20px 22px;
 }
 
 .fpp-info-panel__title {
-	font-size: var(--fpp-fs-lg);
+	font-size: 15px;
 	font-weight: var(--fpp-fw-semibold);
 	color: var(--fpp-text-primary);
 	margin: 0 0 var(--fpp-sp-md) 0;
@@ -2111,17 +2297,18 @@
 	width: 100%;
 }
 
-/* Resources list styling */
+/* Resources list styling: single row when it fits, wrapping to avoid clipping
+   on narrow-desktop / tablet-landscape widths above the 768px breakpoint. */
 .fpp-resources-list {
 	list-style: none;
 	padding: 0;
 	margin: 0;
 	display: flex;
 	flex-wrap: wrap;
-	gap: var(--fpp-sp-sm) var(--fpp-sp-xl);
+	gap: 8px 24px;
 }
 
-/* Spread modifier - evenly distributed across full width */
+/* Spread modifier - distribute items evenly across the row. */
 .fpp-resources-list--spread {
 	justify-content: space-between;
 }
@@ -2131,21 +2318,23 @@
 	align-items: center;
 	gap: var(--fpp-sp-sm);
 	font-size: var(--fpp-fs-base);
+	white-space: nowrap;
 }
 
 .fpp-resources-list li i {
-	width: 16px;
+	width: 14px;
 	text-align: center;
 	color: var(--fpp-text-muted);
 }
 
 .fpp-resources-list li a {
-	color: var(--fpp-primary);
+	color: var(--fpp-text-secondary);
 	text-decoration: none;
 }
 
 .fpp-resources-list li a:hover {
-	text-decoration: underline;
+	color: var(--fpp-primary);
+	text-decoration: none;
 }
 
 @media (max-width: 768px) {
@@ -2231,10 +2420,17 @@
 	color: var(--fpp-info-text);
 }
 
-/* Block-level note with top margin */
+/* Block-level small-print note */
 .fpp-note {
 	display: block;
-	margin-top: var(--fpp-sp-md);
+	margin-top: var(--fpp-sp-sm);
+	font-size: 12.5px;
+	line-height: 1.5;
+	color: var(--fpp-text-secondary);
+}
+
+.fpp-note strong {
+	color: var(--fpp-text-primary);
 }
 
 /* Badge size variants */

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -1650,17 +1650,21 @@
 	transform: rotate(180deg);
 }
 
+/* Grid-based reveal (0fr -> 1fr) rather than a fixed max-height, so answers of
+   any length expand fully without a magic-number clip and animate evenly. */
 .fpp-faq__answer {
-	max-height: 0;
-	overflow: hidden;
-	transition: max-height var(--fpp-transition-normal);
+	display: grid;
+	grid-template-rows: 0fr;
+	transition: grid-template-rows var(--fpp-transition-normal);
 }
 
 .fpp-faq__item--open .fpp-faq__answer {
-	max-height: 300px;
+	grid-template-rows: 1fr;
 }
 
 .fpp-faq__answer-inner {
+	overflow: hidden;
+	min-height: 0;
 	padding: 0 0 var(--fpp-sp-sm) 0;
 	font-size: 13.5px;
 	color: var(--fpp-text-secondary);

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -2002,6 +2002,42 @@
 }
 
 /* ==========================================================================
+   SKELETON LOADING
+   Placeholder shimmer for values fetched asynchronously (OS version, build,
+   kernel, current-OS tag). Reserves inline space so the real text swaps in
+   place instead of shifting the layout when the API responds.
+   ========================================================================== */
+.fpp-skeleton {
+	display: inline-block;
+	vertical-align: middle;
+	min-width: 4.5rem;
+	height: 0.9em;
+	border-radius: var(--fpp-radius-sm);
+	background: linear-gradient(90deg,
+			var(--fpp-border-light) 25%,
+			var(--fpp-border-dark) 37%,
+			var(--fpp-border-light) 63%);
+	background-size: 400% 100%;
+	animation: fpp-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes fpp-skeleton-shimmer {
+	0% {
+		background-position: 100% 50%;
+	}
+
+	100% {
+		background-position: 0 50%;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.fpp-skeleton {
+		animation: none;
+	}
+}
+
+/* ==========================================================================
    UPDATE STATUS DOT
    Quiet inline "update available" indicator — reads as status next to a value
    without the weight of a full badge.

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -712,7 +712,7 @@
 	margin-bottom: 0;
 }
 
-.fpp-health-recovery__inner > span {
+.fpp-health-recovery__inner>span {
 	flex: 1 1 240px;
 	min-width: 0;
 }
@@ -788,7 +788,7 @@
 }
 
 /* Ensure columns containing health checks don't overflow */
-.health-check-card .row > [class*='col-'] {
+.health-check-card .row>[class*='col-'] {
 	overflow: hidden;
 }
 
@@ -1136,6 +1136,7 @@
 }
 
 @keyframes pulse-heart {
+
 	0%,
 	100% {
 		transform: scale(1);
@@ -1350,7 +1351,7 @@
 	margin-bottom: var(--fpp-sp-md);
 }
 
-.fpp-info-collapsible > .fpp-info-grid {
+.fpp-info-collapsible>.fpp-info-grid {
 	margin-bottom: 0;
 	margin-top: var(--fpp-sp-sm);
 }
@@ -1383,7 +1384,7 @@
 	color: var(--fpp-text-primary);
 }
 
-.fpp-info-collapsible[open] > .fpp-info-collapsible__summary {
+.fpp-info-collapsible[open]>.fpp-info-collapsible__summary {
 	color: var(--fpp-primary);
 	border-color: var(--fpp-primary);
 }
@@ -1393,7 +1394,7 @@
 	transition: transform var(--fpp-transition-normal);
 }
 
-.fpp-info-collapsible[open] > .fpp-info-collapsible__summary .fpp-info-collapsible__chevron {
+.fpp-info-collapsible[open]>.fpp-info-collapsible__summary .fpp-info-collapsible__chevron {
 	transform: rotate(180deg);
 }
 
@@ -1517,7 +1518,7 @@
 	border-color: var(--fpp-border);
 }
 
-.fpp-version-indicator--current > i {
+.fpp-version-indicator--current>i {
 	color: var(--bs-success);
 	font-size: 1.1rem;
 }
@@ -1556,8 +1557,7 @@
 	box-shadow: 0 2px 8px rgba(245, 158, 11, 0.25);
 }
 
-.fpp-version-indicator--upgrade.fpp-version-indicator--clickable:hover
-	.fpp-version-indicator__label {
+.fpp-version-indicator--upgrade.fpp-version-indicator--clickable:hover .fpp-version-indicator__label {
 	color: #d97706;
 }
 
@@ -2374,9 +2374,11 @@
 .fpp-release-notes h3 {
 	font-size: var(--fpp-fs-lg);
 }
+
 .fpp-release-notes h4 {
 	font-size: var(--fpp-fs-md);
 }
+
 .fpp-release-notes h5 {
 	font-size: var(--fpp-fs-base);
 }

--- a/www/css/fpp-system-design.css
+++ b/www/css/fpp-system-design.css
@@ -1568,31 +1568,22 @@
 .fpp-faq {
 	display: flex;
 	flex-direction: column;
-	gap: var(--fpp-sp-sm);
 }
 
+/* Flat divider list (matches the upgrade mockup) rather than carded rows. */
 .fpp-faq__item {
-	border: 1px solid var(--fpp-border-light);
-	border-radius: var(--fpp-radius-lg);
-	overflow: hidden;
-	transition: all var(--fpp-transition-normal);
-	background: var(--fpp-bg-card);
+	border-bottom: 1px solid var(--fpp-border-light);
 }
 
-.fpp-faq__item:hover {
-	border-color: var(--fpp-border-dark);
-}
-
-.fpp-faq__item--open {
-	border-color: var(--fpp-primary);
-	background: var(--fpp-info-light);
+.fpp-faq__item:last-child {
+	border-bottom: none;
 }
 
 .fpp-faq__question {
-	padding: var(--fpp-sp-sm) var(--fpp-sp-md);
-	font-size: var(--fpp-fs-sm);
-	font-weight: var(--fpp-fw-semibold);
-	color: var(--fpp-text-secondary);
+	padding: var(--fpp-sp-sm) 0;
+	font-size: 14px;
+	font-weight: var(--fpp-fw-medium);
+	color: var(--fpp-text-primary);
 	cursor: pointer;
 	display: flex;
 	justify-content: space-between;
@@ -1600,15 +1591,8 @@
 	transition: all var(--fpp-transition-fast);
 }
 
-.fpp-faq__question:hover {
-	color: var(--fpp-text-primary);
-}
-
-.fpp-faq__item--open .fpp-faq__question {
-	color: var(--fpp-primary);
-}
-
 .fpp-faq__question i {
+	color: var(--fpp-text-muted);
 	font-size: var(--fpp-fs-xs);
 	transition: transform var(--fpp-transition-normal);
 }
@@ -1624,18 +1608,18 @@
 }
 
 .fpp-faq__item--open .fpp-faq__answer {
-	max-height: 200px;
+	max-height: 300px;
 }
 
 .fpp-faq__answer-inner {
-	padding: 0 var(--fpp-sp-md) var(--fpp-sp-sm) var(--fpp-sp-md);
-	font-size: var(--fpp-fs-sm);
-	color: var(--fpp-text-muted);
-	line-height: 1.5;
+	padding: 0 0 var(--fpp-sp-sm) 0;
+	font-size: 13.5px;
+	color: var(--fpp-text-secondary);
+	line-height: 1.55;
 }
 
 .fpp-faq__answer-inner strong {
-	color: var(--fpp-text-secondary);
+	color: var(--fpp-text-primary);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
Per Feedback Fixes #2613 — https://github.com/FalconChristmas/fpp/issues/2613

## Summary

Reworks the About page upgrade experience and the changelog into a cleaner, more coordinated design, plus a set of UX refinements.

## Changes

- **Redesigned the About upgrade UI** with a coordinated recommendation layout so the recommended action reads clearly.
- **Un-fade the OS card and button** once a user selects an image, and show an **empty-state note** when no OS image matches the current platform.
- **Gate nightly and other prereleases separately** in the OS image list.
- **Added skeleton shimmer** placeholders for version fields while they populate asynchronously.
- **Restyled the FAQ** as a flat divider list and fixed the reveal animation to drive `max-height` from JS instead of grid rows.
- **Redesigned the changelog** as a commit list with a revert modal.
- Normalized CSS formatting in `fpp-system-design.css`.