### PR TITLE
feat(plugins): Add plugin icons with initials fallback and manual URL marking

### DIFF
--- a/www/api/controllers/plugin.php
+++ b/www/api/controllers/plugin.php
@@ -608,6 +608,31 @@ function GetPluginInfo()
 }
 
 /**
+ * Serve plugin icon
+ *
+ * Serves the icon.png from a plugin's directory if it exists.
+ *
+ * @route GET /api/plugin/{RepoName}/icon
+ * @response 200 PNG image data
+ * @response 404 No icon available
+ */
+function PluginServeIcon()
+{
+	global $settings;
+	$plugin = params('RepoName');
+	$file = $settings['pluginDirectory'] . '/' . $plugin . '/icon.png';
+	if (file_exists($file)) {
+		header('Content-Type: image/png');
+		header('Cache-Control: public, max-age=86400');
+		ob_clean();
+		flush();
+		readfile($file);
+		exit;
+	}
+	http_response_code(404);
+}
+
+/**
  * Uninstall plugin
  *
  * Uninstall plugin {RepoName}.

--- a/www/api/controllers/plugin.php
+++ b/www/api/controllers/plugin.php
@@ -610,7 +610,10 @@ function GetPluginInfo()
 /**
  * Serve plugin icon
  *
- * Serves the icon.png from a plugin's directory if it exists.
+ * Serves the plugin icon. First checks for a local icon.png in the plugin
+ * directory. If not found, checks the plugin's pluginInfo.json for an
+ * iconURL field and proxies it (same-origin, avoids CSP restrictions on
+ * external image hosts).
  *
  * @route GET /api/plugin/{RepoName}/icon
  * @response 200 PNG image data
@@ -620,7 +623,10 @@ function PluginServeIcon()
 {
 	global $settings;
 	$plugin = params('RepoName');
-	$file = $settings['pluginDirectory'] . '/' . $plugin . '/icon.png';
+	$pluginDir = $settings['pluginDirectory'] . '/' . $plugin;
+
+	// Check for local icon.png
+	$file = $pluginDir . '/icon.png';
 	if (file_exists($file)) {
 		header('Content-Type: image/png');
 		header('Cache-Control: public, max-age=86400');
@@ -629,6 +635,23 @@ function PluginServeIcon()
 		readfile($file);
 		exit;
 	}
+
+	// Check pluginInfo.json for iconURL and proxy it
+	$infoFile = $pluginDir . '/pluginInfo.json';
+	if (file_exists($infoFile)) {
+		$info = json_decode(file_get_contents($infoFile), true);
+		if (!empty($info['iconURL'])) {
+			$ctx = stream_context_create(['http' => ['timeout' => 10, 'follow_location' => 1, 'user_agent' => 'FPP']]);
+			$data = @file_get_contents($info['iconURL'], false, $ctx);
+			if ($data !== false) {
+				header('Content-Type: image/png');
+				header('Cache-Control: public, max-age=86400');
+				echo $data;
+				exit;
+			}
+		}
+	}
+
 	http_response_code(404);
 }
 
@@ -1057,6 +1080,52 @@ function GetPluginPopularity()
 		}
 	}
 	return json(array('period' => PLUGIN_POPULARITY_PERIOD, 'counts' => new stdClass(), 'source' => 'unavailable'));
+}
+
+/**
+ * Proxy-fetch a plugin icon image
+ *
+ * Fetches an image from an external URL and serves it with the correct
+ * content-type. Used to bypass CSP restrictions that block loading
+ * images from external hosts (e.g. raw.githubusercontent.com) directly
+ * in `<img>` tags.
+ *
+ * @route GET /api/plugin/fetchImage?url=...
+ * @response 200 Image data
+ * @response 400 Missing or invalid URL
+ */
+function PluginFetchImage()
+{
+	$url = isset($_GET['url']) ? $_GET['url'] : '';
+	if ($url === '' || !preg_match('#^https?://#i', $url)) {
+		http_response_code(400);
+		echo 'Missing or invalid url parameter';
+		exit;
+	}
+
+	$ctx = stream_context_create(['http' => ['timeout' => 10, 'follow_location' => 1, 'user_agent' => 'FPP']]);
+	$data = @file_get_contents($url, false, $ctx);
+	if ($data === false) {
+		http_response_code(404);
+		exit;
+	}
+
+	// Determine content type from the URL extension
+	$ext = strtolower(pathinfo(parse_url($url, PHP_URL_PATH), PATHINFO_EXTENSION));
+	switch ($ext) {
+		case 'png':  $ct = 'image/png'; break;
+		case 'jpg':
+		case 'jpeg': $ct = 'image/jpeg'; break;
+		case 'gif':  $ct = 'image/gif'; break;
+		case 'svg':  $ct = 'image/svg+xml'; break;
+		case 'webp': $ct = 'image/webp'; break;
+		default:     $ct = 'image/png';
+	}
+
+	header('Content-Type: ' . $ct);
+	header('Cache-Control: public, max-age=86400');
+	echo $data;
+	exit;
 }
 
 function FetchPluginInfoProxy()

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -204,6 +204,7 @@ dispatch_post('/plugin', 'InstallPlugin');
 dispatch_post('/plugin/fetchInfo', 'FetchPluginInfoProxy');
 dispatch_get('/plugin/popularity', 'GetPluginPopularity'); // keep above /plugin/:RepoName
 dispatch_get('/plugin/:RepoName', 'GetPluginInfo');
+dispatch_get('/plugin/:RepoName/icon', 'PluginServeIcon');
 dispatch_delete('/plugin/:RepoName', 'UninstallPlugin');
 dispatch_get('/plugin/:RepoName/settings/:SettingName', 'PluginGetSetting');
 dispatch_put('/plugin/:RepoName/settings/:SettingName', 'PluginSetSetting');

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -203,6 +203,7 @@ dispatch_get('/plugin', 'GetInstalledPlugins');
 dispatch_post('/plugin', 'InstallPlugin');
 dispatch_post('/plugin/fetchInfo', 'FetchPluginInfoProxy');
 dispatch_get('/plugin/popularity', 'GetPluginPopularity'); // keep above /plugin/:RepoName
+dispatch_get('/plugin/fetchImage', 'PluginFetchImage'); // keep above /plugin/:RepoName
 dispatch_get('/plugin/:RepoName', 'GetPluginInfo');
 dispatch_get('/plugin/:RepoName/icon', 'PluginServeIcon');
 dispatch_delete('/plugin/:RepoName', 'UninstallPlugin');

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -4417,6 +4417,66 @@ a.api-anchor {
 	max-height: 180px;
 }
 
+/* Plugin icon / initials avatar */
+.pluginIconWrap {
+	width: 3.5rem;
+	height: 3.5rem;
+	flex-shrink: 0;
+	border-radius: 0.75rem;
+	overflow: hidden;
+	background: var(--fpp-bg-card, #e9ecef);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+.pluginIcon {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	display: block;
+}
+.pluginIconFallback {
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-weight: 600;
+	font-size: 1rem;
+	color: var(--fpp-text-muted, #6c757d);
+	background: var(--fpp-bg-card, #f8f9fa);
+	border: 2px solid #000;
+	border-radius: inherit;
+	box-sizing: border-box;
+	user-select: none;
+}
+[data-bs-theme="dark"] .pluginIconFallback {
+	border-color: #fff;
+}
+/* Small variant for popular strip cards */
+.pluginIconWrapSm {
+	width: 2rem;
+	height: 2rem;
+	border-radius: 0.4rem;
+}
+.pluginIconFallbackSm {
+	font-size: 0.65rem;
+}
+
+/* Manual URL badge */
+.pluginManualBadge {
+	font-size: 0.7rem;
+	background: var(--fpp-danger-light, #fde8e8);
+	color: var(--fpp-danger-dark, #d92d2d);
+	padding: 0.1rem 0.45rem;
+	border-radius: 0.25rem;
+	white-space: nowrap;
+}
+/* Ensure the icon + title row doesn't overflow on narrow cards */
+.min-w-0 {
+	min-width: 0;
+}
+
 /* Plugin marketplace cards */
 .pluginCardInner {
 	cursor: pointer;

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -179,17 +179,12 @@
             return (words[0].charAt(0) + words[1].charAt(0)).toUpperCase();
         }
 
-        // Derive the plugin icon URL. For installed plugins, uses the local API
-        // endpoint. For uninstalled plugins, derives from the pluginInfo.json URL.
+        // Get the plugin icon URL. Always routes through the same-origin API to
+        // avoid CSP restrictions on external image hosts (raw.githubusercontent.com
+        // is only allow-listed in connect-src, not img-src).
         function GetIconUrl(data, installed) {
-            var repo = data.repoName;
-            if (installed) return 'api/plugin/' + repo + '/icon';
-            var infoUrl = pluginInfoURLs[repo];
-            if (infoUrl) {
-                // Replace pluginInfo.json with icon.png in the URL
-                var idx = infoUrl.lastIndexOf('/');
-                if (idx >= 0) return infoUrl.substring(0, idx + 1) + 'icon.png';
-            }
+            if (installed) return 'api/plugin/' + data.repoName + '/icon';
+            if (data.iconURL) return 'api/plugin/fetchImage?url=' + encodeURIComponent(data.iconURL);
             return null;
         }
 

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -16,6 +16,7 @@
         var pluginInfos = [];
         var pluginInfoURLs = [];
         var pluginInfoUseCredentials = {};
+        var manuallyLoadedPlugins = {};
         // --- Plugin categories (Phase 1) ---
         var pluginCategoryList = [];      // [{name,longName,slug,icon}] from pluginCategories.json
         var pluginCategoryBySlug = {};
@@ -166,6 +167,30 @@
             } catch (e) {
                 return '';
             }
+        }
+
+        // Compute a 1-2 character initial from a plugin name.
+        // "FPP Brightness" -> "FB", "MatrixTools" -> "M", "a test plugin" -> "AT"
+        function GetInitials(name) {
+            if (!name) return '?';
+            var words = name.replace(/[^a-zA-Z0-9\s-]/g, '').split(/[\s-]+/).filter(function (w) { return w.length > 0; });
+            if (words.length === 0) return name.charAt(0).toUpperCase() || '?';
+            if (words.length === 1) return words[0].charAt(0).toUpperCase();
+            return (words[0].charAt(0) + words[1].charAt(0)).toUpperCase();
+        }
+
+        // Derive the plugin icon URL. For installed plugins, uses the local API
+        // endpoint. For uninstalled plugins, derives from the pluginInfo.json URL.
+        function GetIconUrl(data, installed) {
+            var repo = data.repoName;
+            if (installed) return 'api/plugin/' + repo + '/icon';
+            var infoUrl = pluginInfoURLs[repo];
+            if (infoUrl) {
+                // Replace pluginInfo.json with icon.png in the URL
+                var idx = infoUrl.lastIndexOf('/');
+                if (idx >= 0) return infoUrl.substring(0, idx + 1) + 'icon.png';
+            }
+            return null;
         }
 
         function BuildCategoryPills() {
@@ -1017,7 +1042,22 @@
             // Wraps (no truncation) so long category names show in full on the narrow card.
             $body.append('<div class="small text-secondary mb-1" title="' + (cat.obj.longName || cat.name) +
                 '"><i class="' + cat.obj.icon + '"></i> ' + cat.name + '</div>');
-            $body.append($('<div class="card-title fw-semibold small mb-1 pluginPopularTitle pluginTitle"></div>').text(data.name));
+            // Icon + title row
+            var $titleRow = $('<div class="d-flex align-items-center gap-2 mb-1"></div>');
+            var iconUrl = GetIconUrl(data, false);
+            var initials = GetInitials(data.name);
+            if (iconUrl) {
+                var $iconWrap = $('<div class="pluginIconWrap pluginIconWrapSm flex-shrink-0"></div>');
+                var $img = $('<img class="pluginIcon pluginIconSm" src="' + iconUrl + '" alt="" loading="lazy">');
+                var $fb = $('<div class="pluginIconFallback pluginIconFallbackSm" style="display:none;">' + initials + '</div>');
+                $img.on('error', function () { $img.hide(); $fb.show(); });
+                $iconWrap.append($img).append($fb);
+                $titleRow.append($iconWrap);
+            } else {
+                $titleRow.append($('<div class="pluginIconWrap pluginIconWrapSm flex-shrink-0"><div class="pluginIconFallback pluginIconFallbackSm">' + initials + '</div></div>'));
+            }
+            $titleRow.append($('<div class="card-title fw-semibold small mb-0 pluginPopularTitle pluginTitle min-w-0"></div>').text(data.name));
+            $body.append($titleRow);
             // Bottom line: install count over the past year. Shares PopularityBadgeHtml
             // with the grid cards so the two can't drift apart.
             var $act = $('<div class="mt-auto d-flex align-items-center gap-2"></div>');
@@ -1112,6 +1152,21 @@
             var installed = PluginIsInstalled(repo);
             var sel = SelectPluginVersionIndices(data);
             var compatibleVersion = sel.compatible, untestedVersion = sel.untested;
+
+            // Small icon to the left of the title
+            var iconUrl = GetIconUrl(data, installed);
+            var initials = GetInitials(data.name);
+            var titleIcon = '';
+            if (iconUrl) {
+                titleIcon += '<div class="pluginIconWrap" style="width:2rem;height:2rem;border-radius:0.4rem;display:inline-flex;vertical-align:middle;margin-right:0.5rem;">';
+                titleIcon += '<img class="pluginIcon" src="' + iconUrl + '" alt="" loading="lazy"';
+                titleIcon += ' onerror="this.style.display=\'none\';this.nextElementSibling.style.display=\'flex\';">';
+                titleIcon += '<div class="pluginIconFallback" style="display:none;font-size:0.65rem;">' + initials + '</div>';
+                titleIcon += '</div>';
+            } else {
+                titleIcon += '<div class="pluginIconWrap" style="width:2rem;height:2rem;border-radius:0.4rem;display:inline-flex;vertical-align:middle;margin-right:0.5rem;"><div class="pluginIconFallback" style="font-size:0.65rem;">' + initials + '</div></div>';
+            }
+
             var body = '';
             body += '<div class="mb-2">' + PluginBadgesHtml(data, true) + '</div>';
             var authorHtml = PluginAuthorHtml(data);
@@ -1149,7 +1204,7 @@
             }
             buttons['Close'] = function () { CloseModalDialog('pluginDetailDialog'); };
 
-            DoModalDialog({ id: 'pluginDetailDialog', class: 'modal-lg', title: data.name, body: body, backdrop: true, keyboard: true, buttons: buttons });
+            DoModalDialog({ id: 'pluginDetailDialog', class: 'modal-lg', title: titleIcon + data.name, body: body, backdrop: true, keyboard: true, buttons: buttons });
         }
 
         // Category name/icon for a plugin, validated against the loaded taxonomy so
@@ -1248,12 +1303,36 @@
                 actions += "<button class='btn btn-sm " + btnClass + "' onclick='event.stopPropagation();ConfirmAndInstall(\"" + data.repoName + "\", \"" + data.versions[idx].branch + "\", \"" + data.versions[idx].sha + "\");'><i class='far fa-arrow-alt-circle-down'></i> " + installText + "</button>";
             }
 
+            // Plugin icon / initials avatar
+            var iconUrl = GetIconUrl(data, installed);
+            var initials = GetInitials(data.name);
+            var iconHtml = '';
+            if (iconUrl) {
+                iconHtml += '<div class="pluginIconWrap">';
+                iconHtml += '<img class="pluginIcon" src="' + iconUrl + '" alt="" loading="lazy"';
+                iconHtml += ' onerror="this.style.display=\'none\';this.nextElementSibling.style.display=\'flex\';">';
+                iconHtml += '<div class="pluginIconFallback" style="display:none;">' + initials + '</div>';
+                iconHtml += '</div>';
+            } else {
+                iconHtml += '<div class="pluginIconWrap"><div class="pluginIconFallback">' + initials + '</div></div>';
+            }
+
             var html = '';
-            html += '<div id="row-' + data.repoName + '" class="col pluginCard" data-category-slug="' + pcatObj.slug + '" data-sort-rank="' + sortRank + '">';
+            html += '<div id="row-' + data.repoName + '" class="col pluginCard" data-category-slug="' + pcatObj.slug + '" data-sort-rank="' + sortRank + '"';
+            if (manuallyLoadedPlugins[data.repoName]) html += ' data-manual="1"';
+            html += '>';
             html += '<div class="card h-100 pluginCardInner" role="button" tabindex="0" onclick="ShowPluginDetail(\'' + data.repoName + '\');">';
             html += '<div class="card-body d-flex flex-column">';
+            html += '<div class="d-flex align-items-start gap-3 mb-1">';
+            html += iconHtml;
+            html += '<div class="min-w-0 flex-grow-1">';
             html += '<h5 class="card-title pluginTitle mb-1">' + data.name + '</h5>';
-            html += '<div class="pluginCardBadges mb-2">' + badges + '</div>';
+			html += '<div class="pluginCardBadges">' + badges;
+            if (manuallyLoadedPlugins[data.repoName]) {
+                html += '<span class="fpp-tag gap-1 pluginManualBadge"><i class="fas fa-link"></i> Manual URL</span>';
+            }
+            html += '</div>';
+            html += '</div></div>';
             var cardAuthorHtml = PluginAuthorHtml(data);
             if (cardAuthorHtml) html += '<div class="text-secondary small mb-1 pluginAuthor"><i class="fas fa-user"></i> ' + cardAuthorHtml + '</div>';
             html += '<p class="card-text pluginCardDesc small flex-grow-1">' + data.description + '</p>';
@@ -1352,6 +1431,7 @@
                 var onSuccess = function (data, viaProxy) {
                     $('html,body').css('cursor', 'auto');
                     pluginInfoURLs[data.repoName] = url;
+                    manuallyLoadedPlugins[data.repoName] = 1;
                     if (viaProxy) {
                         // Loaded via the credentialed proxy => treat as private
                         // for subsequent install/upgrade operations.


### PR DESCRIPTION
# Add plugin icons with initials fallback and manual URL marking

## Summary

Adds plugin icon support with initials fallback and marks plugins loaded from manually entered URLs. All icon images are proxied through same-origin API endpoints to avoid CSP restrictions on external image hosts.

## Changes

### Plugin Icons on Cards (`www/plugins.php`, `www/css/fpp.css`)

- **`GetIconUrl()`** — Routes all icon requests through same-origin API endpoints (`api/plugin/{repoName}/icon` for installed, `api/plugin/fetchImage?url=...` for uninstalled), avoiding CSP `img-src` restrictions on external hosts like `raw.githubusercontent.com`.
- **`GetInitials()`** — Computes 1–2 character initials from the plugin name (first letter of first and second words).
- **Card rendering** — Each plugin card displays a 3.5rem icon/avatar. If the icon loads successfully it is shown; on error the fallback displays initials inside a bordered circle (black in light mode, white in dark mode).
- **Popular strip cards** — Same icon + initials pattern in a compact 2rem variant.
- **Detail modal** — 2rem icon to the left of the plugin name in the modal header.

### Manual URL Marking (`www/plugins.php`, `www/css/fpp.css`)

- **`manuallyLoadedPlugins`** — Tracks which plugins were loaded via the "Get Plugin Info" URL input.
- **`ManualLoadInfo()`** — Sets the manual flag before rendering.
- **Card badge** — Plugins loaded from a manual URL display a red **Manual URL** badge inline with other badges using theme-aware danger colors.

### API Endpoints (`www/api/index.php`, `www/api/controllers/plugin.php`)

- **`GET /api/plugin/{RepoName}/icon`** — Serves the plugin icon same-origin. Checks for a local `icon.png` first, then falls back to proxying the `iconURL` field from `pluginInfo.json` via `file_get_contents()`.
- **`GET /api/plugin/fetchImage?url=...`** — Generic image proxy for uninstalled plugin icons. Fetches the remote image server-side and serves it with the correct Content-Type, bypassing browser CSP restrictions.

### CSS (`www/css/fpp.css`)

- `.pluginIconWrap` / `.pluginIcon` / `.pluginIconFallback` — Avatar container, image fill, and initials display using `--fpp-text-muted` / `--fpp-bg-card` theme variables.
- `.pluginIconWrapSm` / `.pluginIconFallbackSm` — Compact variants for the popular strip.
- `.pluginManualBadge` — Manual URL tag using `--fpp-danger-light` / `--fpp-danger-dark`.
- `.min-w-0` — Prevents flex overflow on narrow cards.
- `[data-bs-theme="dark"] .pluginIconFallback` — White border in dark mode.

## Files Changed

| File | Change |
|------|--------|
| `www/plugins.php` | Added icon/initials rendering, manual URL tracking, `GetInitials()`/`GetIconUrl()` helpers, updated `LoadPlugin()`, `ManualLoadInfo()`, `PopularCardHtml()`, `ShowPluginDetail()` |
| `www/css/fpp.css` | Added styles for plugin icons, initials fallback, manual URL badge, dark mode border |
| `www/api/index.php` | Added routes `GET /plugin/{RepoName}/icon` and `GET /plugin/fetchImage` |
| `www/api/controllers/plugin.php` | Added `PluginServeIcon()` and `PluginFetchImage()` functions |

## Screenshots

#### Icon example:
<img width="1256" height="727" alt="ss1" src="https://github.com/user-attachments/assets/8237596c-d37c-403f-be22-6f30a1826a65" />

#### MANUAL URL tag example:
<img width="1256" height="754" alt="ss2" src="https://github.com/user-attachments/assets/cc1b95c7-6213-440e-8873-df9e0d019ef4" />

## Additional Comments

This addresses some of the discussion and feedback in #2742.