### PR TITLE
fix(wording): Correct wording on 2D Virtual Display to Virtuals tab

### DIFF
--- a/www/virtualdisplaywrapper.php
+++ b/www/virtualdisplaywrapper.php
@@ -32,7 +32,7 @@
         require_once('virtualdisplaybody.php');
         ?>
         <br>NOTE: If the Virtual Display is not working, you need to add the HTTP Virtual Display Channel Output on the
-        'Other' tab of the Channel Outputs config page. Your background image must be uploaded as a file called
+        'Virtuals' tab of the Channel Outputs config page. Your background image must be uploaded as a file called
         'virtualdisplaybackground.jpg' and your pixel map is uploaded from xLights via FPP Connect by ticking the
         'Models' checkbox for this device (it is saved as 'virtualdisplaymap' in FPP's configuration directory).
       </div>


### PR DESCRIPTION
# fix(wording): Correct wording on 2D Virtual Display to Virtuals tab

## Issue

On the 2D Virtual Display page (virtualdisplaywrapper.php) for HTTPVirtualDisplay, a note regarding setup instructions references the 'Other' tab in Channel Outputs. This tab no longer exists on the Other tab as the configuration has been moved to a Virtuals tab in the development of FPP 10.

## Solution

Change the wording from 'Other' tab to 'Virtuals' tab.