### PR TITLE
feat(initialSetup) - Add File Copy Restore option to Initial Setup restore dialog

### DIFF
--- a/www/backup.php
+++ b/www/backup.php
@@ -2125,6 +2125,7 @@ if ($skipHTMLCodeOutput === false) {
         <title><?= $pageTitle ?></title>
         <!--    <script>var helpPage = "help/backup.php";</script>-->
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <script src="js/fpp-backup-filecopy.js"></script>
 
         <?php
         $backupHosts = getKnownFPPSystems();
@@ -2162,6 +2163,97 @@ if ($skipHTMLCodeOutput === false) {
             }
             else {
                 helpPage = "help/" + helpPage;
+            }
+
+            fppFileCopy.config = {
+                direction: '#backup\\.Direction',
+                usbDevice: '#backup\\.USBDevice',
+                pathSelect: '#backup\\.PathSelect',
+                host: '#backup\\.Host',
+                remoteStorage: '#backup\\.RemoteStorage',
+                deleteExtra: '#backup\\.DeleteExtra',
+                copyText: '#copyText',
+                showUSB: '.copyUSB',
+                showHost: '.copyHost',
+                showHostDevice: '.copyHostDevice',
+                showPathSelect: '.copyPathSelect',
+                showPath: '.copyPath',
+                showBackups: '.copyBackups',
+                showCompressed: '.sendCompressed',
+                popupModalId: 'copyPopup_Modal',
+                popupCloseBtnId: 'copyPopup_ModalCloseButton',
+                copyPopupBodyId: 'copyPopup'
+            };
+
+            function BackupDirectionChanged() {
+                fppFileCopy.directionChanged();
+            }
+
+            function GetBackupDevices() {
+                $('#jsonConfigbackup\\.USBDevice').parent().closest('div').addClass('fpp-backup-action-loading');
+                fppFileCopy.getBackupDevices();
+            }
+
+            fppFileCopy.config.onDevicesLoaded = function (data) {
+                $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('fpp-backup-action-loading');
+                var defaultOption = "<option value='none' selected>None</option>";
+                var options = '';
+                for (var i = 0; i < data.length; i++) {
+                    var desc = data[i].name;
+                    if (data[i].vendor != '') desc += ' - ' + data[i].vendor;
+                    if (data[i].model != '') {
+                        desc += (data[i].vendor != '') ? ' ' : ' - ';
+                        desc += ' ' + data[i].model;
+                    }
+                    desc += ' - ' + data[i].size + 'GB';
+                    options += "<option value='" + data[i].name + "'>" + desc + "</option>";
+                }
+                $('#jsonConfigbackup\\.USBDevice').html(defaultOption + options);
+                GetJSONConfigBackupDevice();
+            };
+
+            function GetBackupDeviceDirectories() {
+                fppFileCopy.getBackupDeviceDirectories();
+            }
+
+            function GetRestoreDeviceDirectories() {
+                fppFileCopy.getRestoreDeviceDirectories();
+            }
+
+            function USBDeviceChanged(toFromRemote) {
+                fppFileCopy.usbDeviceChanged();
+            }
+
+            function GetBackupDirsViaAPI(host, remoteStorageSelected, excludeRoot) {
+                fppFileCopy.getBackupDirsViaAPI(host, remoteStorageSelected, excludeRoot);
+            }
+
+            function GetBackupHostBackupDirs(remoteStorageSelected) {
+                fppFileCopy.getBackupHostBackupDirs(remoteStorageSelected);
+            }
+
+            function PopulateBackupDirs(data, excludeRoot) {
+                fppFileCopy.populateBackupDirs(data, excludeRoot);
+            }
+
+            function CheckRemoteHasRsyncdEnabled(host) {
+                fppFileCopy.checkRemoteHasRsyncdEnabled(host);
+            }
+
+            function GetRemoteHostUSBStorage() {
+                fppFileCopy.getRemoteHostUSBStorage();
+            }
+
+            function CloseCopyDialog() {
+                fppFileCopy.closeCopyDialog();
+            }
+
+            function CopyDone() {
+                fppFileCopy.copyDone();
+            }
+
+            function CopyTimeoutError() {
+                fppFileCopy.copyTimeoutError();
             }
 
             function GetCopyFlags() {
@@ -2318,201 +2410,6 @@ if ($skipHTMLCodeOutput === false) {
 
                 StreamURL(url, 'copyText', 'CopyDone', 'CopyTimeoutError');
 
-            }
-
-            function CloseCopyDialog() {
-                var cd_remoteHost = settings['backup.Host'];
-                var cd_remoteStorage = settings['backup.RemoteStorage'];
-
-                if (typeof (cd_remoteHost) !== "undefined" && typeof (cd_remoteStorage) !== "undefined") {
-                    //Run a Unmount against the remote storage to make sure it's unmounted, this helps when there is a issue with the copy_settings_to_storeage.sh script and it doesn't unmount the specified device at the remote host
-                    //We don't do anything with the returned output. Proxied through
-                    //the local API (?ip=) so the browser stays same-origin.
-                    $.post("api/backups/devices/unmount/" + encodeURIComponent(cd_remoteStorage) + "/remote_filecopy?ip=" + encodeURIComponent(cd_remoteHost));
-
-                }
-
-                CloseModalDialog("copyPopup_Modal");
-            }
-
-            function CopyDone() {
-                EnableModalDialogCloseButton('copyPopup_Modal');
-            }
-
-            function CopyTimeoutError() {
-                var fpp_backup_filecopy_log_url = "api/file/Logs/fpp_backup_filecopy.log";
-                var timeoutErrorMessage = "!!! Attempting to track file copy process via it's fallback log file... \n" +
-                    " The file copy is still running in the background and will complete in due course. Progress updates will appear periodically. !!! \n\n ";
-                var noNewDataErrorMessage = "";
-                var iterations = 0;
-                var iterationsWithNoDataWarningsIssued = 1;
-                var noNewDataIterationCount = 600; // The interval is every second so 600 iterations = 10minutes
-                // var noNewDataIterationHardLimit = 900; // 15 minutes - Consider the process failed if no new log data received in 15 minutes
-                var last_response_len = 0;
-
-                //cache the reference to the element
-                var outputArea = $('#copyText');
-                outputArea.val('')
-                outputArea.val(timeoutErrorMessage);
-
-                //Every second read the alternative fpp_backup_filecopy.log
-                var tailLogInterval = setInterval(function () {
-
-                    $.get(fpp_backup_filecopy_log_url, function (text) {
-                        //This is also a nasty workaround, but we reply on logs api will returning a file not found error to signify the copy process ending
-                        //as the log file is deleted at the end of that process
-                        if (text === "File does not exist.") {
-                            //The file copy script has competed and removed the logfile
-                            //If the log file cannot be found anymore consider the process complete
-                            clearInterval(tailLogInterval);
-                            CopyDone();
-                        } else {
-                            //Track the number of interactions the response remained unchanged
-                            if (last_response_len === 0) {
-                                last_response_len = text.length;
-                            }
-
-                            if (last_response_len === text.length) {
-                                iterations += 1;
-                            } else {
-                                noNewDataErrorMessage = "";
-                                //Reset
-                                iterations = 0;
-                                //Store the new data length
-                                last_response_len = text.length;
-                            }
-
-                            //Check if it's been more than 10 minutes that the data has remained unchanged
-                            if (iterations === (noNewDataIterationCount * iterationsWithNoDataWarningsIssued)) {
-                                iterationsWithNoDataWarningsIssued += 1;
-                                //Some error occurred
-                                noNewDataErrorMessage = "!!! WARNING: No new log entries has been received in over " + Math.floor(iterations / 60) + " minutes, still waiting.... !!! \n\n";
-                            }
-                            // if (iterations >= noNewDataIterationHardLimit) {
-                            //     //Some error occurred
-                            //     noNewDataErrorMessage = "!!! ERROR: No new log entries has been received in over " + noNewDataIterationHardLimit + " seconds - File Copy Backup process has likely failed !!! \n\n";
-                            // }
-
-                            //This is a bit ugly, but put our error message first (just to inform the user), then the contents of the log file every time
-                            outputArea.val(timeoutErrorMessage + text + noNewDataErrorMessage);
-
-                            outputArea.scrollTop(outputArea.prop('scrollHeight'));
-                            outputArea.parent().scrollTop(outputArea.parent().prop('scrollHeight'));
-
-                            //Check for device unmounted text - if this exists then the process has completed... the file should be removed at the end
-                            //but this is just a failsafe in case it wasn't
-                            //exit if we hit the hard limit
-                            if (text.includes("unmounted from") || text.length === 0) {
-                                clearInterval(tailLogInterval);
-                                CopyDone();
-                            }
-                        }
-                    });
-                },
-                    1000);
-            }
-
-
-            function GetBackupDevices() {
-                $('#backup\\.USBDevice').html('<option>Loading...</option>');
-                //Add a loading spinner to show something is happening on the JSON Backup page dropdown list
-                $('#jsonConfigbackup\\.USBDevice').parent().closest('div').addClass('fpp-backup-action-loading');
-                //Also do the same for the file copy list these both use the same functions and deal with the same data
-                //Add a loading spinner to show something is happening
-                $('#backup\\.USBDevice').parent().closest('td').addClass('fpp-backup-action-loading');
-
-                $.get("api/backups/devices"
-                ).done(function (data) {
-                    var options = "";
-                    var default_none_selected_option = "<option value='none' selected>None</option>";
-
-                    for (var i = 0; i < data.length; i++) {
-                        var desc = data[i].name;
-                        if (data[i].vendor != '')
-                            desc += ' - ' + data[i].vendor;
-
-                        if (data[i].model != '') {
-                            if (data[i].vendor != '')
-                                desc += ' ';
-                            else
-                                desc += ' - ';
-
-                            desc += data[i].model;
-                        }
-
-                        desc += ' - ' + data[i].size + 'GB';
-                        options += "<option value='" + data[i].name + "'>" + desc + "</option>";
-                    }
-
-                    $('#backup\\.USBDevice').html(options);
-                    $('#jsonConfigbackup\\.USBDevice').html(default_none_selected_option + options);
-
-                    //Remove the loading spinner
-                    $('#jsonConfigbackup\\.USBDevice').parent().closest('div').removeClass('fpp-backup-action-loading');
-                    //Also do the same for the file copy list these both use the same functions and deal with the same data
-                    //Add a loading spinner to show something is happening
-                    $('#backup\\.USBDevice').parent().closest('td').removeClass('fpp-backup-action-loading');
-
-                    if (options != "") {
-                        if (document.getElementById("backup.Direction").value == 'FROMUSB')
-                            GetBackupDeviceDirectories();
-                        else if (document.getElementById("backup.Direction").value == 'TOUSB')
-                            GetRestoreDeviceDirectories();
-
-                        //Get the selected device setting and update the UI
-                        GetJSONConfigBackupDevice();
-                    }
-                }).fail(function () {
-                    $('#backup\\.USBDevice').html('');
-                });
-            }
-
-            function GetBackupDeviceDirectories() {
-                var dev = document.getElementById("backup.USBDevice").value;
-
-                if (dev == '') {
-                    $('#backup\\.PathSelect').html("<option value=''>No USB Device Selected</option>");
-                    return;
-                }
-
-                $('#backup\\.PathSelect').html('<option>Loading...</option>');
-                $.get("api/backups/list/" + dev
-                ).done(function (data) {
-                    PopulateBackupDirs(data);
-                }).fail(function () {
-                    $('#backup\\.PathSelect').html('');
-                });
-            }
-
-            function GetRestoreDeviceDirectories() {
-                var dev = document.getElementById("backup.USBDevice").value;
-
-                if (dev == '') {
-                    $('#backup\\.PathSelect').html("<option value=''>No USB Device Selected</option>");
-                    return;
-                }
-
-                $('#usbDirectories').html('');
-                $.get("api/backups/list/" + dev
-                ).done(function (data) {
-                    var options = '';
-                    for (i = 0; i < data.length; i++) {
-                        if (data[i].substring(0, 5) != 'ERROR')
-                            options += "<option value='" + data[i] + "'>" + data[i] + "</option>";
-                    }
-                    $('#usbDirectories').html(options);
-                });
-            }
-
-            function USBDeviceChanged(toFromRemote = false) {
-                var direction = document.getElementById("backup.Direction").value;
-                if (debug_mode == true) {
-                    alert('direction: ' + direction);
-                }
-                if (direction == 'FROMUSB')
-                    GetBackupDeviceDirectories();
-                else if (direction == 'TOUSB')
-                    GetRestoreDeviceDirectories();
             }
 
             function JSONConfigBackupUSBDeviceChanged() {
@@ -2837,226 +2734,6 @@ if ($skipHTMLCodeOutput === false) {
                 }
 
 
-            }
-
-            function PopulateBackupDirs(data, excludeRoot = false) {
-                var options = "";
-                for (var i = 0; i < data.length; i++) {
-                    // Remote File Copy backups always live in per-host subdirs under
-                    // media/backups/, so the top-level '/' is not a restorable snapshot -
-                    // selecting it would rsync every machine's backup folder into /media
-                    // (see issue #2714). Drop it for those restores.
-                    if (excludeRoot && data[i] == '/')
-                        continue;
-                    if (data[i].substring(0, 5) != 'ERROR')
-                        options += "<option value='" + data[i] + "'>" + data[i] + "</option>";
-                    else
-                        options += "<option value=''>" + data[i] + "</option>";
-                }
-                $('#backup\\.PathSelect').html(options);
-            }
-
-            function GetBackupDirsViaAPI(host, remoteStorageSelected = '', excludeRoot = false) {
-                $('#backup\\.PathSelect').html('<option>Loading...</option>');
-
-                //Build a different URL if a storage device has been specified
-                var url = "api/backups/list";
-                if (remoteStorageSelected !== '' && remoteStorageSelected !== false && remoteStorageSelected !== 'none') {
-                    url = "api/backups/list/" + encodeURIComponent(remoteStorageSelected);
-                }
-                // When a *remote* host is selected, proxy through the local API via
-                // ?ip= so the browser stays same-origin (no per-remote CSP entry).
-                // For this instance itself, call the local API directly.
-                if (host && host !== window.location.host) {
-                    url += (url.indexOf('?') === -1 ? '?' : '&') + "ip=" + encodeURIComponent(host);
-                }
-
-                //Add a loading spinner to show the user something is happening
-                $('#backup\\.PathSelect').parent().closest('td').addClass('fpp-backup-action-loading');
-
-                $.get(url
-                ).done(function (data) {
-                    PopulateBackupDirs(data, excludeRoot);
-                    $('#backup\\.PathSelect').parent().closest('td').removeClass('fpp-backup-action-loading');
-                }).fail(function () {
-                    $('#backup\\.PathSelect').html('');
-                    $('#backup\\.PathSelect').parent().closest('td').removeClass('fpp-backup-action-loading');
-                });
-            }
-
-            //Wrapper for GetBackupDirsViaAPI when quering folders on a remote hosts storage device
-            function GetBackupHostBackupDirs(remoteStorageSelected = false) {
-                if (remoteStorageSelected !== false) {
-                    //Get the value of the selected storage
-                    var selectedStorage = remoteStorageSelected;
-                    //ignore if the default of none is still selected
-                    if (selectedStorage == 'none') {
-                        selectedStorage = '';
-                    }
-                }
-
-                //Get the backup directories on the specified storage device.
-                //Exclude the top-level '/' - for remote restores it maps to the
-                //media/backups/ container (all machines' backups), not a single
-                //restorable snapshot (issue #2714).
-                GetBackupDirsViaAPI($('#backup\\.Host').val(), selectedStorage, true);
-            }
-
-            function BackupDirectionChanged() {
-                var direction = document.getElementById("backup.Direction").value;
-                var host = document.getElementById("backup.Host").value;
-
-                switch (direction) {
-                    case 'TOUSB':
-                        $('.copyUSB').show();
-                        $('.copyPath').show();
-                        $('.copyPathSelect').hide();
-                        $('.copyHost').hide();
-                        $('.copyHostDevice').hide();
-                        $('.copyBackups').show();
-                        GetRestoreDeviceDirectories();
-                        break;
-                    case 'FROMUSB':
-                        $('.copyUSB').show();
-                        $('.copyPath').hide();
-                        $('.copyPathSelect').show();
-                        $('.copyHost').hide();
-                        $('.copyHostDevice').hide();
-                        $('.copyBackups').hide();
-                        GetBackupDeviceDirectories();
-                        break;
-                    case 'TOLOCAL':
-                        $('.copyUSB').hide();
-                        $('.copyPath').show();
-                        $('.copyPathSelect').hide();
-                        $('.copyHost').hide();
-                        $('.copyHostDevice').hide();
-                        $('.copyBackups').hide();
-                        break;
-                    case 'FROMLOCAL':
-                        $('.copyUSB').hide();
-                        $('.copyPath').hide();
-                        $('.copyPathSelect').show();
-                        $('.copyHost').hide();
-                        $('.copyHostDevice').hide();
-                        $('.copyBackups').hide();
-                        // Exclude the top-level '/' - like remote restores it maps to
-                        // the media/backups/ container (all machines' backups), not a
-                        // single restorable snapshot (issue #2714).
-                        GetBackupDirsViaAPI('<?php echo $_SERVER['HTTP_HOST'] ?>', '', true);
-                        break;
-                    case 'TOREMOTE':
-                        $('.copyUSB').hide();
-                        $('.copyPath').show();
-                        $('.copyPathSelect').hide();
-                        $('.copyHost').show();
-                        $('.copyHostDevice').show();
-                        $('.copyBackups').hide();
-                        $('.sendCompressed').show();
-                        //Check if remote has rsynd enabled
-                        CheckRemoteHasRsyncdEnabled(host);
-                        //USB Device on remote
-                        GetRemoteHostUSBStorage();
-                        break;
-                    case 'FROMREMOTE':
-                        $('.copyUSB').hide();
-                        $('.copyPath').hide();
-                        $('.copyPathSelect').show();
-                        $('.copyHost').show();
-                        $('.copyHostDevice').show();
-                        $('.copyBackups').hide();
-                        $('.sendCompressed').show();
-                        GetBackupHostBackupDirs();
-                        //Check if remote has rsynd enabled
-                        CheckRemoteHasRsyncdEnabled(host);
-                        //USB device on remote
-                        GetRemoteHostUSBStorage();
-                        break;
-                }
-            }
-
-            function CheckRemoteHasRsyncdEnabled(host) {
-                //Read the setting value for whether the Rsync Daemon is enabled on the
-                //*remote* host (proxied through the local API via ?ip= so the browser
-                //stays same-origin). If it isn't, prompt the user that this needs to be
-                //enabled before copy TO or FROM the remote host can happen.
-                $.ajax({
-                    url: 'api/settings/Service_rsync?ip=' + encodeURIComponent(host),
-                    type: 'GET',
-                    success: function (data) {
-                        if (typeof (data) !== "undefined") {
-                            var rsyncd_setting_value = data['value'];
-                            if (rsyncd_setting_value === 0 || rsyncd_setting_value === '0') {
-                                //remove the warning text in case it's hanging around from a previous host
-                                $('.host_rsyncd_warning').remove();
-                                //Generate a URL by IP address to the affected host so the user can navigate easier
-                                var hostHref = "<a href='http://" + host + "/settings.php#settings-services' target='_blank'>" + host + "</a>";
-                                //rsynd is disabled on host, add a warning next to the selected host
-                                $('#backup\\.Host').after('<span class="host_rsyncd_warning"><b>WARNING!</b> Rsync server is disabled on remote host, please enable rsync under FPP Settings -> Services -> OS Services on ' + hostHref + ' </span');
-                                //<span><b>WARNING!</b> Rsync server is disabled on this host, please enable under FPP Settings -> System -> OS Services on *host*</span
-                            } else {
-                                //remove the warning text in case it's hanging around from a previous host
-                                $('.host_rsyncd_warning').remove();
-                            }
-                        } else {
-                            //something went wrong
-                            $.jGrowl('Error occurred reading the Service_rsync value from host - ' + host, { themeState: 'danger' });
-                        }
-                    },
-                    error: function (data) {
-                        //something went wrong
-                        $.jGrowl('Error occurred reading the Service_rsync value from host - ' + host, { themeState: 'danger' });
-                    }
-                });
-            }
-
-            //Retrieves a list of available backup devices on the selected remote host
-            function GetRemoteHostUSBStorage() {
-                //Very similar to GetBackupDevices() but adapted to collect storage info from a remote system
-                var host = document.getElementById("backup.Host").value;
-                // Proxy through the local API (?ip=) so the browser stays
-                // same-origin instead of calling the remote directly.
-                var requestUrl = "api/backups/devices?ip=" + encodeURIComponent(host);
-                var default_none_selected_option = "<option value='none' selected>Default FPP Storage</option>";
-
-                // $('#backup\\.USBDevice').html('<option>Loading...</option>');
-                //Add a loading spinner to show something is happening
-                $('#backup\\.RemoteStorage').parent().closest('td').addClass('fpp-backup-action-loading');
-
-                $.get(requestUrl
-                ).done(function (data) {
-                    var options = "";
-
-                    for (var i = 0; i < data.length; i++) {
-                        var desc = data[i].name;
-                        if (data[i].vendor != '')
-                            desc += ' - ' + data[i].vendor;
-
-                        if (data[i].model != '') {
-                            if (data[i].vendor != '')
-                                desc += ' ';
-                            else
-                                desc += ' - ';
-
-                            desc += data[i].model;
-                        }
-
-                        desc += ' - ' + data[i].size + 'GB';
-                        options += "<option value='" + data[i].name + "'>" + desc + "</option>";
-                    }
-                    //Populate the dropdown with the detected storage devices
-                    $('#backup\\.RemoteStorage').html(default_none_selected_option + options);
-
-                    //Remove the loading spinner
-                    $('#backup\\.RemoteStorage').parent().closest('td').removeClass('fpp-backup-action-loading');
-
-                    if (options !== "") {
-                        //After populating the list, Get the currently set remote host storage device
-                        GetBackupRemoteStorageDevice();
-                    }
-                }).fail(function () {
-                    $('#backup\\.RemoteStorage').html(default_none_selected_option);
-                });
             }
 
             //Save the selected remote backup storage device selection to settings

--- a/www/backup.php
+++ b/www/backup.php
@@ -2230,6 +2230,7 @@ if ($skipHTMLCodeOutput === false) {
 
             function GetBackupHostBackupDirs(remoteStorageSelected) {
                 fppFileCopy.getBackupHostBackupDirs(remoteStorageSelected);
+                GetRemoteHostUSBStorage();
             }
 
             function PopulateBackupDirs(data, excludeRoot) {

--- a/www/initialSetup.php
+++ b/www/initialSetup.php
@@ -143,7 +143,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['restoreFile'])) {
         }
     }
     ?>
+    <script src="js/fpp-backup-filecopy.js"></script>
     <script>
+        fppFileCopy.config = {
+            direction: '#fileCopyDirection',
+            usbDevice: '#fcUSBDevice',
+            pathSelect: '#fcPathSelect',
+            host: '#fcHost',
+            remoteStorage: '#fcRemoteStorage',
+            deleteExtra: '#fcDeleteExtra',
+            copyText: '#fileCopyText',
+            showUSB: '.fcUSB',
+            showHost: '.fcHost',
+            showHostDevice: '.fcHostDevice',
+            showPathSelect: '.fcPathSelect',
+            showPath: '.fcPath',
+            showBackups: '.fcBackups',
+            showCompressed: '.fcCompressed',
+            popupModalId: 'fileCopyPopup_Modal',
+            popupCloseBtnId: 'fileCopyPopup_ModalCloseButton',
+            copyPopupBodyId: 'fileCopyPopup'
+        };
+
         // Store all pending setting changes
         var pendingSettings = {};
 
@@ -266,131 +287,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['restoreFile'])) {
 
         // File Copy Restore functions
         function fileCopyDirectionChanged() {
-            var direction = document.getElementById('fileCopyDirection').value;
-            $('.fcUSB').hide();
-            $('.fcHost').hide();
-            $('.fcHostDevice').hide();
-            $('.fcPathSelect').hide();
-            switch (direction) {
-                case 'FROMUSB':
-                    $('.fcUSB').show();
-                    $('.fcPathSelect').show();
-                    GetBackupDeviceDirectories();
-                    break;
-                case 'FROMLOCAL':
-                    $('.fcPathSelect').show();
-                    GetBackupDirsViaAPI(window.location.host, '', true);
-                    break;
-                case 'FROMREMOTE':
-                    $('.fcHost').show();
-                    $('.fcHostDevice').show();
-                    $('.fcPathSelect').show();
-                    if ($('#fcHost').val()) {
-                        GetRemoteHostUSBStorage();
-                    }
-                    break;
-            }
+            fppFileCopy.directionChanged();
         }
 
         function GetBackupDevices() {
-            $('#fcUSBDevice').html('<option>Loading...</option>');
-            $.get('api/backups/devices').done(function (data) {
-                var options = '';
-                for (var i = 0; i < data.length; i++) {
-                    var desc = data[i].name;
-                    if (data[i].vendor != '') desc += ' - ' + data[i].vendor;
-                    if (data[i].model != '') {
-                        if (data[i].vendor != '') desc += ' ';
-                        else desc += ' - ';
-                        desc += ' ' + data[i].model;
-                    }
-                    desc += ' - ' + data[i].size + 'GB';
-                    options += "<option value='" + data[i].name + "'>" + desc + "</option>";
-                }
-                $('#fcUSBDevice').html(options);
-            }).fail(function () {
-                $('#fcUSBDevice').html('');
-            });
+            fppFileCopy.getBackupDevices();
         }
 
         function GetBackupDeviceDirectories() {
-            var dev = $('#fcUSBDevice').val();
-            if (!dev) {
-                $('#fcPathSelect').html("<option value=''>No USB Device Selected</option>");
-                return;
-            }
-            $('#fcPathSelect').html('<option>Loading...</option>');
-            $.get('api/backups/list/' + dev).done(function (data) {
-                PopulateBackupDirs(data);
-            }).fail(function () {
-                $('#fcPathSelect').html('');
-            });
+            fppFileCopy.getBackupDeviceDirectories();
         }
 
         function USBDeviceChanged() {
-            var direction = document.getElementById('fileCopyDirection').value;
-            if (direction == 'FROMUSB') GetBackupDeviceDirectories();
+            fppFileCopy.usbDeviceChanged();
         }
 
         function GetBackupDirsViaAPI(host, remoteStorageSelected, excludeRoot) {
-            $('#fcPathSelect').html('<option>Loading...</option>');
-            var url = 'api/backups/list';
-            if (remoteStorageSelected && remoteStorageSelected !== 'none') {
-                url = 'api/backups/list/' + encodeURIComponent(remoteStorageSelected);
-            }
-            if (host && host !== window.location.host) {
-                url += (url.indexOf('?') === -1 ? '?' : '&') + 'ip=' + encodeURIComponent(host);
-            }
-            $.get(url).done(function (data) {
-                PopulateBackupDirs(data, excludeRoot);
-            }).fail(function () {
-                $('#fcPathSelect').html('');
-            });
+            fppFileCopy.getBackupDirsViaAPI(host, remoteStorageSelected, excludeRoot);
         }
 
         function GetBackupHostBackupDirs(remoteStorageSelected) {
-            var selStorage = (remoteStorageSelected && remoteStorageSelected !== 'none') ? remoteStorageSelected : '';
-            GetBackupDirsViaAPI($('#fcHost').val(), selStorage, true);
+            fppFileCopy.getBackupHostBackupDirs(remoteStorageSelected);
         }
 
         function GetRemoteHostUSBStorage() {
-            var host = $('#fcHost').val();
-            if (!host) return;
-            var requestUrl = 'api/backups/devices?ip=' + encodeURIComponent(host);
-            var defaultOption = "<option value='none'>Default FPP Storage</option>";
-            $('#fcRemoteStorage').parent().closest('td').addClass('fpp-backup-action-loading');
-            $.get(requestUrl).done(function (data) {
-                var options = '';
-                for (var i = 0; i < data.length; i++) {
-                    var desc = data[i].name;
-                    if (data[i].vendor != '') desc += ' - ' + data[i].vendor;
-                    if (data[i].model != '') {
-                        if (data[i].vendor != '') desc += ' ';
-                        else desc += ' - ';
-                        desc += ' ' + data[i].model;
-                    }
-                    desc += ' - ' + data[i].size + 'GB';
-                    options += "<option value='" + data[i].name + "'>" + desc + "</option>";
-                }
-                $('#fcRemoteStorage').html(defaultOption + options);
-                $('#fcRemoteStorage').parent().closest('td').removeClass('fpp-backup-action-loading');
-                if (options) GetBackupHostBackupDirs($('#fcRemoteStorage').val());
-            }).fail(function () {
-                $('#fcRemoteStorage').html(defaultOption);
-                $('#fcRemoteStorage').parent().closest('td').removeClass('fpp-backup-action-loading');
-            });
+            fppFileCopy.getRemoteHostUSBStorage();
         }
 
         function PopulateBackupDirs(data, excludeRoot) {
-            var options = '';
-            for (var i = 0; i < data.length; i++) {
-                if (excludeRoot && data[i] == '/') continue;
-                if (data[i].substring(0, 5) != 'ERROR')
-                    options += "<option value='" + data[i] + "'>" + data[i] + "</option>";
-                else
-                    options += "<option value=''>" + data[i] + "</option>";
-            }
-            $('#fcPathSelect').html(options);
+            fppFileCopy.populateBackupDirs(data, excludeRoot);
         }
 
         function GetFileCopyFlags() {
@@ -470,6 +395,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['restoreFile'])) {
                         class: 'btn-secondary',
                         click: function () {
                             CloseFileCopyDialog();
+                            window.location.href = '/';
                         }
                     }
                 }
@@ -481,36 +407,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['restoreFile'])) {
         }
 
         function CloseFileCopyDialog() {
-            CloseModalDialog('fileCopyPopup_Modal');
+            fppFileCopy.closeCopyDialog();
         }
 
         function FileCopyDone() {
-            EnableModalDialogCloseButton('fileCopyPopup_Modal');
+            fppFileCopy.copyDone();
         }
 
         function FileCopyTimeoutError() {
-            var logUrl = 'api/file/Logs/fpp_backup_filecopy.log';
-            var timeoutMsg = '!!! Attempting to track file copy process via its fallback log file...\n The file copy is still running in the background and will complete in due course.\n\n';
-            var lastLen = 0;
-
-            $('#fileCopyText').val(timeoutMsg);
-
-            var tailInterval = setInterval(function () {
-                $.get(logUrl, function (text) {
-                    if (text === 'File does not exist.') {
-                        clearInterval(tailInterval);
-                        FileCopyDone();
-                    } else {
-                        $('#fileCopyText').val(timeoutMsg + text);
-                        var el = $('#fileCopyText');
-                        el.scrollTop(el.prop('scrollHeight'));
-                        if (text.includes('unmounted from') || text.length === 0) {
-                            clearInterval(tailInterval);
-                            FileCopyDone();
-                        }
-                    }
-                });
-            }, 1000);
+            fppFileCopy.copyTimeoutError();
         }
 
         function showSetupProgress(msg) {

--- a/www/initialSetup.php
+++ b/www/initialSetup.php
@@ -87,6 +87,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['restoreFile'])) {
         #restoreSection .btn, #restoreSection small {
             font-size: 0.875rem;
         }
+        .fpp-backup-action-loading::after {
+            content: '';
+            display: inline-block;
+            width: 1em;
+            height: 1em;
+            border: 2px solid rgba(0,0,0,0.1);
+            border-left-color: var(--fpp-primary, #0d6efd);
+            border-radius: 50%;
+            animation: fpp-spin 0.6s linear infinite;
+            vertical-align: middle;
+            margin-left: 0.25em;
+        }
+        @keyframes fpp-spin {
+            to { transform: rotate(360deg); }
+        }
+        .fileCopyFields label { font-weight: 600; }
+        #fcFlagsTable td { vertical-align: top; white-space: nowrap; }
     </style>
     <?php
     include 'common/htmlMeta.inc';
@@ -115,6 +132,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['restoreFile'])) {
         if (isset($settings[$f]) && $settings[$f] == '1') {
             $alreadyConfigured = 1;
             break;
+        }
+    }
+
+    $backupHosts = getKnownFPPSystems();
+    $hostOptions = '';
+    if (!empty($backupHosts)) {
+        foreach ($backupHosts as $desc => $addr) {
+            $hostOptions .= '<option value="' . htmlspecialchars($addr) . '">' . htmlspecialchars($desc) . '</option>';
         }
     }
     ?>
@@ -237,6 +262,255 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['restoreFile'])) {
                     );
                 }
             });
+        }
+
+        // File Copy Restore functions
+        function fileCopyDirectionChanged() {
+            var direction = document.getElementById('fileCopyDirection').value;
+            $('.fcUSB').hide();
+            $('.fcHost').hide();
+            $('.fcHostDevice').hide();
+            $('.fcPathSelect').hide();
+            switch (direction) {
+                case 'FROMUSB':
+                    $('.fcUSB').show();
+                    $('.fcPathSelect').show();
+                    GetBackupDeviceDirectories();
+                    break;
+                case 'FROMLOCAL':
+                    $('.fcPathSelect').show();
+                    GetBackupDirsViaAPI(window.location.host, '', true);
+                    break;
+                case 'FROMREMOTE':
+                    $('.fcHost').show();
+                    $('.fcHostDevice').show();
+                    $('.fcPathSelect').show();
+                    if ($('#fcHost').val()) {
+                        GetRemoteHostUSBStorage();
+                    }
+                    break;
+            }
+        }
+
+        function GetBackupDevices() {
+            $('#fcUSBDevice').html('<option>Loading...</option>');
+            $.get('api/backups/devices').done(function (data) {
+                var options = '';
+                for (var i = 0; i < data.length; i++) {
+                    var desc = data[i].name;
+                    if (data[i].vendor != '') desc += ' - ' + data[i].vendor;
+                    if (data[i].model != '') {
+                        if (data[i].vendor != '') desc += ' ';
+                        else desc += ' - ';
+                        desc += ' ' + data[i].model;
+                    }
+                    desc += ' - ' + data[i].size + 'GB';
+                    options += "<option value='" + data[i].name + "'>" + desc + "</option>";
+                }
+                $('#fcUSBDevice').html(options);
+            }).fail(function () {
+                $('#fcUSBDevice').html('');
+            });
+        }
+
+        function GetBackupDeviceDirectories() {
+            var dev = $('#fcUSBDevice').val();
+            if (!dev) {
+                $('#fcPathSelect').html("<option value=''>No USB Device Selected</option>");
+                return;
+            }
+            $('#fcPathSelect').html('<option>Loading...</option>');
+            $.get('api/backups/list/' + dev).done(function (data) {
+                PopulateBackupDirs(data);
+            }).fail(function () {
+                $('#fcPathSelect').html('');
+            });
+        }
+
+        function USBDeviceChanged() {
+            var direction = document.getElementById('fileCopyDirection').value;
+            if (direction == 'FROMUSB') GetBackupDeviceDirectories();
+        }
+
+        function GetBackupDirsViaAPI(host, remoteStorageSelected, excludeRoot) {
+            $('#fcPathSelect').html('<option>Loading...</option>');
+            var url = 'api/backups/list';
+            if (remoteStorageSelected && remoteStorageSelected !== 'none') {
+                url = 'api/backups/list/' + encodeURIComponent(remoteStorageSelected);
+            }
+            if (host && host !== window.location.host) {
+                url += (url.indexOf('?') === -1 ? '?' : '&') + 'ip=' + encodeURIComponent(host);
+            }
+            $.get(url).done(function (data) {
+                PopulateBackupDirs(data, excludeRoot);
+            }).fail(function () {
+                $('#fcPathSelect').html('');
+            });
+        }
+
+        function GetBackupHostBackupDirs(remoteStorageSelected) {
+            var selStorage = (remoteStorageSelected && remoteStorageSelected !== 'none') ? remoteStorageSelected : '';
+            GetBackupDirsViaAPI($('#fcHost').val(), selStorage, true);
+        }
+
+        function GetRemoteHostUSBStorage() {
+            var host = $('#fcHost').val();
+            if (!host) return;
+            var requestUrl = 'api/backups/devices?ip=' + encodeURIComponent(host);
+            var defaultOption = "<option value='none'>Default FPP Storage</option>";
+            $('#fcRemoteStorage').parent().closest('td').addClass('fpp-backup-action-loading');
+            $.get(requestUrl).done(function (data) {
+                var options = '';
+                for (var i = 0; i < data.length; i++) {
+                    var desc = data[i].name;
+                    if (data[i].vendor != '') desc += ' - ' + data[i].vendor;
+                    if (data[i].model != '') {
+                        if (data[i].vendor != '') desc += ' ';
+                        else desc += ' - ';
+                        desc += ' ' + data[i].model;
+                    }
+                    desc += ' - ' + data[i].size + 'GB';
+                    options += "<option value='" + data[i].name + "'>" + desc + "</option>";
+                }
+                $('#fcRemoteStorage').html(defaultOption + options);
+                $('#fcRemoteStorage').parent().closest('td').removeClass('fpp-backup-action-loading');
+                if (options) GetBackupHostBackupDirs($('#fcRemoteStorage').val());
+            }).fail(function () {
+                $('#fcRemoteStorage').html(defaultOption);
+                $('#fcRemoteStorage').parent().closest('td').removeClass('fpp-backup-action-loading');
+            });
+        }
+
+        function PopulateBackupDirs(data, excludeRoot) {
+            var options = '';
+            for (var i = 0; i < data.length; i++) {
+                if (excludeRoot && data[i] == '/') continue;
+                if (data[i].substring(0, 5) != 'ERROR')
+                    options += "<option value='" + data[i] + "'>" + data[i] + "</option>";
+                else
+                    options += "<option value=''>" + data[i] + "</option>";
+            }
+            $('#fcPathSelect').html(options);
+        }
+
+        function GetFileCopyFlags() {
+            var flags = '';
+            $('.fcFlag:checked').each(function () {
+                flags += ' ' + $(this).val();
+            });
+            return flags.trim();
+        }
+
+        function PerformFileCopyRestore() {
+            var direction = $('#fileCopyDirection').val();
+            var host = $('#fcHost').val();
+            var remoteStorage = $('#fcRemoteStorage').val();
+            var path = $('#fcPathSelect').val();
+            var flags = GetFileCopyFlags();
+
+            if (!path) {
+                DialogError('Restore Failed', 'No backup path specified');
+                return;
+            }
+            if (!flags) {
+                DialogError('Restore Failed', 'No items selected to restore');
+                return;
+            }
+
+            var storageLocation;
+            var url = 'copystorage.php?wrapped=1&direction=' + direction;
+
+            if (direction == 'FROMUSB') {
+                storageLocation = $('#fcUSBDevice').val();
+                if (!storageLocation || storageLocation == 'none') {
+                    DialogError('Restore Failed', 'No USB device selected');
+                    return;
+                }
+            } else if (direction == 'FROMREMOTE') {
+                if (!host) {
+                    DialogError('Restore Failed', 'No remote host specified');
+                    return;
+                }
+                if (remoteStorage && remoteStorage !== 'none') {
+                    url += '&remoteStorage=' + remoteStorage;
+                }
+                storageLocation = host;
+            } else {
+                storageLocation = settings['mediaDirectory'] + '/backups';
+            }
+
+            url += '&path=' + path;
+            url += '&storageLocation=' + storageLocation;
+            url += '&flags=' + flags;
+            url += '&delete=' + ($('#fcDeleteExtra').is(':checked') ? 'yes' : 'no');
+            url += '&compress=no';
+
+            if (!confirm("Confirm File restore of '" + flags + "' from " + storageLocation + "?\n\nWARNING: This will overwrite any current files with the copies being restored")) {
+                return;
+            }
+
+            $('#restoreDialog').fppDialog('close');
+
+            var titleTxt = 'FPP File Copy Restore';
+            DoModalDialog({
+                id: 'fileCopyPopup_Modal',
+                title: titleTxt,
+                height: 600,
+                width: 900,
+                autoResize: true,
+                closeOnEscape: false,
+                backdrop: true,
+                body: $('#fileCopyPopup').html(),
+                class: 'no-close modal-dialog-scrollable',
+                buttons: {
+                    Close: {
+                        text: 'Please Wait',
+                        disabled: true,
+                        id: 'fileCopyPopup_ModalCloseButton',
+                        class: 'btn-secondary',
+                        click: function () {
+                            CloseFileCopyDialog();
+                        }
+                    }
+                }
+            });
+
+            $('#fileCopyPopup_ModalCloseButton').prop('disabled', true).text('Please Wait');
+            $('#fileCopyText').val('');
+            StreamURL(url, 'fileCopyText', 'FileCopyDone', 'FileCopyTimeoutError');
+        }
+
+        function CloseFileCopyDialog() {
+            CloseModalDialog('fileCopyPopup_Modal');
+        }
+
+        function FileCopyDone() {
+            EnableModalDialogCloseButton('fileCopyPopup_Modal');
+        }
+
+        function FileCopyTimeoutError() {
+            var logUrl = 'api/file/Logs/fpp_backup_filecopy.log';
+            var timeoutMsg = '!!! Attempting to track file copy process via its fallback log file...\n The file copy is still running in the background and will complete in due course.\n\n';
+            var lastLen = 0;
+
+            $('#fileCopyText').val(timeoutMsg);
+
+            var tailInterval = setInterval(function () {
+                $.get(logUrl, function (text) {
+                    if (text === 'File does not exist.') {
+                        clearInterval(tailInterval);
+                        FileCopyDone();
+                    } else {
+                        $('#fileCopyText').val(timeoutMsg + text);
+                        var el = $('#fileCopyText');
+                        el.scrollTop(el.prop('scrollHeight'));
+                        if (text.includes('unmounted from') || text.length === 0) {
+                            clearInterval(tailInterval);
+                            FileCopyDone();
+                        }
+                    }
+                });
+            }, 1000);
         }
 
         function showSetupProgress(msg) {
@@ -660,43 +934,168 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['restoreFile'])) {
         </div>
 
         <div id="restoreDialog" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog" role="document">
+            <div class="modal-dialog modal-lg" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title"><i class="fas fa-upload"></i> Restore from Backup</h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        <p class="text-muted small mb-2">Upload a JSON backup file to restore all settings. All current settings will be overwritten.</p>
-                        <div id="dropZone" class="border border-primary rounded text-center py-3 px-2"
-                            onclick="document.getElementById('restoreFileInput').click()">
-                            <div>
-                                <div><i class="fas fa-cloud-upload-alt fa-lg text-primary"></i></div>
-                                <p class="mb-0 small fw-bold">Drag file here or click to browse</p>
+                        <div class="mb-3">
+                            <label class="fw-bold mb-2">Restore Type</label>
+                            <select id="restoreType" class="form-select" onchange="restoreTypeChanged()">
+                                <option value="json">JSON Configuration Restore</option>
+                                <option value="filecopy">File Copy Restore</option>
+                            </select>
+                        </div>
+
+                        <div id="jsonRestoreSection">
+                            <p class="text-muted small mb-2">Upload a JSON backup file to restore configuration settings.</p>
+                            <div class="alert alert-info small py-2 mb-2">
+                                <i class="fas fa-info-circle"></i> The JSON Configuration backup file does not contain sequences, media, plugin files, or additional files. You will need to upload those files or perform an FPP Connect from xLights to restore your data.
+                            </div>
+                            <div id="dropZone" class="border border-primary rounded text-center py-3 px-2"
+                                onclick="document.getElementById('restoreFileInput').click()">
+                                <div>
+                                    <div><i class="fas fa-cloud-upload-alt fa-lg text-primary"></i></div>
+                                    <p class="mb-0 small fw-bold">Drag file here or click to browse</p>
+                                </div>
+                            </div>
+                            <input type="file" id="restoreFileInput" accept=".json" class="d-none">
+                            <div id="restoreFileInfo" class="d-none mt-1">
+                                <span class="text-success small"><i class="fas fa-check-circle"></i> <span id="restoreFileName" class="fw-bold"></span></span>
+                                <button type="button" class="btn btn-sm btn-outline-secondary py-0 px-1 ms-1" onclick="clearRestoreFile()"><i class="fas fa-times"></i></button>
+                            </div>
+                            <div id="restoreStatus" class="mt-1 d-none"></div>
+                        </div>
+
+                        <div id="fileCopySection" class="d-none">
+                            <p class="text-muted small mb-2">Restore configuration, sequences, plugins, and other files from a backup directory.</p>
+                            <table class="fileCopyFields">
+                                <tr>
+                                    <td class="pe-3 pb-2" style="white-space: nowrap;">Restore from:</td>
+                                    <td class="pb-2">
+                                        <select id="fileCopyDirection" class="form-select" onchange="fileCopyDirectionChanged()">
+                                            <option value="FROMUSB">Restore from USB</option>
+                                            <option value="FROMLOCAL">Restore from Local FPP Backups Directory</option>
+                                            <option value="FROMREMOTE">Restore from Remote FPP Backups Directory</option>
+                                        </select>
+                                    </td>
+                                </tr>
+                                <tr class="fcUSB" style="display: none;">
+                                    <td class="pe-3 pb-2">USB Device:</td>
+                                    <td class="pb-2">
+                                        <select id="fcUSBDevice" class="form-select d-inline w-auto" onchange="USBDeviceChanged()"></select>
+                                        <input type='button' class='buttons btn-sm' onClick='GetBackupDevices();' value='Refresh List'>
+                                    </td>
+                                </tr>
+                                <tr class="fcHost" style="display: none;">
+                                    <td class="pe-3 pb-2">Remote Host:</td>
+                                    <td class="pb-2">
+                                        <select id="fcHost" class="form-select" onchange="GetBackupHostBackupDirs($('#fcRemoteStorage').val())">
+                                            <option value="">-- Select Remote Host --</option>
+                                            <?php echo $hostOptions; ?>
+                                        </select>
+                                    </td>
+                                </tr>
+                                <tr class="fcHostDevice" style="display: none;">
+                                    <td class="pe-3 pb-2">Remote Storage:</td>
+                                    <td class="pb-2">
+                                        <select id="fcRemoteStorage" class="form-select" onchange="GetBackupHostBackupDirs($(this).val())">
+                                            <option value="none">Default FPP Storage</option>
+                                        </select>
+                                    </td>
+                                </tr>
+                                <tr class="fcPathSelect" style="display: none;">
+                                    <td class="pe-3 pb-2">Backup Path:</td>
+                                    <td class="pb-2">
+                                        <select id="fcPathSelect" class="form-select"></select>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <div class="mt-2">
+                                <label class="fw-bold">What to restore:</label>
+                                <table id="fcFlagsTable">
+                                    <tr>
+                                        <td>
+                                            <input type='checkbox' class='fcFlag' value='Configuration' id='fcFlagConfig' checked>Configuration<br>
+                                            <input type='checkbox' class='fcFlag' value='Playlists' id='fcFlagPlaylists' checked>Playlists<br>
+                                        </td>
+                                        <td width='10px'></td>
+                                        <td>
+                                            <input type='checkbox' class='fcFlag' value='Plugins' id='fcFlagPlugins' checked>Plugins<br>
+                                        </td>
+                                        <td width='10px'></td>
+                                        <td>
+                                            <input type='checkbox' class='fcFlag' value='Sequences' id='fcFlagSequences' checked>Sequences<br>
+                                            <input type='checkbox' class='fcFlag' value='Images' id='fcFlagImages' checked>Images<br>
+                                        </td>
+                                        <td width='10px'></td>
+                                        <td>
+                                            <input type='checkbox' class='fcFlag' value='Scripts' id='fcFlagScripts' checked>Scripts<br>
+                                            <input type='checkbox' class='fcFlag' value='Effects' id='fcFlagEffects' checked>Effects<br>
+                                        </td>
+                                        <td width='10px'></td>
+                                        <td>
+                                            <input type='checkbox' class='fcFlag' value='Music' id='fcFlagMusic' checked>Music<br>
+                                            <input type='checkbox' class='fcFlag' value='Videos' id='fcFlagVideos' checked>Videos<br>
+                                        </td>
+                                        <td width='10px'></td>
+                                        <td>
+                                            <input type='checkbox' class='fcFlag' value='EEPROM' id='fcFlagEEPROM' checked>Virtual EEPROM<br>
+                                        </td>
+                                    </tr>
+                                </table>
+                                <div class="mt-1">
+                                    Delete extras:
+                                    <input type='checkbox' id='fcDeleteExtra'>
+                                    (Delete extra files on destination that do not exist in the backup)
+                                </div>
                             </div>
                         </div>
-                        <input type="file" id="restoreFileInput" accept=".json" class="d-none">
-                        <div id="restoreFileInfo" class="d-none mt-1">
-                            <span class="text-success small"><i class="fas fa-check-circle"></i> <span id="restoreFileName" class="fw-bold"></span></span>
-                            <button type="button" class="btn btn-sm btn-outline-secondary py-0 px-1 ms-1" onclick="clearRestoreFile()"><i class="fas fa-times"></i></button>
-                        </div>
-                        <div id="restoreStatus" class="mt-1 d-none"></div>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="buttons" data-bs-dismiss="modal">Cancel</button>
                         <button type="button" id="uploadRestoreBtn" class="buttons btn-success" disabled onclick="uploadRestoreFile()">
                             <i class="fas fa-upload"></i> Upload &amp; Restore
                         </button>
+                        <button type="button" id="fileCopyRestoreBtn" class="buttons btn-success d-none" onclick="PerformFileCopyRestore()">
+                            <i class="fas fa-undo"></i> Restore
+                        </button>
                     </div>
                 </div>
             </div>
         </div>
 
+        <div id="fileCopyPopup" class="d-none">
+            <textarea class="w-100" style="height: 55vh; min-height: 200px;" disabled id="fileCopyText"></textarea>
+        </div>
+
         <script>
+        function restoreTypeChanged() {
+            var type = $('#restoreType').val();
+            if (type == 'json') {
+                $('#jsonRestoreSection').removeClass('d-none');
+                $('#fileCopySection').addClass('d-none');
+                $('#uploadRestoreBtn').removeClass('d-none');
+                $('#fileCopyRestoreBtn').addClass('d-none');
+            } else {
+                $('#jsonRestoreSection').addClass('d-none');
+                $('#fileCopySection').removeClass('d-none');
+                $('#uploadRestoreBtn').addClass('d-none');
+                $('#fileCopyRestoreBtn').removeClass('d-none');
+                fileCopyDirectionChanged();
+            }
+        }
+
         function openRestoreDialog() {
             clearRestoreFile();
+            $('#restoreType').val('json');
+            restoreTypeChanged();
             $('#restoreDialog').fppDialog('open');
             setupDropZone();
+            GetBackupDevices();
         }
         </script>
 </body>

--- a/www/initialSetup.php
+++ b/www/initialSetup.php
@@ -87,21 +87,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['restoreFile'])) {
         #restoreSection .btn, #restoreSection small {
             font-size: 0.875rem;
         }
-        .fpp-backup-action-loading::after {
-            content: '';
-            display: inline-block;
-            width: 1em;
-            height: 1em;
-            border: 2px solid rgba(0,0,0,0.1);
-            border-left-color: var(--fpp-primary, #0d6efd);
-            border-radius: 50%;
-            animation: fpp-spin 0.6s linear infinite;
-            vertical-align: middle;
-            margin-left: 0.25em;
-        }
-        @keyframes fpp-spin {
-            to { transform: rotate(360deg); }
-        }
         .fileCopyFields label { font-weight: 600; }
         #fcFlagsTable td { vertical-align: top; white-space: nowrap; }
     </style>
@@ -897,7 +882,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['restoreFile'])) {
                                 <tr class="fcHost" style="display: none;">
                                     <td class="pe-3 pb-2">Remote Host:</td>
                                     <td class="pb-2">
-                                        <select id="fcHost" class="form-select" onchange="GetBackupHostBackupDirs($('#fcRemoteStorage').val())">
+                                        <select id="fcHost" class="form-select" onchange="GetRemoteHostUSBStorage(); GetBackupHostBackupDirs($('#fcRemoteStorage').val())">
                                             <option value="">-- Select Remote Host --</option>
                                             <?php echo $hostOptions; ?>
                                         </select>

--- a/www/js/fpp-backup-filecopy.js
+++ b/www/js/fpp-backup-filecopy.js
@@ -1,0 +1,302 @@
+var fppFileCopy = fppFileCopy || {};
+
+fppFileCopy.config = {
+    direction: '#backup\\.Direction',
+    usbDevice: '#backup\\.USBDevice',
+    pathSelect: '#backup\\.PathSelect',
+    host: '#backup\\.Host',
+    remoteStorage: '#backup\\.RemoteStorage',
+    deleteExtra: '#backup\\.DeleteExtra',
+    copyText: '#copyText',
+    showUSB: '.copyUSB',
+    showHost: '.copyHost',
+    showHostDevice: '.copyHostDevice',
+    showPathSelect: '.copyPathSelect',
+    showPath: '.copyPath',
+    showBackups: '.copyBackups',
+    showCompressed: '.sendCompressed',
+    popupModalId: 'copyPopup_Modal',
+    popupCloseBtnId: 'copyPopup_ModalCloseButton',
+    copyPopupBodyId: 'copyPopup',
+    onDevicesLoaded: null,
+    onCopyDone: null,
+    hostChangeFunction: null,
+    usbChangeFunction: null
+};
+
+fppFileCopy.directionChanged = function () {
+    var direction = $(fppFileCopy.config.direction).val();
+
+    $(fppFileCopy.config.showUSB).hide();
+    $(fppFileCopy.config.showHost).hide();
+    $(fppFileCopy.config.showHostDevice).hide();
+    $(fppFileCopy.config.showPathSelect).hide();
+    $(fppFileCopy.config.showPath).hide();
+    $(fppFileCopy.config.showBackups).hide();
+    $(fppFileCopy.config.showCompressed).hide();
+
+    switch (direction) {
+        case 'TOUSB':
+            $(fppFileCopy.config.showUSB).show();
+            $(fppFileCopy.config.showPath).show();
+            $(fppFileCopy.config.showBackups).show();
+            fppFileCopy.getRestoreDeviceDirectories();
+            break;
+        case 'FROMUSB':
+            $(fppFileCopy.config.showUSB).show();
+            $(fppFileCopy.config.showPathSelect).show();
+            fppFileCopy.getBackupDeviceDirectories();
+            break;
+        case 'TOLOCAL':
+            $(fppFileCopy.config.showPath).show();
+            break;
+        case 'FROMLOCAL':
+            $(fppFileCopy.config.showPathSelect).show();
+            fppFileCopy.getBackupDirsViaAPI(window.location.host, '', true);
+            break;
+        case 'TOREMOTE':
+            $(fppFileCopy.config.showHost).show();
+            $(fppFileCopy.config.showHostDevice).show();
+            $(fppFileCopy.config.showPath).show();
+            $(fppFileCopy.config.showCompressed).show();
+            fppFileCopy.checkRemoteHasRsyncdEnabled($(fppFileCopy.config.host).val());
+            fppFileCopy.getRemoteHostUSBStorage();
+            break;
+        case 'FROMREMOTE':
+            $(fppFileCopy.config.showHost).show();
+            $(fppFileCopy.config.showHostDevice).show();
+            $(fppFileCopy.config.showPathSelect).show();
+            $(fppFileCopy.config.showCompressed).show();
+            fppFileCopy.getBackupHostBackupDirs();
+            fppFileCopy.checkRemoteHasRsyncdEnabled($(fppFileCopy.config.host).val());
+            fppFileCopy.getRemoteHostUSBStorage();
+            break;
+    }
+};
+
+fppFileCopy.getBackupDevices = function () {
+    $(fppFileCopy.config.usbDevice).html('<option>Loading...</option>');
+    $(fppFileCopy.config.usbDevice).parent().closest('td').addClass('fpp-backup-action-loading');
+
+    $.get('api/backups/devices').done(function (data) {
+        var options = '';
+        for (var i = 0; i < data.length; i++) {
+            var desc = data[i].name;
+            if (data[i].vendor != '')
+                desc += ' - ' + data[i].vendor;
+            if (data[i].model != '') {
+                if (data[i].vendor != '')
+                    desc += ' ';
+                else
+                    desc += ' - ';
+                desc += ' ' + data[i].model;
+            }
+            desc += ' - ' + data[i].size + 'GB';
+            options += "<option value='" + data[i].name + "'>" + desc + "</option>";
+        }
+        $(fppFileCopy.config.usbDevice).html(options);
+        $(fppFileCopy.config.usbDevice).parent().closest('td').removeClass('fpp-backup-action-loading');
+
+        if (options != '') {
+            var dir = $(fppFileCopy.config.direction).val();
+            if (dir == 'FROMUSB')
+                fppFileCopy.getBackupDeviceDirectories();
+            else if (dir == 'TOUSB')
+                fppFileCopy.getRestoreDeviceDirectories();
+        }
+
+        if (fppFileCopy.config.onDevicesLoaded)
+            fppFileCopy.config.onDevicesLoaded(data);
+    }).fail(function () {
+        $(fppFileCopy.config.usbDevice).html('');
+        $(fppFileCopy.config.usbDevice).parent().closest('td').removeClass('fpp-backup-action-loading');
+    });
+};
+
+fppFileCopy.getBackupDeviceDirectories = function () {
+    var dev = $(fppFileCopy.config.usbDevice).val();
+    if (!dev) {
+        $(fppFileCopy.config.pathSelect).html("<option value=''>No USB Device Selected</option>");
+        return;
+    }
+    $(fppFileCopy.config.pathSelect).html('<option>Loading...</option>');
+    $.get('api/backups/list/' + dev).done(function (data) {
+        fppFileCopy.populateBackupDirs(data);
+    }).fail(function () {
+        $(fppFileCopy.config.pathSelect).html('');
+    });
+};
+
+fppFileCopy.getRestoreDeviceDirectories = function () {
+    var dev = $(fppFileCopy.config.usbDevice).val();
+    if (!dev) {
+        $(fppFileCopy.config.pathSelect).html("<option value=''>No USB Device Selected</option>");
+        return;
+    }
+    $('#usbDirectories').html('');
+    $.get('api/backups/list/' + dev).done(function (data) {
+        var options = '';
+        for (i = 0; i < data.length; i++) {
+            if (data[i].substring(0, 5) != 'ERROR')
+                options += "<option value='" + data[i] + "'>" + data[i] + "</option>";
+        }
+        $('#usbDirectories').html(options);
+    });
+};
+
+fppFileCopy.usbDeviceChanged = function () {
+    var direction = $(fppFileCopy.config.direction).val();
+    if (direction == 'FROMUSB')
+        fppFileCopy.getBackupDeviceDirectories();
+    else if (direction == 'TOUSB')
+        fppFileCopy.getRestoreDeviceDirectories();
+};
+
+fppFileCopy.getBackupDirsViaAPI = function (host, remoteStorageSelected, excludeRoot) {
+    $(fppFileCopy.config.pathSelect).html('<option>Loading...</option>');
+    var url = 'api/backups/list';
+    if (remoteStorageSelected && remoteStorageSelected !== 'none') {
+        url = 'api/backups/list/' + encodeURIComponent(remoteStorageSelected);
+    }
+    if (host && host !== window.location.host) {
+        url += (url.indexOf('?') === -1 ? '?' : '&') + 'ip=' + encodeURIComponent(host);
+    }
+    $(fppFileCopy.config.pathSelect).parent().closest('td').addClass('fpp-backup-action-loading');
+    $.get(url).done(function (data) {
+        fppFileCopy.populateBackupDirs(data, excludeRoot);
+        $(fppFileCopy.config.pathSelect).parent().closest('td').removeClass('fpp-backup-action-loading');
+    }).fail(function () {
+        $(fppFileCopy.config.pathSelect).html('');
+        $(fppFileCopy.config.pathSelect).parent().closest('td').removeClass('fpp-backup-action-loading');
+    });
+};
+
+fppFileCopy.getBackupHostBackupDirs = function (remoteStorageSelected) {
+    var selStorage = (remoteStorageSelected && remoteStorageSelected !== 'none') ? remoteStorageSelected : '';
+    fppFileCopy.getBackupDirsViaAPI($(fppFileCopy.config.host).val(), selStorage, true);
+    fppFileCopy.checkRemoteHasRsyncdEnabled($(fppFileCopy.config.host).val());
+};
+
+fppFileCopy.populateBackupDirs = function (data, excludeRoot) {
+    var options = '';
+    for (var i = 0; i < data.length; i++) {
+        if (excludeRoot && data[i] == '/') continue;
+        if (data[i].substring(0, 5) != 'ERROR')
+            options += "<option value='" + data[i] + "'>" + data[i] + "</option>";
+        else
+            options += "<option value=''>" + data[i] + "</option>";
+    }
+    $(fppFileCopy.config.pathSelect).html(options);
+};
+
+fppFileCopy.getRemoteHostUSBStorage = function () {
+    var host = $(fppFileCopy.config.host).val();
+    if (!host) return;
+    var requestUrl = 'api/backups/devices?ip=' + encodeURIComponent(host);
+    var defaultOption = "<option value='none' selected>Default FPP Storage</option>";
+    $(fppFileCopy.config.remoteStorage).parent().closest('td').addClass('fpp-backup-action-loading');
+    $.get(requestUrl).done(function (data) {
+        var options = '';
+        for (var i = 0; i < data.length; i++) {
+            var desc = data[i].name;
+            if (data[i].vendor != '') desc += ' - ' + data[i].vendor;
+            if (data[i].model != '') {
+                if (data[i].vendor != '') desc += ' ';
+                else desc += ' - ';
+                desc += ' ' + data[i].model;
+            }
+            desc += ' - ' + data[i].size + 'GB';
+            options += "<option value='" + data[i].name + "'>" + desc + "</option>";
+        }
+        $(fppFileCopy.config.remoteStorage).html(defaultOption + options);
+        $(fppFileCopy.config.remoteStorage).parent().closest('td').removeClass('fpp-backup-action-loading');
+        if (options) fppFileCopy.getBackupHostBackupDirs($(fppFileCopy.config.remoteStorage).val());
+    }).fail(function () {
+        $(fppFileCopy.config.remoteStorage).html(defaultOption);
+        $(fppFileCopy.config.remoteStorage).parent().closest('td').removeClass('fpp-backup-action-loading');
+    });
+};
+
+fppFileCopy.checkRemoteHasRsyncdEnabled = function (host) {
+    if (!host) return;
+    $.ajax({
+        url: 'api/settings/Service_rsync?ip=' + encodeURIComponent(host),
+        type: 'GET',
+        success: function (data) {
+            if (typeof (data) !== 'undefined') {
+                var rsyncd_setting_value = data['value'];
+                if (rsyncd_setting_value === 0 || rsyncd_setting_value === '0') {
+                    $('.host_rsyncd_warning').remove();
+                    var hostHref = "<a href='http://" + host + "/settings.php#settings-services' target='_blank'>" + host + "</a>";
+                    $(fppFileCopy.config.host).after('<span class="host_rsyncd_warning"><b>WARNING!</b> Rsync server is disabled on remote host, please enable rsync under FPP Settings -> Services -> OS Services on ' + hostHref + ' </span');
+                } else {
+                    $('.host_rsyncd_warning').remove();
+                }
+            }
+        },
+        error: function () {
+            $.jGrowl('Error occurred reading the Service_rsync value from host - ' + host, { themeState: 'danger' });
+        }
+    });
+};
+
+fppFileCopy.closeCopyDialog = function () {
+    var cd_remoteHost = $(fppFileCopy.config.host).val();
+    var cd_remoteStorage = $(fppFileCopy.config.remoteStorage).val();
+
+    if (cd_remoteHost && cd_remoteStorage && cd_remoteStorage !== 'none') {
+        $.post('api/backups/devices/unmount/' + encodeURIComponent(cd_remoteStorage) + '/remote_filecopy?ip=' + encodeURIComponent(cd_remoteHost));
+    }
+
+    CloseModalDialog(fppFileCopy.config.popupModalId);
+};
+
+fppFileCopy.copyDone = function () {
+    EnableModalDialogCloseButton(fppFileCopy.config.popupModalId);
+    if (fppFileCopy.config.onCopyDone) {
+        fppFileCopy.config.onCopyDone();
+    }
+};
+
+fppFileCopy.copyTimeoutError = function () {
+    var logUrl = 'api/file/Logs/fpp_backup_filecopy.log';
+    var timeoutMsg = '!!! Attempting to track file copy process via its fallback log file...\n The file copy is still running in the background and will complete in due course.\n\n';
+    var iterations = 0;
+    var iterationsWithNoDataWarningsIssued = 1;
+    var noNewDataIterationCount = 600;
+    var last_response_len = 0;
+    var outputArea = $(fppFileCopy.config.copyText);
+
+    outputArea.val(timeoutMsg);
+
+    var tailInterval = setInterval(function () {
+        $.get(logUrl, function (text) {
+            if (text === 'File does not exist.') {
+                clearInterval(tailInterval);
+                fppFileCopy.copyDone();
+            } else {
+                if (last_response_len === 0) {
+                    last_response_len = text.length;
+                }
+                if (last_response_len === text.length) {
+                    iterations += 1;
+                } else {
+                    iterations = 0;
+                    last_response_len = text.length;
+                }
+                var noNewDataError = '';
+                if (iterations === (noNewDataIterationCount * iterationsWithNoDataWarningsIssued)) {
+                    iterationsWithNoDataWarningsIssued += 1;
+                    noNewDataError = '\n!!! WARNING: No new log entries received in over ' + Math.floor(iterations / 60) + ' minutes, still waiting... !!!\n';
+                }
+                outputArea.val(timeoutMsg + text + noNewDataError);
+                outputArea.scrollTop(outputArea.prop('scrollHeight'));
+
+                if (text.includes('unmounted from') || text.length === 0) {
+                    clearInterval(tailInterval);
+                    fppFileCopy.copyDone();
+                }
+            }
+        });
+    }, 1000);
+};


### PR DESCRIPTION
# Add File Copy Restore option to Initial Setup restore dialog

## Summary

Enhances the **Restore from Backup** dialog on the initial setup page to support two restore methods: **JSON Configuration Restore** (existing behavior) and **File Copy Restore** (new, reusing the same backend logic as `backup.php#tab-fileCopy`).

As part of this work, the file-copy/backup/restore UI logic shared between `backup.php` and `initialSetup.php` was extracted into a reusable JavaScript module, eliminating ~420 lines of duplicated code and fixing several behavioral inconsistencies between the two pages.

## Changes

### New file: `www/js/fpp-backup-filecopy.js` (302 lines)

A shared JavaScript module extracted from the common file-copy logic previously duplicated across `backup.php` and `initialSetup.php`. Provides configurable helpers:

- `directionChanged` — shows/hides the correct field groups (USB, host, path, etc.) based on the selected direction (TOUSB, FROMUSB, TOLOCAL, FROMLOCAL, TOREMOTE, FROMREMOTE)
- `getBackupDevices` — fetches USB devices and triggers directory listing
- `getBackupDeviceDirectories` / `getRestoreDeviceDirectories` — list backup directories on USB
- `getBackupDirsViaAPI` — fetches backup directories (local or remote via `?ip=`)
- `populateBackupDirs` — populates the path `<select>` from API data
- `getBackupHostBackupDirs` — fetches remote host backup directories AND checks rsync status
- `getRemoteHostUSBStorage` — fetches available USB storage on a remote host
- `checkRemoteHasRsyncdEnabled` — queries remote rsync service status and shows a warning if disabled
- `closeCopyDialog` — unmounts remote storage and closes the modal
- `copyDone` / `copyTimeoutError` — enables the close button on completion; fallback polling for long-running copies

Configuration object (`fppFileCopy.config`) allows each page to supply its own DOM selectors, making the module page-agnostic.

### `www/initialSetup.php`

**Restore dialog now has two modes**, selectable via a dropdown at the top of the modal:

1. **JSON Configuration Restore** (default)
   - Unchanged upload-and-restore flow using the existing PHP handler (`doRestore('all', ...)`)
   - Added informational alert: *"The JSON Configuration backup file does not contain sequences, media, plugin files, or additional files..."*

2. **File Copy Restore**
   - Direction selector: **Restore from USB**, **Restore from Local FPP Backups Directory**, **Restore from Remote FPP Backups Directory**
   - Conditionally shows/hides USB device list, remote host dropdown, remote storage selector, and backup path dropdown based on the chosen direction
   - **"What to restore"** checkboxes (Configuration, Playlists, Plugins, Sequences, Images, Scripts, Effects, Music, Videos, Virtual EEPROM) — rendered as a table matching `backup.php`'s `#CopyFlagsTable` layout
   - **Delete extras** checkbox
   - Calls `copystorage.php` with the same parameters (`direction`, `storageLocation`, `path`, `flags`, `delete`, `compress`) as `backup.php`'s `PerformCopy()`
   - Progress popup using `StreamURL` + fallback log polling

- Added `<script src="js/fpp-backup-filecopy.js">` include
- Added page-specific config block mapping DOM IDs (`#fc*` selectors) to `fppFileCopy.config`
- **Removed ~97 lines** of duplicated file-copy helper functions — replaced with one-line wrappers delegating to `fppFileCopy.*`
- Kept page-specific functions: `GetFileCopyFlags`, `PerformFileCopyRestore`, JSON restore flow, `restoreTypeChanged`, `openRestoreDialog`

### `www/backup.php`

- Added `<script src="js/fpp-backup-filecopy.js">` include
- Added page-specific config block mapping DOM IDs to `fppFileCopy.config`
- **Removed ~324 lines** of duplicated file-copy helper functions — replaced with one-line wrappers delegating to `fppFileCopy.*`
- Kept page-specific functions: `GetCopyFlags`, `PerformCopy`, JSON backup flow, HTML

**No backend changes** — all logic reuses existing `copystorage.php`, `backup.php`, and API endpoints.

## Bug fixes

### jQuery selector escaping for dotted IDs (`backup.php`)

The backup page uses HTML IDs containing dots (e.g. `id="backup.USBDevice"`). jQuery interprets an unescaped dot as a CSS class selector, so `$('#backup.USBDevice')` matches `id="backup"` with class `USBDevice` — never the actual element.

**Fix:** All dotted ID selectors in both `backup.php` and the shared module default config were escaped with `\\` (e.g. `'#backup\\.USBDevice'`), so jQuery's selector engine sees the escaped dot and matches the literal ID.

### Inconsistent rsync-disabled warning

The "Rsync server is disabled on remote host" warning appeared on `backup.php` when restoring from a remote host but was missing from `initialSetup.php`'s restore dialog.

**Root cause:** The rsync check only ran during `directionChanged`, which fires before the user has selected a host (host value is empty → check exits early). `initialSetup.php` lacked the secondary trigger that `backup.php` had via `PrintSettingSelect`'s callback mechanism.

**Fix:** Added `fppFileCopy.checkRemoteHasRsyncdEnabled($(fppFileCopy.config.host).val())` to the shared `getBackupHostBackupDirs` function. This function is called whenever the host or remote storage dropdown changes on both pages, so the rsync check always fires after a host is selected.

### Remote storage dropdown never populates on host change

On `initialSetup.php`, selecting a remote host in the restore dialog left `#fcRemoteStorage` stuck on "Default FPP Storage" because the host `<select>`'s `onchange` only called `GetBackupHostBackupDirs()` — which fetches backup directories but never touches the storage dropdown. The `getRemoteHostUSBStorage()` function (which populates the storage dropdown) was only called once during `directionChanged()`, at which point the host field was still empty, causing it to no-op.

Same bug on `backup.php`: `PrintSettingSelect`'s generated callback only called `GetBackupHostBackupDirs` on host change, never refreshing remote storage.

**Fix (initialSetup.php):** Changed `#fcHost` onchange to call `GetRemoteHostUSBStorage()` before `GetBackupHostBackupDirs()`. `getRemoteHostUSBStorage()` already chains into `getBackupHostBackupDirs` on success, so the explicit call provides a fallback when no USB storage options exist.

**Fix (backup.php):** Added `GetRemoteHostUSBStorage()` call to the `GetBackupHostBackupDirs` wrapper so it fires whenever the host changes.

### Incorrect post-restore redirect on `initialSetup.php`

After a file-copy restore completed and the user clicked "Close", the page stayed on `initialSetup.php` instead of navigating to the FPP homepage.

**Fix:** Added `window.location.href = '/'` to the close button's click handler in the restore dialog.

### Duplicate spinner CSS on `initialSetup.php`

The page defined its own `.fpp-backup-action-loading::after` pseudo-element and `@keyframes fpp-spin`, while `css/fpp.css` already provides a `.fpp-backup-action-loading:before` spinner globally. Both pseudo-elements rendered simultaneously — two spinners with different colors, sizes, and animation speeds.

**Fix:** Deleted the redundant `::after` spinner block and `@keyframes fpp-spin` from `initialSetup.php`'s inline `<style>`.

## Screenshots

<img width="1359" height="812" alt="ss1" src="https://github.com/user-attachments/assets/3bacf424-26fa-4909-9c6c-a79cad8ba792" />
<img width="1359" height="735" alt="ss2" src="https://github.com/user-attachments/assets/b743a964-edcf-4436-bed7-100c626a8384" />

## Additional Comments

This is also a fix for one of 3 issues reported in [#2339](https://github.com/FalconChristmas/fpp/issues/2339#issuecomment-4993280577).