### PR TITLE
fix(commands): Refresh page after fppd restart when command list has changed

### DIFF
--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -49,6 +49,13 @@ var _wsWarnings = [];
 var _wsWarningInfo = [];
 var _systemWarnings = [];
 var _systemWarningInfo = [];
+
+// Track fppd running state across status callbacks to detect a restart
+// transition (not-running → running), at which point we re-fetch the
+// command list and refresh the page if it has changed (e.g. plugin
+// commands added/removed).
+var _fppdWasRunning = null;
+var _savedCommandListHash = '';
 var zebraPinSubContentTop = 0;
 var VolumeChangeInProgress = false;
 var VolumeChangeAPIInProgress = false;
@@ -142,9 +149,24 @@ function loadPageReadyActions () {
 	setViewPortControl();
 }
 
+// Status-change callback that detects an fppd restart (transition from
+// not-running to running).  When that happens, re-fetch the command list
+// and reload the page if the list has changed.
+function OnFPPDRestart () {
+	var isRunning = lastStatusJSON &&
+		'fppd' in lastStatusJSON &&
+		lastStatusJSON.fppd === 'running';
+	if (_fppdWasRunning === false && isRunning) {
+		checkCommandListChanged();
+	}
+	_fppdWasRunning = isRunning;
+}
+
 function common_PageLoad_DOM_Setup () {
 	OnSystemStatusChange(RefreshHeaderBar);
 	OnSystemStatusChange(IsFPPDrunning);
+	OnSystemStatusChange(OnFPPDRestart);
+	captureCommandListHash();
 	// If status was pre-populated server-side, fire callbacks immediately so
 	// the header/footer render without waiting for the first AJAX round-trip.
 	if (lastStatusJSON) {
@@ -8240,6 +8262,36 @@ function PopulateCommandListCache () {
 			$.each(commandList, function (key, val) {
 				commandListByName[val['name']] = val;
 			});
+		}
+	});
+}
+
+// Eagerly capture the command list fingerprint once on page load so we can
+// detect changes after an fppd restart.
+function captureCommandListHash () {
+	$.ajax({
+		dataType: 'json',
+		url: 'api/commands',
+		async: true,
+		success: function (data) {
+			_savedCommandListHash = JSON.stringify(data);
+		}
+	});
+}
+
+// Called after an fppd restart transition.  Re-fetches the command list and
+// hard-reloads the page if it differs from the pre-restart snapshot.
+function checkCommandListChanged () {
+	if (!_savedCommandListHash) return;
+	$.ajax({
+		dataType: 'json',
+		url: 'api/commands',
+		async: true,
+		success: function (data) {
+			var hash = JSON.stringify(data);
+			if (hash !== _savedCommandListHash) {
+				location.reload();
+			}
 		}
 	});
 }


### PR DESCRIPTION
# fix(commands): Refresh page after fppd restart when command list has changed

## Issue

When fppd is restarted (e.g. after a plugin is installed or updated that adds or removes commands), the frontend continues to show the stale command list cached from before the restart. Users must manually refresh the page to see the updated commands — and they may not even know the command list has changed, leading to confusion when newly added commands don't appear in dropdowns or preset editors.

## Solution

Detect when fppd transitions from "not running" back to "running" (indicating a restart), then compare the current command list against a snapshot taken on page load. If the list differs — for example, a plugin registered or removed commands — the page is hard-reloaded automatically so the user sees the updated command list immediately.

## Changes

**`www/js/fpp.js`**

- **Globals** (`_fppdWasRunning`, `_savedCommandListHash`): Track fppd running state across status callbacks and store a JSON fingerprint of the command list captured on page load.
- **`captureCommandListHash()`**: Eagerly fetches `/api/commands` once on page load and stores the JSON-stringified result as a baseline.
- **`checkCommandListChanged()`**: Called after a restart transition; re-fetches `/api/commands` and triggers `location.reload()` if the list differs from the baseline.
- **`OnFPPDRestart()`**: New `OnSystemStatusChange` callback that detects the not-running → running transition of fppd.
- **Registration**: `OnFPPDRestart` is registered and `captureCommandListHash()` is invoked in `common_PageLoad_DOM_Setup`, alongside existing status-change subscribers.

## How it works

1. On initial page load, the current command list is captured as a hash.
2. `OnFPPDRestart` monitors each status update, tracking whether fppd was previously running.
3. When fppd transitions from not-running to running (restart detected), it fetches the current command list.
4. If the new list differs from the pre-restart snapshot, the page reloads automatically.

This covers all restart scenarios — manual restart via the UI button, external restart, crash recovery — via the existing WebSocket reconnection and HTTP polling mechanisms, without adding any new polling or timers.