### PR TITLE
Fix(9.5.3): Race condition causing FPP commands on same marker to not fire

### DIFF
--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -202,7 +202,7 @@ void Sequence::ReadFramesLoop() {
                 if (m_doneRead || file == nullptr) {
                     // memset(fd->data, 0, maxChanToRead);
                 } else {
-                    fd = m_seqFile->getFrame(frame);
+                    fd = file->getFrame(frame);
                 }
                 long long unlock = GetTimeMS();
                 readlock.unlock();
@@ -275,6 +275,7 @@ int Sequence::OpenSequenceFile(const std::string& filename, int startFrame, int 
     if (IsSequenceRunning())
         CloseSequenceFile();
 
+    std::unique_lock<std::mutex> readLock(readFileLock);
     std::unique_lock<std::mutex> lock(frameCacheLock);
     if (m_seqFile) {
         std::string fn = m_seqFile->getFilename();
@@ -285,6 +286,7 @@ int Sequence::OpenSequenceFile(const std::string& filename, int startFrame, int 
         effectsOff.clear();
         checkForReplacementFile(fn);
     }
+    readLock.unlock();
 
     m_seqStarting = 2;
     m_doneRead = false;
@@ -382,14 +384,15 @@ int Sequence::OpenSequenceFile(const std::string& filename, int startFrame, int 
     lock.lock();
     m_seqFile = seqFile;
     lock.unlock();
-    m_seqStarting = 1; // beyond header, read loop can start reading frames
-    frameLoadSignal.notify_all();
     m_seqPaused = 0;
     m_seqSingleStep = 0;
     m_seqSingleStepBack = 0;
     m_dataProcessed = false;
     ProcessVariableHeaders();
     ReadSequenceData(true);
+    // beyond header, read loop can start reading frames
+    m_seqStarting = 1;
+    frameLoadSignal.notify_all();
     seqLock.unlock();
     StartChannelOutputThread();
 


### PR DESCRIPTION
## Fix: Race condition causing FPP commands on same marker to not fire

### Problem

When a sequence contains multiple FPP command timing tracks with commands on the same markers, commands from the second (and subsequent) tracks fail to fire. For example, given this sequence XML:

```xml
<Element type="timing" name="FPP Commands">
  <EffectLayer>
    <Effect label="CMD_1" startTime="6000" endTime="7750" />
  </EffectLayer>
</Element>
<Element type="timing" name="FPP Commands_2">
  <EffectLayer>
    <Effect label="CMD_2" startTime="6000" endTime="7250" />
  </EffectLayer>
</Element>
```

`CMD_1` fires at frame 6000 but `CMD_2` never fires.

### Root Cause

A race condition in `Sequence::OpenSequenceFile()` (`src/Sequence.cpp`) between the `ProcessVariableHeaders()` function (which parses FC/FPP Command variable headers from the FSEQ file into `commandPresets`) and the `ReadFramesLoop` thread (which reads frame data from the same file object).

In the original code, the execution order was:

```
m_seqFile = seqFile;          // new file assigned
m_seqStarting = 1;            // read thread can now start
frameLoadSignal.notify_all(); // wake read thread
ProcessVariableHeaders();      // parse FC/FE headers  ← TOO LATE
```

The `ReadFramesLoop` thread could begin calling `m_seqFile->getFrame()` while `ProcessVariableHeaders()` was concurrently calling `vh.getData()` → `loadData()` → `fseqFile->seek()` / `fseqFile->read()` on the same `FILE*` handle. This concurrent I/O corrupted the lazy-loaded variable header data, causing subsequent FC headers (from later timing tracks) to be parsed incorrectly or skipped entirely — manifesting as missing commands.

Two additional related issues were also fixed:

1. **Missing `readFileLock` in `OpenSequenceFile()`**: The old `m_seqFile` was deleted and the new one assigned without holding `readFileLock`, creating a race window where the `ReadFramesLoop` thread could hold a stale local pointer while the main thread freed the underlying object.

2. **TOCTOU bug in `ReadFramesLoop()`**: A local copy `file = m_seqFile` was stored at line 200 but line 205 used `m_seqFile->getFrame(frame)` instead of `file->getFrame(frame)`, re-reading the raw pointer and risking use-after-free.

### Fix

All changes in `src/Sequence.cpp`:

1. **Moved `ProcessVariableHeaders()` before `m_seqStarting = 1`** — variable headers are fully parsed before the read thread is allowed to start reading frames:
   ```cpp
   // BEFORE (broken order):
   m_seqStarting = 1;
   frameLoadSignal.notify_all();
   ProcessVariableHeaders();

   // AFTER (fixed order):
   ProcessVariableHeaders();
   ReadSequenceData(true);
   m_seqStarting = 1;
   frameLoadSignal.notify_all();
   ```

2. **Added `readFileLock` protection around `m_seqFile` deletion** — prevents race with `ReadFramesLoop` which reads `m_seqFile` under `readFileLock`:
   ```cpp
   std::unique_lock<std::mutex> readLock(readFileLock);
   std::unique_lock<std::mutex> lock(frameCacheLock);
   if (m_seqFile) {
       delete m_seqFile;
       m_seqFile = nullptr;
       ...
   }
   readLock.unlock();
   ```

3. **Fixed TOCTOU in `ReadFramesLoop`** — use the local copy `file` instead of re-reading `m_seqFile`:
   ```cpp
   // BEFORE:
   fd = m_seqFile->getFrame(frame);

   // AFTER:
   fd = file->getFrame(frame);
   ```

These changes are a backport of the corresponding fixes from FPP 10 (commits `078a49c` and `365903d`), adapted for the raw-pointer design used in version 9.5.