### PR TITLE
feat(plugins): Match top tab border-radius to category pills, thicken separator, and add missing URL scheme warning

### DIFF
--- a/www/plugins.php
+++ b/www/plugins.php
@@ -1823,6 +1823,18 @@
         #pluginTopTabs {
             border-bottom-width: 3px;
         }
+
+        /* On mobile portrait (<576px), move the "Installed Plugins" heading
+           below the action buttons instead of sitting beside them.
+           flex-direction: column-reverse puts the heading (first child) at the
+           bottom and the button group (second child) at the top. */
+        @media (max-width: 575.98px) {
+            .pluginsHeader {
+                flex-direction: column-reverse;
+                align-items: flex-start;
+                gap: 0.5rem;
+            }
+        }
     </style>
     <title><? echo $pageTitle; ?></title>
 </head>

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -1742,17 +1742,26 @@
             $('#manageHeading').toggleClass('invisible', activeTopTab === 'updates' && updateVisible === 0);
 
             var installedTotal = $('#installedGrid').children('.pluginCard').length;
+            var hasUrlScheme = /^https?:\/\//i.test(raw);
+            var hasUrlSchemeError = isUrlInput && !hasUrlScheme;
             var hasUrlError = pluginUrlError && raw === pluginUrlError;
-            if (hasUrlError) {
+            if (hasUrlSchemeError) {
+                $('#noAvailableResults').addClass('d-none');
+                $('#noUrlResults').addClass('d-none');
+                $('#noUrlSchemeResults').removeClass('d-none');
+            } else if (hasUrlError) {
                 $('#noAvailableResults').addClass('d-none');
                 $('#noUrlResults').removeClass('d-none');
+                $('#noUrlSchemeResults').addClass('d-none');
             } else {
                 $('#noAvailableResults').toggleClass('d-none', !(searching && activeTopTab === 'available' && availVisible === 0));
                 $('#noUrlResults').addClass('d-none');
+                $('#noUrlSchemeResults').addClass('d-none');
             }
             $('#noInstalledResults').toggleClass('d-none', !(searching && activeTopTab === 'installed' && installedVisible === 0 && installedTotal > 0));
             $('.fppNoResultsTerm').text(raw);
             $('.fppUrlErrorTerm').text(raw);
+            $('.fppUrlSchemeErrorTerm').text(raw);
 
             $('#pluginCategoryPills .fppCatCount').each(function () {
                 var s = $(this).attr('data-count-slug');
@@ -1795,6 +1804,26 @@
 
         });
     </script>
+    <style>
+        /* Round the top corners of the Available/Installed/Updates tabs to match
+           the 12px border-radius used by the category pills (.nav-pills).  The
+           category pills get 12px from --bs-nav-pills-border-radius; the top tabs
+           use Bootstrap's default --bs-nav-tabs-border-radius (~0.375rem).  We
+           override just the top corners here so both tab strips share the same
+           visual radius. */
+        #pluginTopTabs .nav-link {
+            border-top-left-radius: 12px;
+            border-top-right-radius: 12px;
+        }
+
+        /* Thicken the bottom border of the top tab bar to make the separator
+           between the tabs and the category pills more visually distinct.
+           Bootstrap's .nav-tabs default is 1px; bumping to 3px gives a
+           visible line without overwhelming the layout. */
+        #pluginTopTabs {
+            border-bottom-width: 3px;
+        }
+    </style>
     <title><? echo $pageTitle; ?></title>
 </head>
 
@@ -1895,6 +1924,11 @@
                                 <div id="noUrlResults" class="alert alert-info d-none mt-2">
                                     <i class="fas fa-exclamation-triangle"></i> No valid plugins found on JSON URL:
                                     "<b class="fppUrlErrorTerm"></b>". Clear the search box to see all plugins.
+                                </div>
+                                <div id="noUrlSchemeResults" class="alert alert-warning d-none mt-2">
+                                    <i class="fas fa-exclamation-circle"></i> URL:
+                                    "<b class="fppUrlSchemeErrorTerm"></b>" must contain http:// or https://.
+                                    Clear the search box to see all plugins.
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
# feat(plugins): Match top tab border-radius to category pills, thicken separator, and add missing URL scheme warning

## Changes

**1. Rounded top corners on Available/Installed/Updates tabs**

The top-level tab bar (`#pluginTopTabs`) uses Bootstrap's `.nav-tabs` class, which defaults to a ~0.375rem top border-radius via `--bs-nav-tabs-border-radius`. The category pills below it use `.nav-pills` with `--bs-nav-pills-border-radius: 12px`, giving them a noticeably more rounded appearance.

Added a `<style>` block in the document `<head>` that overrides `border-top-left-radius` and `border-top-right-radius` to `12px` on `#pluginTopTabs .nav-link`, so the two tab rows share the same visual radius.

**2. Thickened separator line below the top tabs**

Bootstrap's `.nav-tabs` bottom border defaults to 1px. Increased `#pluginTopTabs` `border-bottom-width` to 3px so the horizontal separator between the top tabs and the category pills is more visually distinct, without altering any spacing.

**3. Warning when a plugin URL is entered without `http://` or `https://`**

When the user pastes a URL ending in `plugininfo.json` without a scheme (e.g. `hello.com/plugininfo.json`), `ManualLoadInfo()` silently fell through — it only attempts to fetch URLs containing `://`, and the auto-mode path skipped the `alert()` that the non-auto path shows. No warning was displayed, leaving the user with a blank grid and no feedback.

- Added a new `<div id="noUrlSchemeResults">` with `alert-warning` styling.
- In `FilterPlugins()`, added `hasUrlSchemeError` detection: if the input matches the `plugininfo.json` pattern but lacks an `http://` or `https://` prefix, the new warning is shown (taking priority over the existing fetch-error and no-results warnings).
- The URL text is populated via a new `.fppUrlSchemeErrorTerm` class.

## Verification

- PHP lint: `php -l www/plugins.php` — no syntax errors.
- Existing warnings (`noAvailableResults`, `noUrlResults`) continue to work as before.
- New warning behavior:
  - `plugininfo.json` → shows *"URL: 'plugininfo.json' must contain http:// or https://."*
  - `hello.com/plugininfo.json` → shows *"URL: 'hello.com/plugininfo.json' must contain http:// or https://."*
  - `http://example.com/plugininfo.json` → proceeds to fetch as before (no new warning)
  - Clearing the search or pressing the clear button hides all warnings (existing behaviour, unchanged).

## Additional Comments

This PR addresses feedback from @cybercop23 in [#2742](https://github.com/FalconChristmas/fpp/issues/2742#issuecomment-5029901371).

Also added a fix for mobile (portrait view) when on the Installed tab, the text header "Installed Plugins" appears broken up and justified to the left of the buttons. Moved it to below the buttons.