### PR TITLE
feat(plugins): Show incompatible plugins in a collapsed section

### DIFF
--- a/www/plugins.php
+++ b/www/plugins.php
@@ -1496,7 +1496,13 @@
                 } else if (untestedVersion >= 0) {
                     if (uiLevel < 1) return;
                 } else {
-                    if (uiLevel < 3) return;
+                    InsertCardSorted('incompatibleGrid', data.name, html, sortRank);
+                    var $wrap = $('#incompatiblePluginsWrap');
+                    $('#incompatiblePluginsCount').text($wrap.find('.pluginCard').length);
+                    $wrap.removeClass('d-none');
+                    FilterPlugins();
+                    ScheduleSettle();
+                    return;
                 }
                 InsertCardSorted('pluginGrid', data.name, html, sortRank);
             }
@@ -1977,6 +1983,18 @@
                                     "<b class="fppUrlSchemeErrorTerm"></b>" must contain http:// or https://.
                                     Clear the search box to see all plugins.
                                 </div>
+                            </div>
+
+                            <div id="incompatiblePluginsWrap" class="mt-4 d-none">
+                                <details>
+                                    <summary class="text-secondary">
+                                        <i class="fas fa-exclamation-triangle"></i> Incompatible Plugins (<span id="incompatiblePluginsCount">0</span>)
+                                    </summary>
+                                    <div class="callout mt-2">
+                                        These plugins are not compatible with this version of FPP.
+                                    </div>
+                                    <div id='incompatibleGrid' class="row row-cols-1 row-cols-md-2 row-cols-xxl-3 g-3 mt-1"></div>
+                                </details>
                             </div>
                         </div>
 

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -1496,6 +1496,7 @@
                 } else if (untestedVersion >= 0) {
                     if (uiLevel < 1) return;
                 } else {
+					if (uiLevel < 1) return;
                     InsertCardSorted('incompatibleGrid', data.name, html, sortRank);
                     var $wrap = $('#incompatiblePluginsWrap');
                     $('#incompatiblePluginsCount').text($wrap.find('.pluginCard').length);


### PR DESCRIPTION
# feat(plugins): Show incompatible plugins in a collapsed section

Previously, plugins with no compatible or untested version for the current FPP version/platform were entirely hidden from the Available tab unless the user was in Developer mode (UI level 3). This made it impossible to discover or investigate why a plugin can't be installed.

This change adds a collapsible "Incompatible Plugins" section at the bottom of the Available pane, matching the existing pattern used by the Script Browser (`scriptbrowser.php`). The section uses the native HTML `<details>`/`<summary>` disclosure widget, is collapsed by default, and shows a count of incompatible plugins with a warning icon.

## Changes

**`www/plugins.php`**

- **HTML**: Added a `<details>`/`<summary>` block with id `incompatiblePluginsWrap` inside `pane-available`, below the plugin grid. Initially hidden (`d-none`), it contains a responsive card grid (`incompatibleGrid`) matching the same `row-cols-*` classes as the main grid.

- **JavaScript (`LoadPlugin`)**: Instead of returning early when a plugin is incompatible (the old `if (uiLevel < 3) return;`), the card is now inserted into `incompatibleGrid` via `InsertCardSorted`, the section's count badge is updated, and the wrapper is made visible.

## Behavior

- Incompatible plugins appear in their own collapsed section with a red "Incompatible" badge, the usual card layout (icon, title, description, author), and are clickable to open the detail modal (which explains why no version is compatible).
- The main Available grid, Installed tab, Updates tab, Popular strip, and category counts are unaffected.
- The section only appears when there are incompatible plugins (auto-hidden via `d-none` when empty).

## Screenshots
<img width="1388" height="807" alt="ss_1" src="https://github.com/user-attachments/assets/57fb3908-2b3e-4bc5-bdb8-53145c2b2fde" />
<img width="1388" height="807" alt="ss_2" src="https://github.com/user-attachments/assets/0480687d-ab3e-435d-8d3b-819d8bde1e69" />

## Additional Comments
Added "if (uiLevel < 1) return;" so that the incompatible plugins section is only displayed if UI mode is set to Advanced or higher.