### PR TITLE
fix(mqtt-restore): Restore MQTT connection after JSON configuration backup restore

### DIFF
--- a/www/common.php
+++ b/www/common.php
@@ -202,6 +202,9 @@ function WriteSettingToFile($settingName, $new_setting_value, $plugin = "")
         }
         file_put_contents($filename, $RevisedSettingsStr);
     }
+    if ($plugin == "") {
+        $settings[$settingName] = $new_setting_value;
+    }
     flock($fd, LOCK_UN);
     fclose($fd);
 }


### PR DESCRIPTION
## Fix: Restore MQTT connection after JSON configuration backup restore

### Issue

When restoring a backup from a JSON configuration file that has "Enable Local MQTT" enabled, the local MQTT broker remains disconnected after the restore completes. The user must manually toggle the "Enable Local MQTT" setting off and back on to restore connectivity.

### Root Cause

The `WriteSettingToFile()` function in `www/common.php` writes the updated value to the settings file on disk but never updates the in-memory `$settings` global array. During a backup restore, `backup.php` iterates over all settings in a single HTTP request, calling `WriteSettingToFile()` then `ApplySetting()` for each one. Since `GetSettingValue()` reads from the `$settings` array (loaded at request start), every `ApplySetting()` call sees stale pre-restore values.

For MQTT specifically, this causes `SetupLocalMQTTBroker('1')` to generate the mosquitto password file using the **old** `MQTTPassword` — because `GetSettingValue('MQTTPassword')` reads the stale in-memory array rather than the just-written file. The `ApplySetting` handler for `MQTTPassword` (which would normally regenerate the password file with the correct value) also fails because its `GetSettingValue('Service_MQTT_localbroker')` check returns the pre-restore value, skipping the fixup entirely. The result: mosquitto restarts with a wrong password file and the fppd MQTT client cannot authenticate.

### Fix

**File:** `www/common.php` — `WriteSettingToFile()` function

Add `$settings[$settingName] = $new_setting_value;` after the file write, guarded by `if ($plugin == "")` to avoid polluting the main settings array with plugin settings (which use a separate `$pluginSettings` global).

```php
if ($plugin == "") {
    $settings[$settingName] = $new_setting_value;
}
```

This ensures the in-memory `$settings` array is always consistent with what was just written to disk. All subsequent `GetSettingValue()` and `ApplySetting()` calls during the same HTTP request reflect the restored values.

### Why this is sufficient

The fppd `MosquittoClient` uses `mosquitto_connect_async` + background loop, which handles automatic reconnection. Once the password file is correctly generated and mosquitto restarts, the client reconnects without needing to be recreated or toggled.

### Safety considerations

- Plugin writes (`$plugin != ""`) write to separate files (`/media/settings/plugin.<name>`). The guard prevents plugin values from overwriting main settings in `$settings`.
- No callers write temporary or speculative values that should not be visible via `GetSettingValue()`.
- Existing code already manually compensates for the lack of sync (e.g., email settings in `backup.php:742-752`, `MQTTPassword` in `settings.php:426`, `restartFlag`/`rebootFlag` in `backup.php:2137-2139`). These manual syncs become redundant but harmless.
- All restore ordering scenarios are handled correctly (MQTTPassword first or Service_MQTT_localbroker first both arrive at the correct end state).

### Verification

- `php -l www/common.php` confirms valid syntax (pre-existing parse error at line 1644 is unrelated).
- Restore flow analysis confirms both possible setting orderings produce the correct password file and MQTT connection.

### Additional Comments

This is a fix for one of 3 issues reported in  [#2339](https://github.com/FalconChristmas/fpp/issues/2339#issuecomment-4993280577).