### PR TITLE
fix(backups): Implement reboot flag for configuration restoration

### DIFF
--- a/www/copystorage.php
+++ b/www/copystorage.php
@@ -79,6 +79,15 @@ echo "\n";
 
 sleep(2);
 
+// Flag for reboot only when "Configuration" is restored via File Copy restore.
+$direction = $_GET['direction'] ?? '';
+$flags = $_GET['flags'] ?? '';
+$isRestore = stripos($direction, 'FROM') === 0;
+$hasConfig = stripos($flags, 'Configuration') !== false;
+if ($isRestore && $hasConfig && $backupRc === 0) {
+    WriteSettingToFile('rebootFlag', '1');
+}
+
 // The run's output goes into the fppd.log timeline, and the progress file is
 // then removed rather than kept as fpp_backup_filecopy_last.log.
 //


### PR DESCRIPTION
## Implement reboot flag for configuration restoration

### Problem
When a user restores configuration via File Copy Backup/Restore (from `backup.php` or `initialSetup.php`), certain configuration changes require a reboot to take effect, but no reboot flag was being set. This left users unaware that a reboot is needed, leading to confusing behavior where restored settings appeared to not apply.

### Solution
After a successful File Copy restore operation that includes `Configuration` in the selected restore flags, set the `rebootFlag` setting so the UI displays the reboot-required banner.

### Changes
- **`www/copystorage.php`**: Added a check after the copy completes — if the direction is a restore (`FROMUSB`, `FROMREMOTE`, or `FROMLOCAL`), the `Configuration` flag is included, and the exit code is 0 (success), write `rebootFlag` via `WriteSettingToFile('rebootFlag', '1')`.

### Notes
- The flag is intentionally scoped to only the `Configuration` flag, not other restore flags like `Sequences` or `Music`, since those do not require a reboot.
- This covers all entry points since both `backup.php` and `initialSetup.php` route File Copy operations through `copystorage.php`.

### Additional Comments
This provides a fix for issues referenced in #2752.