### PR TITLE
feat(plugins): Category pill spacing, dynamic search counts, section headings, and 404 icon cleanup

### DIFF
--- a/www/api/controllers/plugin.php
+++ b/www/api/controllers/plugin.php
@@ -751,6 +751,9 @@ function GetPluginInfo()
 		$result['Status'] = 'OK';
 		$result['updatesAvailable'] = PluginHasUpdates($plugin);
 
+		$iconFile = $settings['pluginDirectory'] . '/' . $plugin . '/icon.png';
+		$result['hasIcon'] = file_exists($iconFile) || !empty($result['iconURL']);
+
 		return json($result);
 	}
 

--- a/www/api/openapi.json
+++ b/www/api/openapi.json
@@ -6651,6 +6651,7 @@
                   "author": "Chris Pinkham (CaptainMurdoch)",
                   "srcURL": "https://github.com/cpinkham/fpp-matrixtools.git",
                   "updatesAvailable": 0,
+                  "hasIcon": true,
                   "versions": [
                     {
                       "minFPPVersion": 0,

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -246,7 +246,10 @@
         // avoid CSP restrictions on external image hosts (raw.githubusercontent.com
         // is only allow-listed in connect-src, not img-src).
         function GetIconUrl(data, installed) {
-            if (installed) return 'api/plugin/' + data.repoName + '/icon?_=' + iconCacheNonce;
+            if (installed) {
+                if (data.hasOwnProperty('hasIcon') && !data.hasIcon) return null;
+                return 'api/plugin/' + data.repoName + '/icon?_=' + iconCacheNonce;
+            }
             if (data.iconURL) return 'api/plugin/fetchImage?url=' + encodeURIComponent(data.iconURL);
             return null;
         }
@@ -1663,7 +1666,7 @@
             $('#pluginTopTabs .nav-link[data-top-tab="' + name + '"]').addClass('active');
             $('#pane-available').toggleClass('d-none', name !== 'available');
             $('#pane-manage').toggleClass('d-none', name === 'available');
-            $('#manageHeading').text(name === 'updates' ? 'Updates Available' : 'Installed Plugins');
+            $('#manageHeading').html(name === 'updates' ? '<i class="fas fa-arrow-alt-circle-up text-secondary"></i> Updates Available' : '<i class="fas fa-check-circle text-secondary"></i> Installed Plugins');
             if (name === 'updates' && !updatesCheckedOnce && installedPlugins.length > 0) {
                 updatesCheckedOnce = true;
                 CheckAllPluginsForUpdates();
@@ -1697,11 +1700,10 @@
             var counts = {}, total = 0, availVisible = 0;
             $('#pluginGrid').children('.pluginCard').each(function () {
                 var slug = $(this).attr('data-category-slug') || 'other';
-                counts[slug] = (counts[slug] || 0) + 1; total++;
                 if (urlLoadedMode) {
                     var show = this === loadedCardEl;
                     $(this).toggleClass('d-none', !show);
-                    if (show) availVisible++;
+                    if (show) { counts[slug] = (counts[slug] || 0) + 1; total++; availVisible++; }
                 } else {
                     var searchText = $('.pluginTitle', this).text().toLowerCase();
                     var authorTxt = $('.pluginAuthor', this).text().toLowerCase();
@@ -1713,6 +1715,7 @@
                     var show = matchesSearch && matchesCat;
                     $(this).toggleClass('d-none', !show);
                     if (show) availVisible++;
+                    if (matchesSearch) { counts[slug] = (counts[slug] || 0) + 1; total++; }
                 }
             });
 
@@ -1751,14 +1754,26 @@
                 $('#noUrlSchemeResults').removeClass('d-none');
             } else if (hasUrlError) {
                 $('#noAvailableResults').addClass('d-none');
-                $('#noUrlResults').removeClass('d-none');
-                $('#noUrlSchemeResults').addClass('d-none');
-            } else {
-                $('#noAvailableResults').toggleClass('d-none', !(searching && activeTopTab === 'available' && availVisible === 0));
                 $('#noUrlResults').addClass('d-none');
                 $('#noUrlSchemeResults').addClass('d-none');
+            } else {
+                var showAvailEmpty = searching && activeTopTab === 'available' && availVisible === 0;
+                $('#noAvailableResults').toggleClass('d-none', !showAvailEmpty);
+                $('#noUrlResults').addClass('d-none');
+                $('#noUrlSchemeResults').addClass('d-none');
+                if (showAvailEmpty && installedVisible > 0) {
+                    $('#noAvailCrossRef').text('Found ' + installedVisible + ' plugin' + (installedVisible === 1 ? '' : 's') + ' that match on the Installed list. ');
+                } else {
+                    $('#noAvailCrossRef').text('');
+                }
             }
-            $('#noInstalledResults').toggleClass('d-none', !(searching && activeTopTab === 'installed' && installedVisible === 0 && installedTotal > 0));
+            var showInstalledEmpty = searching && activeTopTab === 'installed' && installedVisible === 0 && installedTotal > 0;
+            $('#noInstalledResults').toggleClass('d-none', !showInstalledEmpty);
+            if (showInstalledEmpty && availVisible > 0) {
+                $('#noInstalledCrossRef').text('Found ' + availVisible + ' plugin' + (availVisible === 1 ? '' : 's') + ' that match on the Available list.');
+            } else {
+                $('#noInstalledCrossRef').text('');
+            }
             $('.fppNoResultsTerm').text(raw);
             $('.fppUrlErrorTerm').text(raw);
             $('.fppUrlSchemeErrorTerm').text(raw);
@@ -1777,8 +1792,8 @@
                 UpdatePopularStripVisibility();
             }
 
-            $('#topCountAvailable').text(total);
-            $('#topCountInstalled').text($('#installedGrid').children('.pluginCard').length);
+            $('#topCountAvailable').text(availVisible);
+            $('#topCountInstalled').text(installedVisible);
             $('#topCountUpdates').text(updateVisible);
         }
         $(document).ready(function () {
@@ -1900,7 +1915,8 @@
 
                         <div id="pane-available" class="pluginTopPane">
                             <div class="fppPluginAvailableHead">
-                                <ul class="nav nav-pills mb-3 pageContent-tabs flex-nowrap flex-md-wrap overflow-x-auto pb-1" id="pluginCategoryPills" role="tablist"></ul>
+                                <h2 class="h5 mb-2"><i class="fas fa-tags text-secondary"></i> Categories</h2>
+                                <ul class="nav nav-pills mb-3 pageContent-tabs flex-nowrap flex-md-wrap overflow-x-auto gap-1 pb-1" id="pluginCategoryPills" role="tablist"></ul>
                             </div>
 
                             <!-- Lives inside pane-available, below the pills that drive it: the strip
@@ -1928,10 +1944,11 @@
                             </div>
 
                             <div id='pluginTable'>
+                                <h2 class="h5 mb-2"><i class="fas fa-box text-secondary"></i> Available Plugins</h2>
                                 <div id='pluginGrid' class="row row-cols-1 row-cols-md-2 row-cols-xxl-3 g-3"></div>
                                 <div id="noAvailableResults" class="alert alert-info d-none mt-2">
                                     <i class="fas fa-search"></i> No plugins match
-                                    "<b class="fppNoResultsTerm"></b>". Clear the search box to see all plugins.
+                                    "<b class="fppNoResultsTerm"></b>". <span id="noAvailCrossRef"></span>Clear the search box to see all plugins.
                                 </div>
                                 <div id="noUrlResults" class="alert alert-info d-none mt-2">
                                     <i class="fas fa-exclamation-triangle"></i> No valid plugins found on JSON URL:
@@ -1947,7 +1964,7 @@
 
                         <div id="pane-manage" class="pluginTopPane d-none">
                             <div class='pluginsHeader'>
-                                <h2 id="manageHeading">Installed Plugins</h2>
+                                <h2 id="manageHeading"><i class="fas fa-check-circle text-secondary"></i> Installed Plugins</h2>
                                 <div class="d-flex flex-wrap gap-2 align-items-center">
                                     <button id="checkAllUpdatesBtn" class="buttons btn-outline-success"
                                         onClick='CheckAllPluginsForUpdates();'
@@ -1976,7 +1993,7 @@
                             </div>
                             <div id="noInstalledResults" class="alert alert-info d-none mt-2">
                                 <i class="fas fa-search"></i> No installed plugins match
-                                "<b class="fppNoResultsTerm"></b>".
+                                "<b class="fppNoResultsTerm"></b>". <span id="noInstalledCrossRef"></span>
                             </div>
                             <div id="noUpdatesHint" class="text-secondary d-none">No updates found. Use <b>Check All for Updates</b> to refresh.</div>
                         </div>


### PR DESCRIPTION
# feat(plugins): Category pill spacing, dynamic search counts, section headings, and 404 icon cleanup

## Changes

**Category pill spacing** (`www/plugins.php`)
- Added `gap-1` to the nav-pills `<ul>` so pills have consistent horizontal spacing between rows.

**Dynamic search counts** (`www/plugins.php`)
- Category pill badges now only count cards matching the current search term, updating in real time as the user types.
- Available and Installed tab badges now show the number of **visible** (filtered) cards instead of the total unfiltered count.

**Cross-tab "no results" hints** (`www/plugins.php`)
- When a search on the Available tab yields no results but matching plugins exist on the Installed tab, the empty-state message now reads: *"No plugins match "term". Found X plugins that match on the Installed list. Clear the search box to see all plugins."*
- The same hint appears in reverse when searching on the Installed tab.

**Section headings** (`www/plugins.php`)
- Added "Categories" heading with `fa-tags` icon above the category pills.
- Added "Available Plugins" heading with `fa-box` icon above the available plugin grid.
- Added `fa-check-circle` icon to the existing "Installed Plugins" heading for consistency.
- The JavaScript that toggles the Installed heading text now uses `.html()` instead of `.text()` so the icon is preserved when switching between Installed and Updates tabs.

**Eliminated 404 icon requests** (`www/plugins.php`, `www/api/controllers/plugin.php`)
- `GetPluginInfo()` now includes a `hasIcon` field in its JSON response, computed from either the presence of `icon.png` on disk or a non-empty `iconURL` in `pluginInfo.json`.
- `GetIconUrl()` skips the icon fetch for installed plugins when `hasIcon` is explicitly `false`, avoiding unnecessary 404 requests.
- Backward-compatible: when `hasIcon` is absent (e.g. cached responses), the icon URL is still generated as before.

**OpenAPI documentation** (`www/api/openapi.json`)
- Added `hasIcon` field to the example response for `GET /api/plugin/{RepoName}`.

## Files changed

- `www/plugins.php`
- `www/api/controllers/plugin.php`
- `www/api/openapi.json`

## Additional Comments

This PR addresses feedback from @cybercop23 in [#2742](https://github.com/FalconChristmas/fpp/issues/2742#issuecomment-5029901371) and #2761.

This concludes the last of the major updates for the Plugin Manager. On merge, please mark #2742 as "Fix Applied - Testing Required".