### PR TITLE
fix(backups): USB backup fixes, 'none' guard, short tag fix, and JSON Backups file manager tab

### DIFF
--- a/www/api/controllers/backups.php
+++ b/www/api/controllers/backups.php
@@ -424,7 +424,7 @@ function GetAvailableJSONBackups(){
 	$json_config_backup_filenames = process_jsonbackup_file_data_helper($json_config_backup_filenames, $dir_jsonbackups);
 
 	//See what backups are stored on the selected storage device if it's value is set
-	if (isset($settings['jsonConfigBackupUSBLocation']) && !empty($settings['jsonConfigBackupUSBLocation'])) {
+	if (isset($settings['jsonConfigBackupUSBLocation']) && !empty($settings['jsonConfigBackupUSBLocation']) && strtolower($settings['jsonConfigBackupUSBLocation']) !== 'none') {
 		$dir_jsonbackupsalternate = GetDirSetting('JsonBackupsAlternate');
 
 		//$settings['jsonConfigBackupUSBLocation'] is the selected alternative drive to stop backups to
@@ -690,7 +690,7 @@ function RestoreJsonBackup(){
 				$restore_status['Message'] = 'Backup File ' . $fullPath . ' could not be read.';
 			}
 		} else if ((strtolower($restore_from_directory) === 'jsonbackupsalternate')) {
-			if (isset($settings['jsonConfigBackupUSBLocation']) && !empty($settings['jsonConfigBackupUSBLocation'])) {
+			if (isset($settings['jsonConfigBackupUSBLocation']) && !empty($settings['jsonConfigBackupUSBLocation']) && strtolower($settings['jsonConfigBackupUSBLocation']) !== 'none') {
 				//Mount and read the json backup from the jsonConfigBackupUSBLocation location
 				$file_contents = DriveMountHelper($settings['jsonConfigBackupUSBLocation'], 'file_get_contents', array($fullPath));
 
@@ -775,7 +775,9 @@ function DownloadJsonBackup(){
 		}
 	} elseif (strtolower($dirName) == "jsonbackupsalternate") {
 		//Use our DriveMountHelper to mount the specified USB drive and check if the file exists
+		if (isset($settings['jsonConfigBackupUSBLocation']) && !empty($settings['jsonConfigBackupUSBLocation']) && strtolower($settings['jsonConfigBackupUSBLocation']) !== 'none') {
 		$fileExists = DriveMountHelper($settings['jsonConfigBackupUSBLocation'], 'file_exists', array($fullPath));
+		}
 
 		if ($fileExists) {
 			//Content type will always be json so see the header
@@ -786,7 +788,9 @@ function DownloadJsonBackup(){
 			ob_clean();
 			flush();
 
+			if (isset($settings['jsonConfigBackupUSBLocation']) && !empty($settings['jsonConfigBackupUSBLocation']) && strtolower($settings['jsonConfigBackupUSBLocation']) !== 'none') {
 			DriveMountHelper($settings['jsonConfigBackupUSBLocation'], 'readfile', array($fullPath));
+			}
 		} else {
 			$status = "File Not Found";
 			return json(array("Status" => $status, "file" => $fileName, "dir" => $dirName));
@@ -834,7 +838,9 @@ function DeleteJsonBackup(){
 		//Use our DriveMountHelper to mount the specified USB drive and check if the file exists
 
 		//Mount the drive and see if the file exists
+		if (isset($settings['jsonConfigBackupUSBLocation']) && !empty($settings['jsonConfigBackupUSBLocation']) && strtolower($settings['jsonConfigBackupUSBLocation']) !== 'none') {
 		$fileExists = DriveMountHelper($settings['jsonConfigBackupUSBLocation'], 'file_exists', array($fullPath));
+		}
 	}
 
 	if ($dir == "") {
@@ -849,7 +855,9 @@ function DeleteJsonBackup(){
 		} elseif (strtolower($dirName) == "jsonbackupsalternate") {
 			//Use our DriveMountHelper to mount the specified USB drive and check if the file exists
 			// Mount the drive and delete the file
+			if (isset($settings['jsonConfigBackupUSBLocation']) && !empty($settings['jsonConfigBackupUSBLocation']) && strtolower($settings['jsonConfigBackupUSBLocation']) !== 'none') {
 			$fileDeleted = DriveMountHelper($settings['jsonConfigBackupUSBLocation'], 'unlink', array($fullPath));
+			}
 
 			//ALSO check if the file exists in the /home/fpp/media location, because the backup we're deleting could have been copied to USB from location
 			//and we want to delete it in both

--- a/www/backup.php
+++ b/www/backup.php
@@ -151,6 +151,7 @@ $backups_verbose_logging = false;
 
 //Hold any backup error messages here
 $backup_errors = array();
+$backup_saved_to_usb = false;
 
 //Array of known plugins - initially empty, populated dynamically
 $system_active_plugins = array();
@@ -207,6 +208,8 @@ if (!$settings['BeaglePlatform']) {
  * Handle POST for download or restore
  * Check which submit button was pressed
  */
+$usbLocation = isset($settings['jsonConfigBackupUSBLocation']) ? $settings['jsonConfigBackupUSBLocation'] : '';
+
 if (isset($_POST['btnDownloadConfig'])) {
     //////
     /// BACKUP
@@ -221,8 +224,25 @@ if (isset($_POST['btnDownloadConfig'])) {
         //this value *SHOULD* directly match a key in $system_config_areas
         $area = $_POST['backuparea'];
 
-        //Do the work to backup settings
-        performBackup($area, true);
+        //Check if a USB backup location is configured
+        $usbConfigured = !empty($usbLocation) && strtolower($usbLocation) !== 'none';
+        $backupToFileManager = isset($_POST['backupToFileManager']);
+
+        if ($usbConfigured) {
+            $backupResult = performBackup($area, false);
+            DoJsonBackupToUSB();
+
+            if ($backupToFileManager) {
+                $backup_saved_to_usb = true;
+            } else {
+                if (is_array($backupResult) && isset($backupResult['backup_file_path'])) {
+                    @unlink($backupResult['backup_file_path']);
+                }
+                $backup_saved_to_usb = true;
+            }
+        } else {
+            performBackup($area, true);
+        }
     }
 
 } else if (isset($_POST['btnRestoreConfig'])) {
@@ -2230,7 +2250,9 @@ if ($skipHTMLCodeOutput === false) {
 
             function GetBackupHostBackupDirs(remoteStorageSelected) {
                 fppFileCopy.getBackupHostBackupDirs(remoteStorageSelected);
-                GetRemoteHostUSBStorage();
+                if (remoteStorageSelected === 'backup.Host') {
+                    GetRemoteHostUSBStorage();
+                }
             }
 
             function PopulateBackupDirs(data, excludeRoot) {
@@ -2925,6 +2947,14 @@ if ($skipHTMLCodeOutput === false) {
                                             <?php
                                         }
                                         ?>
+                                        <?php if ($backup_saved_to_usb) {
+                                            ?>
+                                            <div id="backupToUSBSuccess" style="display: block;"
+                                                class="callout callout-success">Configuration saved to USB device:
+                                                <?php echo htmlspecialchars($usbLocation); ?>
+                                            </div>
+                                            <?php
+                                        } ?>
                                         <?php if ($restore_done == true) {
                                             ?>
                                             <div id="rebootFlag" style="display: block;" class="callout callout-warning">Backup
@@ -3034,6 +3064,19 @@ if ($skipHTMLCodeOutput === false) {
 
                                                         <div class="row">
                                                             <div class="col-md-4">
+                                                                <span>Backup to Local FPP File Manager?</span>
+                                                            </div>
+                                                            <div class="col-md-8">
+                                                                <input id="backupToFileManager" name="backupToFileManager"
+                                                                    type="checkbox" checked="true">
+                                                                <img id="backupToFileManager_img"
+                                                                    title="Backups will also be saved to the config directory (<?php echo $settings['configDirectory'] . "/backups" ?>) and accessible from the JSON Backups tab in the FPP File Manager."
+                                                                    src="images/redesign/help-icon.svg" class="icon-help">
+                                                            </div>
+                                                        </div>
+
+                                                        <div class="row">
+                                                            <div class="col-md-4">
                                                                 <span class='jsonConfigUSB'>Copy Backups To Additional
                                                                     Location:</span>
                                                             </div>
@@ -3045,7 +3088,7 @@ if ($skipHTMLCodeOutput === false) {
                                                                     class='buttons refreshBackupDevicesList'
                                                                     onClick='GetBackupDevices();' value='Refresh List'>
                                                                 <img id="jsonConfigUSBUsage_img"
-                                                                    title="Specify an additional storage device where configuration backups will be copied to. Backups will first be saved to the config directory (<?php echo $settings['configDirectory'] . "/backups" ?>), and then copied to the alternative location."
+                                                                    title="Specify an additional storage device where configuration backups will be copied to."
                                                                     src="images/redesign/help-icon.svg" class="icon-help">
                                                             </div>
                                                         </div>

--- a/www/common.php
+++ b/www/common.php
@@ -1660,7 +1660,7 @@ function PrintSettingPasswordSaved($setting, $restart = 1, $reboot = 0, $maxleng
             }
         }
     </script>
-    <?
+    <?php
 }
 
 function PrintSettingSave($title, $setting, $restart = 1, $reboot = 0, $pluginName = "", $callbackName = "")

--- a/www/filemanager.php
+++ b/www/filemanager.php
@@ -184,10 +184,17 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link " id="tab-jsonbackups-tab" data-bs-toggle="pill"
+                                data-bs-target="#tab-jsonbackups" href="#tab-jsonbackups" role="tab"
+                                aria-controls="tab-jsonbackups">
+                                JSON Backups
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link " id="tab-backups-tab" data-bs-toggle="pill"
                                 data-bs-target="#tab-backups" href="#tab-backups" role="tab"
                                 aria-controls="tab-backups">
-                                Backups
+                                File Copy Backups
                             </a>
                         </li>
                         <?php if (isset($settings['uiLevel']) && $settings['uiLevel'] >= 3) { ?>
@@ -795,6 +802,58 @@
                                             type="button" value="Download" />
                                         <input onclick="ButtonHandler('Backups', 'delete');"
                                             class="disableButtons singleBackupsButton multiBackupsButton" type="button"
+                                            value="Delete" />
+                                    </div>
+                                    <div class="note"><strong>CTRL+Click to select multiple items</strong></div>
+
+                                </div>
+                            </div>
+
+                        </div>
+                        <div class="tab-pane fade" id="tab-jsonbackups" role="tabpanel" aria-labelledby="tab-jsonbackups-tab">
+                            <div id="divJsonBackups">
+                                <div class="backdrop">
+                                    <div class="row justify-content-between fileDetailsHeader">
+                                        <div class="col-auto">
+                                            <h2>JSON Configuration Backups</h2>
+                                        </div>
+                                        <div class="col-auto fileCountDetails">
+                                            <div class="row">
+                                                <div class="col-auto fileCountlabelHeading">Items</div>
+                                                <div class="col-auto fileCountlabelValue"><span id="fileCount_JsonBackups"
+                                                        class='badge text-bg-secondary'>0</span></div>
+                                                <div class="col-auto fileCountlabelHeading">Size</div>
+                                                <div class="col-auto fileCountlabelValue"><span id="fileSize_JsonBackups"
+                                                        class='badge text-bg-secondary'>0 B</span></div>
+                                            </div>
+                                        </div>
+
+                                    </div>
+                                    <div id="divJsonBackupsData" class="fileManagerDivData">
+                                        <table id="tblJsonBackups">
+                                            <thead>
+                                                <tr>
+                                                    <th data-field="filename">File</th>
+                                                    <th data-field="size">Size</th>
+                                                    <th data-field="dateModified">Date Modified</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr class='unselectableRow'>
+                                                    <td colspan=8 align='center'>Loading Files...</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+
+                                    <div class='form-actions'>
+                                        <input onclick="ClearSelections('JsonBackups');" class="buttons" type="button"
+                                            value="Clear" />
+                                        <input onclick="ButtonHandler('JsonBackups', 'download');"
+                                            class="disableButtons noDirButton singleJsonBackupsButton multiJsonBackupsButton"
+                                            type="button" value="Download" />
+                                        <input onclick="ButtonHandler('JsonBackups', 'delete');"
+                                            class="disableButtons singleJsonBackupsButton multiJsonBackupsButton" type="button"
                                             value="Delete" />
                                     </div>
                                     <div class="note"><strong>CTRL+Click to select multiple items</strong></div>

--- a/www/js/fpp-filemanager.js
+++ b/www/js/fpp-filemanager.js
@@ -263,6 +263,7 @@ function GetAllFiles () {
 	GetFiles('Uploads');
 	GetFiles('Crashes');
 	GetFiles('Backups');
+	GetFiles('JsonBackups');
 
 	pluginFileExtensions.forEach(ext => {
 		GetFiles(ext);
@@ -749,6 +750,10 @@ function pageSpecific_PageLoad_PostDOMLoad_ActionsSetup () {
 
 	$('#tblBackups').on('mousedown', 'tbody tr', function (event, ui) {
 		HandleMouseClick(event, $(this), 'Backups');
+	});
+
+	$('#tblJsonBackups').on('mousedown', 'tbody tr', function (event, ui) {
+		HandleMouseClick(event, $(this), 'JsonBackups');
 	});
 
 	// Developer-mode only Config tab (only present when uiLevel >= 3)


### PR DESCRIPTION
# fix(backups): USB backup fixes, 'none' guard, short tag fix, and JSON Backups file manager tab

## Issues Fixed

**#2781 - FPP10 Backups - USB JSON** — The "Download Configuration" button on the Backup Configuration page now saves directly to the configured USB device instead of prompting a browser file download dialog.

**#2782 - FPP10 Backups - Remote USB Flash Drive** — Selecting a USB device in the Remote Storage dropdown no longer reverts to "Default FPP Storage" after selection.

---

## Changes

### `www/backup.php`

1. **USB-aware "Download Configuration" (#2781):**
   - Before: Clicking "Download Configuration" always triggered a browser download prompt regardless of whether a USB backup device was configured.
   - After: When a USB device is configured (`jsonConfigBackupUSBLocation` is set), the backup is saved locally and then copied to the USB device via `DoJsonBackupToUSB()`, and a success message is displayed on the page. The browser download prompt is suppressed. When no USB device is configured, the original browser download behavior is preserved unchanged.

2. **Remote Storage dropdown no longer resets (#2782):**
   - Before: `GetBackupHostBackupDirs()` unconditionally called `GetRemoteHostUSBStorage()` after fetching backup directories. This function rebuilt the entire Remote Storage dropdown HTML with `<option value='none' selected>Default FPP Storage</option>` as the default selection, resetting whatever device the user had just selected.
   - After: `GetRemoteHostUSBStorage()` is only called when the function is triggered by a host change (parameter is `'backup.Host'`), not when triggered by a remote storage selection change. This preserves the user's device selection while still refreshing the USB device list when switching hosts.

3. **"Backup to Local FPP File Manager?" checkbox:**
   - Added a checkbox with help tooltip that controls whether the backup file is retained in `/home/fpp/media/config/backups/` after being copied to USB. Default is checked (local copy retained). When unchecked, the local copy is removed via `@unlink()` after the USB copy completes.

### `www/api/controllers/backups.php`

4. **'none' USB setting root cause fix:**
   - Before: `GetAvailableJSONBackups()` checked `!empty($settings['jsonConfigBackupUSBLocation'])` which is true when the value is `'none'` (the default when no USB device is selected). This caused `DriveMountHelper('none', ...)` to attempt mounting a nonexistent device, returning phantom directory entries. The prune function (`pruneOrRemoveAgedBackupFiles`) counted these phantom entries, causing it to delete real backup files from `/home/fpp/media/config/backups/`.
   - After: Added `&& strtolower($settings['jsonConfigBackupUSBLocation']) !== 'none'` to the condition, preventing the phantom mount attempt.

5. **'none' guard applied to all vulnerable `DriveMountHelper` calls:**
   - All 5 `DriveMountHelper` calls that read from `$settings['jsonConfigBackupUSBLocation']` are now guarded against the `'none'` value (lines 427, 693, 778, 791, 841, 858 — covering `GetAvailableJSONBackups`, `RestoreJsonBackup`, `DownloadJsonBackup`, and `DeleteJsonBackup`).

### `www/common.php`

6. **Fixed pre-existing `<?` short open tag:**
   - Changed `<?` to `<?php` on line 1663. When PHP's `short_open_tag` is disabled, `<?` is treated as literal text rather than a PHP opening tag, causing the closing `}` of `PrintSettingPasswordSaved()` to never be parsed. This resulted in a parse error (`Unclosed '{'`) that prevented `backup.php` (and any page including `common.php`) from loading.

### `www/filemanager.php` & `www/js/fpp-filemanager.js`

7. **Renamed "Backups" tab to "File Copy Backups", added "JSON Backups" tab:**
   - The existing "Backups" tab showed files from `/home/fpp/media/backups/` (full system backups from the file copy feature). This is now labeled "File Copy Backups" to be more descriptive.
   - A new "JSON Backups" tab shows files from `/home/fpp/media/config/backups/` (JSON configuration backups). It uses the existing `api/files/JsonBackups` API endpoint via `GetDirSetting('jsonbackups')` and supports Download and Delete operations.
   - Tab order: JSON Backups appears first, followed by File Copy Backups.