### PR TITLE
Remove SetRestartFlag call in MultiSyncEnableToggled (fix restart flag)

### DIFF
--- a/www/multisync.php
+++ b/www/multisync.php
@@ -2542,7 +2542,6 @@
         }
 
         function MultiSyncEnableToggled() {
-            SetRestartFlag();
         }
 
 


### PR DESCRIPTION
## Fix: FPPD restart warning banner not showing when toggling "Send MultiSync Packets"

### Problem

On the MultiSync settings page (`multisync.php`), toggling the "Send MultiSync Packets" checkbox failed to display the "Settings have changed. FPPD Restart Required" warning banner, even though the setting definition in `settings.json` had `"restart": 2`.

### Root Cause

The `MultiSyncEnableToggled()` callback at `multisync.php:2544` was calling `SetRestartFlag()` with no arguments:

```js
function MultiSyncEnableToggled() {
    SetRestartFlag();
}
```

The `PrintSettingCheckbox`-generated JavaScript already handles the restart flag correctly via `SetSetting('MultiSyncEnabled', value, 2, 0, ...)` — which calls `SetRestartFlag(2)` in its success handler. However, the subsequent callback then called `SetRestartFlag()` with `undefined`, overwriting the properly-set restart flag with `"undefined"` on the server. On page reload, the check `settings['restartFlag'] >= 1` evaluated to `false` (since `"undefined" >= 1` is `NaN >= 1` → `false`), so the banner never appeared.

### Fix

Removed the spurious `SetRestartFlag()` call from `MultiSyncEnableToggled()`, making it a no-op. The restart flag is already managed by the `SetSetting` infrastructure via the `"restart": 2` property in `settings.json` — the callback was redundantly (and incorrectly) trying to set it a second time.

Note: The empty function is intentionally retained to override the `reloadUI: 1` default behavior. Without a custom callback, `PrintSetting` would fall back to `reloadSettingsPage`, causing an unwanted full page reload on the dynamic multisync management page.

### Checklist

- [x] The "FPPD Restart Required" banner now appears when toggling "Send MultiSync Packets" on `multisync.php`
- [x] The existing behavior on `settings.php#settings-playback` (which already worked via the `"restart": 2` property) is unaffected
- [x] No unwanted page reloads on the multisync management page

### Additional Comments

This PR closes #2723.