### PR TITLE
fix(plugins): Show Update button in plugin detail modal when an update is available

### DIFF
--- a/www/plugins.php
+++ b/www/plugins.php
@@ -309,6 +309,15 @@
                     if (data.Status == 'OK') {
                         if (data.updatesAvailable) {
                             $('#row-' + plugin).addClass('fppHasUpdate').find('.updatesAvailable').show();
+                            var $modal = $('#pluginDetailDialog');
+                            if ($modal.length && $modal.is(':visible')) {
+                                var $checkBtn = $modal.find('#pluginDetailCheckBtn');
+                                if ($checkBtn.length) {
+                                    $checkBtn.replaceWith(
+                                        $('<button class="btn btn-success" onclick="CloseModalDialog(\'pluginDetailDialog\');UpgradePlugin(\'' + plugin + '\');"><i class="far fa-arrow-alt-circle-down"></i> Update</button>')
+                                    );
+                                }
+                            }
                         } else {
                             $('#row-' + plugin).removeClass('fppHasUpdate');
                             $.jGrowl('No updates available for ' + plugin, { themeState: 'detract' });
@@ -1301,7 +1310,7 @@
                 if (data.pageUrl) {
                     buttons['Open'] = function () { CloseModalDialog('pluginDetailDialog'); window.open(data.pageUrl, 'pluginContent'); };
                 }
-                buttons['Check for Updates'] = function () { CheckPluginForUpdates(repo); };
+                buttons['Check for Updates'] = { id: 'pluginDetailCheckBtn', click: function () { CheckPluginForUpdates(repo); } };
                 buttons['Uninstall'] = function () { CloseModalDialog('pluginDetailDialog'); ShowUninstallPluginPopup(repo, data.name); };
             } else if (compatibleVersion >= 0 || untestedVersion >= 0) {
                 var idx = compatibleVersion < 0 ? untestedVersion : compatibleVersion;


### PR DESCRIPTION
# fix(plugins): Show Update button in plugin detail modal when an update is available

## Description

When viewing plugin details in the detail modal (`ShowPluginDetail`), clicking "Check for Updates" previously only updated the grid card (adding the `fppHasUpdate` class and showing the inline Update button). The modal itself remained unchanged — the user had to close the modal and find the card to apply the update.

## Change

Two edits in `www/plugins.php`:

1. **`ShowPluginDetail`** — The "Check for Updates" button now has a unique `id` (`pluginDetailCheckBtn`) so it can be targeted for replacement.

2. **`CheckPluginForUpdates`** — After the API confirms an update is available, the code checks whether the plugin detail modal is visible. If so, it replaces the "Check for Updates" button in-place with a green "Update" button that closes the modal and calls `UpgradePlugin()`.

## Behavior

- Open plugin detail popup for an installed plugin
- Click "Check for Updates" — API call fires
- If an update is available, the button immediately swaps to "Update" (no modal close/reopen needed)
- Click "Update" to run the upgrade (modal closes, progress dialog opens)
- If no update is available, a jGrowl notification is shown (existing behavior, unchanged)
- If the modal is already dismissed when the API response arrives, the DOM update is safely skipped