### PR TITLE
Add LAN gateway fallback for NTP sync and enhance NTP health check

### DIFF
--- a/scripts/healthCheck
+++ b/scripts/healthCheck
@@ -245,18 +245,28 @@ HC_DNS() {
 HC_NTPOffset() {
     PrintItemHead "Network Time Protocol Offset"
 
-    # ntpq is not fully reliable, additional verification may be required
-    offsets=$(ntpq -nc peers | tail -n +3 | cut -c 62-66 | tr -d '\.-')
-
     STATUS=1
     STATUSSTR="Your time is accurate"
 
-    for offset in ${offsets}; do
-        if [ ${offset:-0} -ge ${limit:-100} ]; then
+    ntp_synced=$(timedatectl show --property=NTPSynchronized --value 2>/dev/null)
+
+    if [ "$ntp_synced" != "yes" ]; then
+        if pgrep -x ntpd >/dev/null 2>&1; then
+            STATUS=2
+            STATUSSTR="NTP daemon not synchronized"
+        else
             STATUS=0
-            STATUSSTR="Your time may be incorrect, please verify"
+            STATUSSTR="NTP daemon not running"
         fi
-    done
+    else
+        offsets=$(ntpq -nc peers 2>/dev/null | tail -n +3 | cut -c 62-66 | tr -d '\.-')
+        for offset in ${offsets}; do
+            if [ ${offset:-0} -ge ${limit:-100} ]; then
+                STATUS=0
+                STATUSSTR="Your time may be incorrect, please verify"
+            fi
+        done
+    fi
 
     PrintItemFoot
 }

--- a/scripts/healthCheckSSE
+++ b/scripts/healthCheckSSE
@@ -281,18 +281,28 @@ HC_DNS() {
 HC_NTPOffset() {
     local status="pass"
     local message=""
+    local ntp_synced
 
-    offsets=$(ntpq -nc peers 2>/dev/null | tail -n +3 | cut -c 62-66 | tr -d '\.-')
+    ntp_synced=$(timedatectl show --property=NTPSynchronized --value 2>/dev/null)
 
-    status="pass"
-    message="Time synchronized"
-
-    for offset in ${offsets}; do
-        if [ ${offset:-0} -ge ${limit:-100} ]; then
+    if [ "$ntp_synced" != "yes" ]; then
+        if pgrep -x ntpd >/dev/null 2>&1; then
             status="warn"
-            message="Time may be incorrect"
+            message="NTP daemon not synchronized"
+        else
+            status="fail"
+            message="NTP daemon not running"
         fi
-    done
+    else
+        offsets=$(ntpq -nc peers 2>/dev/null | tail -n +3 | cut -c 62-66 | tr -d '\.-')
+        message="Time synchronized"
+        for offset in ${offsets}; do
+            if [ ${offset:-0} -ge ${limit:-100} ]; then
+                status="warn"
+                message="Time may be incorrect"
+            fi
+        done
+    fi
 
     emit_event "ntp" "Time Sync (NTP)" "fa-clock" "$status" "$message"
 }

--- a/src/boot/FPPINIT_Network.cpp
+++ b/src/boot/FPPINIT_Network.cpp
@@ -466,6 +466,30 @@ void setupNetwork(bool fullReload) {
         }
     }
 
+    // Auto-detect default gateway as a fallback NTP server so that ntpsec has
+    // a reachable peer when internet pool servers are blocked (e.g. behind
+    // double NAT). LAN traffic to the gateway does not cross any NAT boundary.
+    // ntpsec gracefully ignores non-responsive servers, so this is safe even
+    // if the gateway does not run NTP.
+    {
+        std::string gw = execAndReturn(
+            "/usr/bin/ip route show default 2>/dev/null | /usr/bin/awk '{print $3}'");
+        TrimWhiteSpace(gw);
+        if (!gw.empty()) {
+            struct sockaddr_in sa;
+            if (inet_pton(AF_INET, gw.c_str(), &(sa.sin_addr)) == 1) {
+                std::string ntpConf = GetFileContents("/etc/ntpsec/ntp.conf");
+                if (ntpConf.find("server " + gw) == std::string::npos) {
+                    ntpConf += "\n# Auto-detected default gateway fallback\nserver "
+                            + gw + " minpoll 10 maxpoll 12 iburst\n";
+                    PutFileContents("/etc/ntpsec/ntp.conf", ntpConf);
+                    execbg("/usr/bin/systemctl reload-or-restart ntpsec.service &");
+                    printf("FPP - Added default gateway %s as fallback NTP server\n",
+                           gw.c_str());
+                }
+            }
+        }
+    }
     bool changed = false;
     for (auto& ftc : filesToConsider) {
         if (filesNeeded.find(ftc) == filesNeeded.end()) {

--- a/www/common/settings.php
+++ b/www/common/settings.php
@@ -61,6 +61,18 @@ function SetNTPServer($value)
         exec("sudo sed -i -e 's/minsane 1/minsane 3/' $ntpConfigFile");
     }
 
+    // Add default gateway as a fallback NTP server reachable on the local
+    // subnet (no NAT boundary). Safe even if the gateway does not run NTP;
+    // ntpsec simply marks it as unreachable.
+    $gateway = exec("ip route show default 2>/dev/null | awk '{print \$3}'");
+    if (!empty($gateway) && filter_var($gateway, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+        $gwInConf = exec("grep -c 'server $gateway' $ntpConfigFile 2>/dev/null");
+        if ($gwInConf == 0) {
+            exec("sudo sh -c \"echo >> $ntpConfigFile\"");
+            exec("sudo sh -c \"echo '# Auto-detected default gateway fallback' >> $ntpConfigFile\"");
+            exec("sudo sh -c \"echo server $gateway minpoll 10 maxpoll 12 iburst >> $ntpConfigFile\"");
+        }
+    }
     // Note: Assume NTP is always enabled now.
     RestartNTPD();
 }


### PR DESCRIPTION
## Add LAN gateway fallback for NTP and fix silent clock drift detection

### Problem

FPP uses `ntpsec` configured with only `falconplayer.pool.ntp.org` as its NTP source. Behind double NAT (or any network path that drops NTP replies), the daemon never syncs — `ntpq -pn` permanently shows every peer as `.INIT.` with `reach 0`.

The boot-time SNTP client in `handleTimeSyncWait()` does a one-shot query that may succeed on boot, but after that `ntpsec` takes over and can never sync. The clock silently drifts from the boot-time value with no indication in the FPP UI.

The existing health check (`HC_NTPOffset`) parses `ntpq -nc peers` for offset values, but when no peer is reachable the output is empty — so it reports **"Time synchronized"**, the exact opposite of reality.

### Solution

**Part A — LAN gateway as fallback NTP source**

Auto-detect the default gateway via `ip route show default` and add it to `ntp.conf` as a lower-priority fallback server (`minpoll 10 maxpoll 12 iburst`). LAN traffic to the gateway does not cross any NAT boundary, and consumer routers almost always respond to NTP queries. If the gateway doesn't run NTP, `ntpsec` simply marks it as unreachable — no harm.

| File | Change |
|------|--------|
| `src/boot/FPPINIT_Network.cpp` | `setupNetwork()` detects gateway after existing ntpsec config, validates with `inet_pton`, appends to `ntp.conf` if not already present, restarts `ntpsec` |
| `www/common/settings.php` | Same logic in `SetNTPServer()` so it takes effect immediately on UI save (not just next boot) |

**Part B — Fix NTP health check**

| File | Change |
|------|--------|
| `scripts/healthCheckSSE` | Check `timedatectl NTPSynchronized` first; show "NTP daemon not synchronized" (warn) or "NTP daemon not running" (fail) instead of incorrectly reporting pass |
| `scripts/healthCheck` | Same fix for the non-SSE health check variant |

### Edge cases

| Scenario | Behavior |
|----------|----------|
| No default gateway | `gw` is empty, skip — no change to ntp.conf |
| Gateway already in ntp.conf | Duplicate check prevents re-add |
| Gateway doesn't run NTP | ntpsec marks it unreachable, no harm |
| Gateway matches user's configured server | Duplicate check prevents re-add |
| `timedatectl` unavailable | Health check falls through gracefully |
| ntpsec not running | Health check reports "NTP daemon not running" |

### Testing

- [ ] On double-NAT network: gateway appears in `ntpq -pn` as a reachable peer
- [ ] On normal internet: `falconplayer.pool.ntp.org` remains preferred (`prefer` flag unchanged)
- [ ] Health check shows "NTP daemon not synchronized" when daemon can't sync

### Additional Comments

This is an attempt to fix issue #2736. After merging, please mark as "Fix Applied - Testing Required".