### PR TITLE
fix(files): Fix zero-byte download of manually copied files from Uploads directory

### DIFF
--- a/www/api/controllers/files.php
+++ b/www/api/controllers/files.php
@@ -588,6 +588,7 @@ function GetFile()
  */
 function GetFileImpl($dir, $filename, $lines, $play, $attach)
 {
+    global $SUDO;
     $isImage = 0;
     $isLog = 0;
     if ($dir == 'Images') {
@@ -652,13 +653,17 @@ function GetFileImpl($dir, $filename, $lines, $play, $attach)
         header('Content-disposition: attachment;filename="' . $filename . '"');
     }
 
-    ob_clean();
+    if (ob_get_level()) {
+        ob_end_clean();
+    }
     flush();
     if ($lines == -1) {
-        readfile($dir . '/' . $filename);
+        header('Content-Length: ' . real_filesize($dir . '/' . $filename));
+        passthru($SUDO . " cat " . escapeshellarg($dir . '/' . $filename));
     } else {
-        passthru('tail -' . $lines . ' ' . $dir . '/' . $filename);
+        passthru($SUDO . ' tail -' . $lines . ' ' . escapeshellarg($dir . '/' . $filename));
     }
+    exit;
 }
 
 /**


### PR DESCRIPTION
# fix(files): Fix zero-byte download of manually copied files from Uploads directory

## Root Cause

When a file is manually copied into the Uploads directory (e.g. `cp /var/log/syslog.1 /home/fpp/media/upload`), the copied file retains its original ownership and permissions (typically owned by `root`, mode 600/640). The web server user cannot read such files.

The file listing endpoint (`GET /api/files/{DirName}`) already handles this correctly by using `sudo find` to stat files — so the correct file size is displayed in the UI. However, the file download endpoint (`GET /api/file/{DirName}/**`) used PHP's `readfile()` which runs as the web server user without elevated privileges, silently returning 0 bytes when the file is unreadable.

## Changes Made

**`www/api/controllers/files.php` — `GetFileImpl()`:**

1. **Added `global $SUDO;`** — brings the sudo helper into scope, matching the pattern used by `GetFilesHelper()`.

2. **Replaced `readfile()` with `passthru($SUDO . " cat ...")`** — reads the file with the same privilege level used by the file listing code (`sudo find`). Uses `escapeshellarg()` for safety. On macOS and when running as root, `$SUDO` is `""` so this degrades to plain `cat`.

3. **Added `$SUDO` to the `tail` passthru** — consistency fix so log tailing also works on protected files. Also added `escapeshellarg()` which was missing from the original tail command.

4. **Added `Content-Length` header** — lets the browser validate the expected byte count against what's actually received, preventing premature connection closure.

5. **Improved output buffer cleanup** — replaced `ob_clean()` with `ob_end_clean()` (with a level guard), matching the pattern in `sequence.php`. This properly closes output buffer layers instead of just clearing them.

6. **Added `exit;`** — prevents the limonade framework from appending session data, shutdown handler output, or other content after the binary file stream. This matches the pattern used by `plugin.php`, `backup.php`, and the zip download in the same file.

## Testing

- Files uploaded through the FPP UI (which are created with correct ownership) continue to download normally.
- Files manually copied into Uploads (root-owned, restricted permissions) now download with full content instead of 0 bytes.
- File listing continues to show correct sizes for all files.
- Log tailing, image preview, and media playback endpoints are unaffected.

## Additional Comments

This PR provides a fix for an edge case that was reported in issue #2765. After merging, please mark as "Fix Applied - Testing Required".