### PR TITLE
Show missing sequence/media indicators inside playlist editor

### DIFF
--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -1812,6 +1812,18 @@ body.is-loading #schedulerInfo .labelValue:before {
 	margin-left: 0.8em;
 }
 
+.playlistRowWarning {
+	background-color: var(--bs-warning-bg-subtle) !important;
+}
+.playlistEntryWarningIcon {
+	color: var(--bs-warning);
+	font-family: 'Font Awesome 5 Free';
+	font-weight: 900;
+	font-size: 1.1em;
+	margin-left: 0.4em;
+	vertical-align: middle;
+}
+
 .playlistCard {
 	margin-top: 0.5em;
 	cursor: pointer;

--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -2118,18 +2118,42 @@ function GetPlaylistDurationDiv (entry) {
 	);
 }
 
-function GetPlaylistRowHTML (ID, entry, editMode) {
+function GetPlaylistRowHTML (ID, entry, editMode, invalidNames = {}) {
 	var HTML = '';
 	var rowNum = ID + 1;
 
+	var warningClass = '';
+	var warningTitle = '';
+	if (entry.type == 'sequence' && entry.sequenceName && invalidNames[entry.sequenceName]) {
+		warningClass = ' playlistRowWarning';
+		warningTitle = ' title="Missing sequence: ' + entry.sequenceName.replace(/'/g, '&#39;') + '"';
+	} else if (entry.type == 'both') {
+		if (entry.sequenceName && invalidNames[entry.sequenceName]) {
+			warningClass = ' playlistRowWarning';
+			warningTitle = ' title="Missing sequence: ' + entry.sequenceName.replace(/'/g, '&#39;') + '"';
+		} else if (entry.mediaName && invalidNames[entry.mediaName]) {
+			warningClass = ' playlistRowWarning';
+			warningTitle = ' title="Missing media: ' + entry.mediaName.replace(/'/g, '&#39;') + '"';
+		}
+	} else if (entry.type == 'media' && entry.mediaName && invalidNames[entry.mediaName]) {
+		warningClass = ' playlistRowWarning';
+		warningTitle = ' title="Missing media: ' + entry.mediaName.replace(/'/g, '&#39;') + '"';
+	} else if (entry.type == 'playlist' && entry.name && invalidNames[entry.name]) {
+		warningClass = ' playlistRowWarning';
+		warningTitle = ' title="Missing playlist: ' + entry.name.replace(/'/g, '&#39;') + '"';
+	} else if (entry.type == 'image' && entry.imagePath && invalidNames[entry.imagePath]) {
+		warningClass = ' playlistRowWarning';
+		warningTitle = ' title="Missing image: ' + entry.imagePath.replace(/'/g, '&#39;') + '"';
+	}
+
 	if (editMode) {
-		HTML += "<tr class='playlistRow'>";
+		HTML += "<tr class='playlistRow" + warningClass + "'" + warningTitle + ">";
 		HTML +=
 			"<td class='playlistRowCheckCell'><input type='checkbox' class='playlistEntryCheckbox' onchange='UpdatePlaylistSelectCount()' /></td>";
 		HTML +=
 			"<td class='center' valign='middle'> <div class='rowGrip'><i class='rowGripIcon fpp-icon-grip'></i></div></td>";
 	} else {
-		HTML += "<tr id='playlistRow" + rowNum + "' class='playlistRow'>";
+		HTML += "<tr id='playlistRow" + rowNum + "' class='playlistRow" + warningClass + "'" + warningTitle + ">";
 	}
 
 	HTML += "<td class='colPlaylistNumber";
@@ -2158,6 +2182,7 @@ function GetPlaylistRowHTML (ID, entry, editMode) {
 		PlaylistEntryTypeToString(entry.type) +
 		':' +
 		deprecated +
+		(warningClass ? "<span class='playlistEntryWarningIcon'>&#x26a0;</span>" : "") +
 		"<span style='display: none;' class='entryType'>" +
 		entry.type +
 		"</span></div><div class='psiData'>";
@@ -2329,10 +2354,28 @@ function PlaylistNameOK (name) {
 function LoadPlaylistDetails (name) {
 	$.get('api/playlist/' + name)
 		.done(function (data) {
-			// Use setTimeout to allow UI to update before heavy DOM manipulation
+			var invalidNames = {};
+			for (var i = 0; i < playListArray.length; i++) {
+				if (playListArray[i].name == name) {
+					var msgs = playListArray[i].messages;
+					for (var m = 0; m < msgs.length; m++) {
+						var msg = msgs[m];
+						var match;
+						if ((match = msg.match(/^Invalid Sequence (.+)$/))) {
+							invalidNames[match[1]] = true;
+						} else if ((match = msg.match(/^Invalid mediaName (.+)$/))) {
+							invalidNames[match[1]] = true;
+						} else if ((match = msg.match(/^Invalid Playlist (.+)$/))) {
+							invalidNames[match[1]] = true;
+						} else if ((match = msg.match(/^Invalid Image (.+)$/))) {
+							invalidNames[match[1]] = true;
+						}
+					}
+					break;
+				}
+			}
 			setTimeout(function () {
-				PopulatePlaylistDetails(data, 1, name);
-				//$("#tblPlaylistLeadInHeader").get(0).scrollIntoView();
+				PopulatePlaylistDetails(data, 1, name, invalidNames);
 			}, 0);
 		})
 		.fail(function () {
@@ -7009,7 +7052,7 @@ function UpdatePlaylistHeaderDetailVisibility () {
 	});
 }
 
-function PopulatePlaylistDetails (data, editMode, name = '') {
+function PopulatePlaylistDetails (data, editMode, name = '', invalidNames = {}) {
 	var innerHTML = '';
 	var entries = 0;
 	gblPlaylistDetailsEditMode = editMode ? 1 : 0;
@@ -7027,7 +7070,7 @@ function PopulatePlaylistDetails (data, editMode, name = '') {
 			let sectionData = data[sections[s]];
 			innerHTML = '';
 			for (var i = 0; i < sectionData.length; i++) {
-				innerHTML += GetPlaylistRowHTML(entries, sectionData[i], editMode);
+				innerHTML += GetPlaylistRowHTML(entries, sectionData[i], editMode, invalidNames);
 				entries++;
 			}
 			$('#tblPlaylist' + idPart).html(innerHTML);


### PR DESCRIPTION
## Summary

When a playlist entry references a missing sequence, media, playlist, or image file, the top-level playlist card view correctly shows a yellow warning indicator — but the drill-in editor view shows nothing. This restores the per-entry warning indicator inside the playlist editor so users can immediately identify which entry is broken without manually checking each one.

## Changes

### `www/js/fpp.js`

- **`LoadPlaylistDetails()`** — After loading the playlist data, parses the existing validation messages from `playListArray` (fetched by `GET /api/playlists/validate`) to build a set of invalid entry names. Passes the set to `PopulatePlaylistDetails()`.

- **`PopulatePlaylistDetails()`** — Accepts a new optional `invalidNames` parameter (default `{}`, no breaking change) and forwards it to `GetPlaylistRowHTML()`.

- **`GetPlaylistRowHTML()`** — Accepts a new optional `invalidNames` parameter. When an entry references a name present in the invalid set:
  - Adds a `playlistRowWarning` CSS class to the `<tr>` (yellow background highlight)
  - Adds a `title` attribute with details (e.g. "Missing sequence: show.fseq")
  - Renders a warning icon (`⚠`) next to the entry type label in the header

### `www/css/fpp.css`

- **`.playlistRowWarning`** — Yellow background using Bootstrap's `--bs-warning-bg-subtle` variable (works correctly in both light and dark themes)
- **`.playlistEntryWarningIcon`** — Inline warning symbol styled with `--bs-warning` color

## How It Works

The backend already computes which entries are invalid via the existing `GET /api/playlists/validate` endpoint and loads the results into the global `playListArray` during page initialization. The fix simply plumbs that existing validation data into the per-entry rendering code — no new API endpoints, no backend changes, and no breaking changes to any existing function signatures (all new parameters default to `{}`).

## Verification

- New entries created in the editor don't show warnings (correct — they haven't been saved yet)
- After saving a playlist, the warning updates correctly (the save flow refreshes `playListArray` via `PopulateLists()` before re-rendering)
- The playback/non-edit view is unaffected (doesn't pass `invalidNames`, defaults to `{}`)
- Dark mode is supported via Bootstrap CSS custom properties

## Additional Comments

This PR closes #2738.