### PR TITLE
fix(plugins): Bust browser cache for plugin icon updates

### DIFF
--- a/www/api/controllers/plugin.php
+++ b/www/api/controllers/plugin.php
@@ -778,8 +778,18 @@ function PluginServeIcon()
 	// Check for local icon.png
 	$file = $pluginDir . '/icon.png';
 	if (file_exists($file)) {
+		$mtime = filemtime($file);
+		$lastModified = gmdate('D, d M Y H:i:s', $mtime) . ' GMT';
+
 		header('Content-Type: image/png');
-		header('Cache-Control: public, max-age=86400');
+		header('Cache-Control: public, max-age=0, must-revalidate');
+		header('Last-Modified: ' . $lastModified);
+
+		if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $mtime) {
+			header('HTTP/1.1 304 Not Modified');
+			exit;
+		}
+
 		ob_clean();
 		flush();
 		readfile($file);
@@ -795,7 +805,7 @@ function PluginServeIcon()
 			$data = @file_get_contents($info['iconURL'], false, $ctx);
 			if ($data !== false) {
 				header('Content-Type: image/png');
-				header('Cache-Control: public, max-age=86400');
+				header('Cache-Control: public, no-cache');
 				echo $data;
 				exit;
 			}

--- a/www/api/openapi.json
+++ b/www/api/openapi.json
@@ -6677,6 +6677,9 @@
               }
             }
           },
+          "304": {
+            "description": "Not modified — icon file unchanged since `If-Modified-Since` timestamp"
+          },
           "404": {
             "description": "No icon available"
           }

--- a/www/plugin.php
+++ b/www/plugin.php
@@ -117,7 +117,26 @@ if (!isset($_GET['nopage'])):
         <div id="bodyWrapper">
             <?php include 'menu.inc'; ?>
             <div class="mainContainer">
-                <h1 class="title"><? echo $pluginInfo['name']; ?></h1>
+                <?php
+                $pluginIconUrl = 'api/plugin/' . $pluginName . '/icon';
+                $pluginIconFile = $pluginDirectory . '/' . $pluginName . '/icon.png';
+                $pluginHasIcon = file_exists($pluginIconFile) || !empty($pluginInfo['iconURL']);
+                if ($pluginHasIcon) {
+                    if (file_exists($pluginIconFile)) {
+                        $pluginIconUrl .= '?t=' . filemtime($pluginIconFile);
+                    } else {
+                        $pluginIconUrl .= '?t=' . time();
+                    }
+                }
+                ?>
+                <h1 class="title d-flex align-items-center gap-2">
+                    <?php if ($pluginHasIcon): ?>
+                    <div class="pluginIconWrap" style="width:2rem;height:2rem;border-radius:0.4rem;flex-shrink:0;">
+                        <img class="pluginIcon" src="<?= $pluginIconUrl ?>" alt="">
+                    </div>
+                    <?php endif; ?>
+                    <?= $pluginInfo['name'] ?>
+                </h1>
                 <div class="pageContent">
 
 

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -233,11 +233,17 @@
             return (words[0].charAt(0) + words[1].charAt(0)).toUpperCase();
         }
 
+        // Cache-busting nonce shared by all icon URLs loaded during this page
+        // session, so a plugin update with a new icon is visible immediately
+        // rather than showing a stale cached copy. The server sends 304 Not
+        // Modified when the icon file is unchanged, so the overhead is minimal.
+        var iconCacheNonce = Date.now();
+
         // Get the plugin icon URL. Always routes through the same-origin API to
         // avoid CSP restrictions on external image hosts (raw.githubusercontent.com
         // is only allow-listed in connect-src, not img-src).
         function GetIconUrl(data, installed) {
-            if (installed) return 'api/plugin/' + data.repoName + '/icon';
+            if (installed) return 'api/plugin/' + data.repoName + '/icon?_=' + iconCacheNonce;
             if (data.iconURL) return 'api/plugin/fetchImage?url=' + encodeURIComponent(data.iconURL);
             return null;
         }

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -256,7 +256,12 @@
             var pills = [];
             // "All" view shown at every UI level (D27) and is the default landing view.
             pills.push({ name: 'All', slug: 'all', icon: 'fas fa-border-all' });
-            for (var i = 0; i < pluginCategoryList.length; i++) pills.push(pluginCategoryList[i]);
+            for (var i = 0; i < pluginCategoryList.length; i++) {
+                // Drop any "Other" entry from the JSON so we only insert
+                // our canonical OTHER_CATEGORY below with the correct icon.
+                if (pluginCategoryList[i].name.localeCompare('Other', undefined, { sensitivity: 'base' }) === 0) continue;
+                pills.push(pluginCategoryList[i]);
+            }
             // Insert "Other" alphabetically among the known categories (skip index 0 which is "All")
             var insIdx = 1;
             while (insIdx < pills.length && pills[insIdx].name.localeCompare('Other', undefined, { sensitivity: 'base' }) < 0) insIdx++;


### PR DESCRIPTION
## fix(plugins): Bust browser cache for plugin icon updates and show plugin icon in page title

### Problem

When a plugin is updated with a new icon, the browser continues to display the old icon because the icon endpoint serves `Cache-Control: public, max-age=86400`, instructing the browser to cache the icon for 24 hours without revalidation. Users must open a private/incognito window or manually clear their cache to see the new icon.

Additionally, when viewing a plugin page (`plugin.php`), the page title only showed the plugin name in plain text with no visual indicator of which plugin was active.

### Changes

**`www/api/controllers/plugin.php`** — Server-side caching fix

- Replace `Cache-Control: public, max-age=86400` with `Cache-Control: public, max-age=0, must-revalidate` so the browser always checks with the server before using a cached icon
- Add `Last-Modified` header set to the icon file's modification time (`filemtime()`)
- Handle `If-Modified-Since` request header — return `304 Not Modified` with no body when the icon file hasn't changed, avoiding unnecessary data transfer
- Apply `Cache-Control: public, no-cache` to proxied (remote) icons for consistency

**`www/plugin.php`** — Show plugin icon next to page title

- Detect whether the plugin has an icon (via `icon.png` in the plugin directory or `iconURL` in `pluginInfo.json`)
- Render the plugin icon inside the `<h1 class="title">` using the existing `.pluginIconWrap` / `.pluginIcon` CSS classes, positioned to the left of the plugin name
- Use `d-flex align-items-center gap-2` on the `<h1>` to keep the icon and title aligned horizontally
- Append a cache-busting `?t=` query parameter to the icon URL using the local file's `mtime` (or current time for remote icons) so the icon reflects the latest version

**`www/plugins.php`** — Client-side cache busting

- Add a page-load nonce (`?_=` query parameter with `Date.now()`) to all installed plugin icon URLs. This immediately busts any icon previously cached under the old 24-hour `max-age` directive
- All icons within a single page load share the same nonce value so the browser can reuse them within the page

**`www/plugins.php`** — Fix duplicate "Other" category in plugin pills

- Filter out any "Other" entry from `pluginCategories.json` before building the category pills so the canonical `OTHER_CATEGORY` (with `fas fa-puzzle-piece` icon) is only inserted once, preventing a duplicate pill with a potentially mismatched icon

**`www/api/openapi.json`** — API documentation

- Add `304 Not Modified` response to the `GET /api/plugin/{RepoName}/icon` endpoint specification

### How it works now

1. **Plugin page view**: The page title area shows the plugin icon (if available) next to the plugin name, making it easy to visually identify the active plugin
2. **Plugin update with new icon**: Next page load → browser fetches icon with a fresh nonce → server sees the file mtime changed → serves the new icon with updated `Last-Modified`
3. **Subsequent page loads (no update)**: Browser sends `If-Modified-Since` → server returns `304 Not Modified` (headers only, no body)
4. **Existing cached icons**: The `?_=` nonce in the URL forces an immediate re-fetch regardless of previous cache state