### PR TITLE
feat(plugins): Add Grid View, Icons, Counters, and Improved Filtering

### DIFF
--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -2573,8 +2573,13 @@ table#fppSystemsTable > thead > tr:last-child > td {
 	background-image: none;
 }
 
+/* ---------- Section cards ---------- */
 .fppPluginSection {
 	display: none;
+}
+
+.fppPluginSection.fppPluginSectionVisible {
+	display: block;
 }
 
 .fppPluginEntry {
@@ -2582,9 +2587,21 @@ table#fppSystemsTable > thead > tr:last-child > td {
 	margin-bottom: 0.8em;
 }
 
+/* ---------- App-store card ---------- */
 .fppPluginEntryBackdrop {
 	position: relative;
-	padding-left: 2.5em;
+	background: var(--fpp-bg-card);
+	border: var(--fpp-card-border-compact, 2px solid var(--fpp-border));
+	border-left-width: 6px;
+	border-radius: 12px;
+	padding: 1.25em 1.5em 1em 2.5em;
+	transition: box-shadow 0.2s ease, border-color 0.2s ease;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.fppPluginEntryBackdrop:hover {
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+	border-color: var(--fpp-border-dark);
 }
 
 .fppPluginEntryBackdrop:before {
@@ -2593,18 +2610,19 @@ table#fppSystemsTable > thead > tr:last-child > td {
 	position: absolute;
 	background-color: gray;
 	border-radius: 4px;
-	width: 5px;
+	width: 6px;
 	top: 0.75em;
 	bottom: 0.75em;
-	left: 0.5em;
+	left: -1px;
 }
 
 .fppPluginEntry .fppPluginEntryFooter {
-	border-top: 1px solid #dbdfe4;
-	margin-right: 1px;
-	padding-top: 1em;
-	font-size: 0.9em;
+	border-top: 1px solid var(--fpp-border-light);
+	margin-right: 0;
+	padding-top: 0.75em;
+	font-size: 0.85em;
 	margin-bottom: 0;
+	margin-top: 0.5em;
 }
 
 .pluginFilterVisible,
@@ -2614,7 +2632,12 @@ table#fppSystemsTable > thead > tr:last-child > td {
 
 .fppPluginEntryFooter a {
 	text-decoration: none;
-	color: #717171;
+	color: var(--fpp-text-secondary);
+}
+
+.fppPluginEntryFooter a:hover {
+	color: var(--fpp-text-primary);
+	text-decoration: underline;
 }
 
 .fppPluginEntryActions .buttons {
@@ -2631,22 +2654,66 @@ table#fppSystemsTable > thead > tr:last-child > td {
 	margin-bottom: 0.5em;
 }
 
+/* ---------- Colored left border per section ---------- */
+#installedPlugins .fppPluginEntryBackdrop {
+	border-left-color: var(--bs-success);
+}
+
 #installedPlugins .fppPluginEntryBackdrop:before {
 	background-color: var(--bs-success);
+}
+
+#pluginTable .fppPluginEntryBackdrop {
+	border-left-color: #6b95ec;
 }
 
 #pluginTable .fppPluginEntryBackdrop:before {
 	background-color: #6b95ec;
 }
 
+#untestedPlugins .fppPluginEntryBackdrop {
+	border-left-color: #f2bc5f;
+}
+
 #untestedPlugins .fppPluginEntryBackdrop:before {
 	background-color: #f2bc5f;
+}
+
+#incompatiblePlugins .fppPluginEntryBackdrop {
+	border-left-color: var(--bs-danger);
 }
 
 #incompatiblePlugins .fppPluginEntryBackdrop:before {
 	background-color: var(--bs-danger);
 }
 
+/* ---------- Plugin avatar circle ---------- */
+.fppPluginAvatar {
+	flex-shrink: 0;
+	width: 2.5em;
+	height: 2.5em;
+	border-radius: 50%;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: #fff;
+	font-weight: 700;
+	font-size: 1.1em;
+	line-height: 1;
+	margin-right: 0.6em;
+	text-transform: uppercase;
+	user-select: none;
+	vertical-align: middle;
+}
+
+.fppPluginAvatarImg {
+	object-fit: cover;
+	background: var(--fpp-bg-card);
+	border: 1px solid var(--fpp-border-light);
+	font-size: inherit;
+}
+
+/* ---------- Compatibility status ---------- */
 .fppPluginEntryCompatibilityStatus {
 	margin-bottom: 1.5em;
 	font-size: 0.9em;
@@ -2654,16 +2721,232 @@ table#fppSystemsTable > thead > tr:last-child > td {
 	margin-top: 0.5em;
 }
 
+/* ---------- Section headers ---------- */
 .pluginsHeader {
 	margin-top: 2em;
 	margin-bottom: 1em;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	flex-wrap: wrap;
+	gap: 0.5em;
 }
 
 .pluginsHeader h2 {
 	margin: 0;
+}
+
+.pluginsHeader .pluginSectionCount {
+	display: inline-block;
+	background: var(--fpp-border-light);
+	color: var(--fpp-text-secondary);
+	font-size: 0.75em;
+	font-weight: 600;
+	padding: 0.15em 0.6em;
+	border-radius: 10px;
+	margin-left: 0.5em;
+	vertical-align: middle;
+	line-height: 1.6;
+}
+
+/* ---------- View toggle ---------- */
+.fppPluginViewLabel {
+	font-size: 0.85em;
+	color: var(--fpp-text-secondary);
+	align-self: center;
+	margin-right: 0.3em;
+}
+
+#pluginViewList.buttons,
+#pluginViewGrid.buttons {
+	width: auto;
+	padding: 0.3em 0.6em;
+	margin-bottom: 0;
+	font-size: 0.85em;
+}
+
+#pluginViewList.buttons.active,
+#pluginViewGrid.buttons.active {
+	background: var(--fpp-text-secondary);
+	color: var(--fpp-bg-card);
+	border-color: var(--fpp-text-secondary);
+}
+
+#pluginViewList.buttons.active:hover,
+#pluginViewGrid.buttons.active:hover {
+	opacity: 0.85;
+}
+
+/* ---------- Grid view ---------- */
+.fppPluginGridView .fppPluginSection {
+	display: grid !important;
+	grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+	gap: 0.8em;
+	padding: 0 0.3em;
+}
+
+@media (max-width: 575.98px) {
+	.fppPluginGridView .fppPluginSection {
+		grid-template-columns: 1fr;
+	}
+}
+
+.fppPluginGridView .fppPluginSection .pluginsHeader {
+	grid-column: 1 / -1;
+	margin-top: 1em;
+	margin-bottom: 0.5em;
+}
+
+.fppPluginGridView .fppPluginEntry {
+	margin-bottom: 0;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+.fppPluginGridView .fppPluginEntryBackdrop {
+	padding: 1em 1.5em 0.75em 2.5em;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+}
+
+.fppPluginGridView .fppPluginEntryBackdrop:before {
+	top: 0;
+	bottom: 0;
+	left: -1px;
+	border-radius: 4px 0 0 4px;
+}
+
+.fppPluginGridView .fppPluginEntry > .row {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	margin: 0;
+	width: 100%;
+}
+
+.fppPluginGridView .fppPluginEntry .col-lg-3,
+.fppPluginGridView .fppPluginEntry .col-lg-2,
+.fppPluginGridView .fppPluginEntry .col-lg,
+.fppPluginGridView .fppPluginEntry .col-lg-auto {
+	width: 100%;
+	max-width: 100%;
+	flex: none;
+	padding: 0;
+}
+
+.fppPluginGridView .fppPluginEntry .col-lg-3 {
+	margin-bottom: 0.4em;
+}
+
+.fppPluginGridView .fppPluginEntry .col-lg-2 {
+	margin-bottom: 0.2em;
+}
+
+.fppPluginGridView .fppPluginEntry .col-lg {
+	margin-bottom: 0.5em;
+	flex: 1;
+}
+
+.fppPluginGridView .fppPluginEntry .labelHeading {
+	font-size: 0.78em;
+}
+
+.fppPluginGridView .fppPluginEntry .pluginAuthor,
+.fppPluginGridView .fppPluginEntry .pluginDescription {
+	font-size: 0.88em;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
+}
+
+.fppPluginGridView .fppPluginEntry .col-lg-auto.fppPluginEntryActions {
+	margin-top: auto;
+	padding-top: 0.5em;
+}
+
+.fppPluginGridView .fppPluginEntryActions .buttons {
+	width: 100%;
+	margin-bottom: 0.3em;
+	font-size: 0.85em;
+	box-sizing: border-box;
+}
+
+.fppPluginGridView .fppPluginEntryActions .buttons:last-child {
+	margin-bottom: 0;
+}
+
+.fppPluginGridView .fppPluginEntryActions .pendingSpan {
+	width: 100%;
+}
+
+.fppPluginGridView .fppPluginEntryActions .pendingSpan .buttons {
+	width: 100%;
+}
+
+.fppPluginGridView .fppPluginEntry .fppPluginEntryFooter {
+	display: flex;
+	border-top: 1px solid var(--fpp-border-light);
+	margin: 0.6em 0 0 0;
+	padding: 0.6em 0 0 0;
+	font-size: 0.78em;
+	flex-wrap: wrap;
+	column-gap: 0.8em;
+	row-gap: 0.2em;
+	width: 100%;
+	--bs-gutter-x: 0;
+}
+
+.fppPluginGridView .fppPluginEntry .fppPluginEntryFooter .col-lg {
+	flex: 1 1 100%;
+	max-width: 100%;
+	padding: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.fppPluginGridView .fppPluginEntry .fppPluginEntryFooter .col-lg a {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	display: block;
+}
+
+.fppPluginGridView .fppPluginEntry .fppPluginEntryFooter .col-lg-auto {
+	flex: 0 0 auto;
+	padding: 0;
+}
+
+.fppPluginGridView .fppPluginEntryInstallStatus {
+	font-size: 0.85em;
+}
+
+.fppPluginGridView .fppPluginEntryUpdateStatus {
+	margin-bottom: 0.3em;
+	font-size: 0.85em;
+}
+
+.fppPluginGridView .fppPluginEntryCompatibilityStatus {
+	font-size: 0.78em;
+	padding: 0.4em 1.5em 0.3em 2.5em;
+	margin: 0;
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+}
+
+.fppPluginGridView .fppPluginEntry .fppPluginEntryCompatibilityStatus + .row {
+	font-size: 0.78em;
+	padding: 0.2em 1.5em 0.5em 2.5em;
+	margin: 0;
+	width: auto;
+	--bs-gutter-x: 0;
+	overflow-wrap: break-word;
+	word-wrap: break-word;
+}
+
+.fppPluginGridView .fppPluginEntry .fppPluginEntryCompatibilityStatus + .row .col {
+	padding: 0;
 }
 
 /* Plugin Header Indicators */

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -521,7 +521,13 @@
             var untestedVersion = versionSel.untested;
             var compatibleVersionClass = (compatibleVersion == -1) ? " has-previous-compatible-version" : '';
             html += '<div id="row-' + data.repoName + '" class="fppPluginEntry' + compatibleVersionClass + '"><div class="backdrop fppPluginEntryBackdrop"><div class="row">';
-            html += '<div class="col-lg-3"><h3 class="pluginTitle">' + data.name + '</h3>';
+            var avatarHtml = '';
+            if (data.icon && data.icon !== '') {
+                avatarHtml = '<img class="fppPluginAvatar fppPluginAvatarImg" src="' + data.icon + '" alt="" loading="lazy" onerror="this.style.display=\'none\'">';
+            } else {
+                avatarHtml = '<div class="fppPluginAvatar fppPluginAvatarInitial" style="background-color: ' + PluginColor(data.repoName) + '">' + PluginInitial(data.name) + '</div>';
+            }
+            html += '<div class="col-lg-3"><div class="d-flex align-items-center">' + avatarHtml + '<h3 class="pluginTitle">' + data.name + '</h3></div>';
 
             if (installed) {
                 html += '<div class="text-success fppPluginEntryInstallStatus"><i class="far fa-check-circle"></i> <b>Installed</b></div>';
@@ -532,8 +538,8 @@
             }
 
             html += '</div>';
-            html += '<div class="col-lg-2"><div class="labelHeading text-secondary">Author:</div><div class="text-primary">' + data.author + '</div></div>';
-            html += '<div class="col-lg"><div class="labelHeading text-secondary">Description:</div><div class="text-primary">' + data.description + '</div>';
+            html += '<div class="col-lg-2"><div class="labelHeading text-secondary">Author:</div><div class="text-primary pluginAuthor">' + data.author + '</div></div>';
+            html += '<div class="col-lg"><div class="labelHeading text-secondary">Description:</div><div class="text-primary pluginDescription">' + data.description + '</div>';
 
             html += '</div>';
             html += '<div class="col-lg-auto fppPluginEntryActions">';
@@ -712,7 +718,7 @@
                         success: function (data) {
                             $('html,body').css('cursor', 'auto');
                             LoadPlugin(data);
-                            $('#pluginInput').on('input', FilterPlugins);
+                            $('#pluginInput').off('input.pluginFilter').on('input.pluginFilter', function () { clearTimeout(filterDebounceTimer); filterDebounceTimer = setTimeout(FilterPlugins, 150); });
                             FilterPlugins();
 
                         },
@@ -789,6 +795,36 @@
                 alert('Invalid pluginInfo.json URL');
             }
         }
+        // Generate a consistent color from a plugin name for the avatar
+        function PluginColor(name) {
+            var hash = 0;
+            for (var i = 0; i < name.length; i++) {
+                hash = name.charCodeAt(i) + ((hash << 5) - hash);
+            }
+            var hue = Math.abs(hash) % 360;
+            return 'hsl(' + hue + ', 50%, 48%)';
+        }
+
+        function PluginInitial(name) {
+            return name.charAt(0);
+        }
+
+        function UpdatePluginSectionCounts() {
+            $('.fppPluginSection').each(function () {
+                var visible = $(this).find('.fppPluginEntry.pluginFilterVisible').length;
+                var total = $(this).find('.fppPluginEntry').length;
+                var badge = $(this).find('.pluginSectionCount');
+                if (badge.length === 0 && total > 0) {
+                    badge = $('<span class="pluginSectionCount"></span>');
+                    $(this).find('.pluginsHeader h2').append(badge);
+                }
+                if (total > 0) {
+                    badge.text(visible + '/' + total);
+                }
+            });
+        }
+
+        var filterDebounceTimer = null;
         function FilterPlugins() {
             if ($('#pluginInput').val().indexOf('://') > -1) {
                 $('.fppPluginInput').addClass('is-url');
@@ -804,7 +840,10 @@
                     $('.fppPluginSection').each(function () {
                         var filterMatchesInSection = 0;
                         $(this).children('.fppPluginEntry').each(function (index) {
-                            if ($(".pluginTitle", this).text().toLowerCase().indexOf(value) > -1) {
+                            var title = $(".pluginTitle", this).text().toLowerCase();
+                            var author = $(this).find('.pluginAuthor').text().toLowerCase();
+                            var desc = $(this).find('.pluginDescription').text().toLowerCase();
+                            if (title.indexOf(value) > -1 || author.indexOf(value) > -1 || desc.indexOf(value) > -1) {
                                 $(this).addClass('pluginFilterVisible');
                                 filterMatchesInSection++;
                             } else {
@@ -819,8 +858,25 @@
                     });
                 }
             }
-
+            UpdatePluginSectionCounts();
         }
+
+        function SetPluginView(view) {
+            if (view === 'grid') {
+                $('.plugindiv').addClass('fppPluginGridView');
+                $('#pluginViewList').removeClass('active');
+                $('#pluginViewGrid').addClass('active');
+            } else {
+                $('.plugindiv').removeClass('fppPluginGridView');
+                $('#pluginViewList').addClass('active');
+                $('#pluginViewGrid').removeClass('active');
+            }
+            try { localStorage.setItem('fppPluginView', view); } catch (e) {}
+        }
+
+        $(document).on('click', '#pluginViewList', function () { SetPluginView('list'); });
+        $(document).on('click', '#pluginViewGrid', function () { SetPluginView('grid'); });
+
         $(document).ready(function () {
             // Uninstall All and Reinstall All are bulk destructive actions, so only
             // expose them in Advanced UI mode or higher.
@@ -828,6 +884,11 @@
                 $('#uninstallAllBtn').removeClass('d-none');
                 $('#reinstallAllBtn').removeClass('d-none');
             }
+            // Restore last-used view
+            try {
+                var savedView = localStorage.getItem('fppPluginView');
+                if (savedView === 'grid') SetPluginView('grid');
+            } catch (e) {}
             GetInstalledPlugins();
 
         });
@@ -853,7 +914,6 @@
                                 <input type="text" id="pluginInput"
                                     class="form-control form-control-lg form-control-rounded has-shadow"
                                     placeholder="Find a Plugin or Enter a plugininfo.json URL" />
-
                             </div>
                             <div class="col-auto fppPluginInputActionCol">
                                 <div class="buttons btn-lg btn-rounded btn-outline-success" onClick='ManualLoadInfo();'>
@@ -862,6 +922,13 @@
                             </div>
                         </div>
 
+                    </div>
+                    <div class="d-flex justify-content-end gap-1 mt-2 mb-1">
+                        <span class="fppPluginViewLabel">View:</span>
+                        <div class="btn-group btn-group-sm" role="group">
+                            <button type="button" class="buttons btn-outline-secondary active" id="pluginViewList" title="List view"><i class="fas fa-list"></i></button>
+                            <button type="button" class="buttons btn-outline-secondary" id="pluginViewGrid" title="Grid view"><i class="fas fa-th-large"></i></button>
+                        </div>
                     </div>
                     <div class='plugindiv'>
 


### PR DESCRIPTION
# Plugin Manager UI Refresh — App Store Style Layout (Grid View, Icons, Counters, Improved Filtering)

## Summary

Overhauls the Plugin Manager page (`www/plugins.php`) with an app-store-like UI — including plugin avatar icons, as-you-type search across name/author/description, list-to-grid view toggle, section count badges, and an optional `icon` field in `pluginInfo.json`.

All existing functionality (install, uninstall, upgrade, check for updates, reinstall all, manual URL loading, private repo support) is preserved. No backend PHP changes were made.

---

## Changes

### `www/plugins.php`

- **Enhanced filtering** — `FilterPlugins()` now searches across plugin name, author, AND description (was name-only). Input is debounced at 150ms.
- **Plugin avatar initials** — Each card shows a colored circle with the first letter of the plugin name. Color is deterministic (HSL hash of `repoName`). When `pluginInfo.json` contains an `"icon"` field (URL), an `<img>` tag is used instead of the initial.
- **Section count badges** — Each section header shows a "visible/total" count (e.g. `3/5`) that updates live during search.
- **List / Grid view toggle** — A button pair below the search bar switches between the traditional single-column list and a responsive multi-column grid. Preference is persisted in `localStorage`.
- **Searchable classes** — `.pluginAuthor` and `.pluginDescription` class names added for the enhanced filter.
- **New helper functions** — `PluginColor(name)`, `PluginInitial(name)`, `SetPluginView(view)`, `UpdatePluginSectionCounts()`.

### `www/css/fpp.css`

- **Plugin cards** — Now use `--fpp-bg-card` background, 12px `border-radius`, subtle `box-shadow`, hover elevation, and a 6px colored left accent border.
- **Plugin avatar** — `.fppPluginAvatar` (2.5em circle, centered initial, white text). `.fppPluginAvatarImg` for image avatars (`object-fit: cover`, border).
- **Section headers** — `.pluginSectionCount` badge (pill, `--fpp-border-light` bg, secondary text).
- **View toggle** — `.fppPluginViewLabel` and active-state toggle buttons.
- **Grid view** — `.fppPluginGridView` scoped rules:
  - Responsive CSS grid (`auto-fill, minmax(320px, 1fr)`), collapses to 1 column on mobile (`<576px`).
  - `.fppPluginEntry` becomes a flex column so content + compatibility status stack vertically.
  - Columns stack vertically with full-width buttons.
  - Footer links shown with text-overflow ellipsis for long URLs.
  - `overflow-wrap: break-word` on author, description, and compatibility text to prevent overflow.
  - `box-sizing: border-box` on buttons to prevent border overflow.

---

## Backward Compatibility — No Breaking Changes

- **No changes to any backend PHP**. The install/uninstall/upgrade API is untouched.
- **No changes to the `pluginInfo.json` schema requirements**. Adding `"icon"` is purely additive — older FPP versions that don't read the field will silently ignore it. JSON parsers skip unknown keys.
- **No changes to pluginInfo URLs or data fetching**. The `icon` value (if present) is simply rendered as an `<img>` tag; absent/empty falls back to the existing colored initial avatar.
- All existing DOM IDs (`#pluginInput`, `#installedPlugins`, `#pluginTable`, etc.) are unchanged.
- All JavaScript function signatures are unchanged.
- All existing CSS class names retain their original behavior. New classes are purely additive.
- View preference is stored in `localStorage` only; absence has no effect (defaults to list view).
- **Zero impact on plugins themselves** — plugin authors only need to optionally add `"icon": "<url>"` to their `pluginInfo.json`.

## Demo

https://github.com/user-attachments/assets/65fce249-8adf-45de-845d-f814af53ea1d

## Additional Comments

I've mentioned some other enhancements to consider in another comment on a PR (FalconChristmas/fpp-data#18), however, none of those were added into here. This is non-changing to the current structure and functionality and just adds a few non-breaking features (grid view, icons, counts, and improved filtering).


The icon field would look like this in the JSON file (and defaults to initials when no icon is supplied - older versions will ignore icon entry):
```
{
  "repoName": "fpp-myplugin",
  "name": "My Plugin",
  "author": "Your Name",
  "description": "Does something useful",
  "homeURL": "https://github.com/user/fpp-myplugin",
  "srcURL": "https://github.com/user/fpp-myplugin",
  "bugURL": "https://github.com/user/fpp-myplugin/issues",
  "icon": "https://raw.githubusercontent.com/user/fpp-myplugin/main/icon.png",
  "versions": [
    {
      "minFPPVersion": "8.0",
      "maxFPPVersion": "0",
      "branch": "master"
    }
  ]
}
```