### PR TITLE
fix(backups): MQTT local broker not starting after backup restore, and stale version info from backed-up fpp-info.json

### DIFF
--- a/scripts/copy_settings_to_storage.sh
+++ b/scripts/copy_settings_to_storage.sh
@@ -182,7 +182,7 @@ for action in $@; do
         rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/config/backups $DEST/config  2>&1 | IgnoreWarnings
         ;;
     "Configuration")
-        rsync $EXTRA_ARGS --exclude=music/* --exclude=sequences/* --exclude=videos/*  --exclude=config/cape-eeprom.bin --exclude=effects/*  --exclude=events/*  --exclude=logs/*  --exclude=scripts/*  --exclude=plugin*  --exclude=playlists/*   --exclude=images/* --exclude=cache/* --exclude=backups/* $SOURCE/* $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS --exclude=music/* --exclude=sequences/* --exclude=videos/*  --exclude=config/cape-eeprom.bin --exclude=effects/*  --exclude=events/*  --exclude=logs/*  --exclude=scripts/*  --exclude=plugin*  --exclude=playlists/*   --exclude=images/* --exclude=cache/* --exclude=backups/* --exclude=fpp-info.json $SOURCE/* $DEST  2>&1 | IgnoreWarnings
         ;;
     *)
         echo -n "Unknown action $action"

--- a/www/copystorage.php
+++ b/www/copystorage.php
@@ -2,6 +2,7 @@
 $skipJSsettings = 1;
 require_once "common.php";
 require_once "common/oplog.inc.php";
+require_once "common/settings.php";
 // Ignore user aborts and allow the script to continue running
 session_write_close();
 ignore_user_abort(true);
@@ -86,6 +87,25 @@ $isRestore = stripos($direction, 'FROM') === 0;
 $hasConfig = stripos($flags, 'Configuration') !== false;
 if ($isRestore && $hasConfig && $backupRc === 0) {
     WriteSettingToFile('rebootFlag', '1');
+
+    // Apply service settings that need system-level setup (config files,
+    // service enable/start) so they survive the reboot.
+    // These are normally applied by handle_boot_actions on every boot, but
+    // that script only runs when BootActions is set — which is rare.
+    // Apply them here so the user doesn't need a second UI visit to get
+    // the services running after a restore.
+    if (GetSettingValue('Service_MQTT_localbroker') === '1') {
+        SetupLocalMQTTBroker('1');
+    }
+    if (GetSettingValue('Service_rsync') === '1') {
+        ApplySetting('Service_rsync', '1');
+    }
+    if (GetSettingValue('Service_smbd_nmbd') === '1') {
+        ApplySetting('Service_smbd_nmbd', '1');
+    }
+    if (GetSettingValue('Service_vsftpd') === '1') {
+        ApplySetting('Service_vsftpd', '1');
+    }
 }
 
 // The run's output goes into the fppd.log timeline, and the progress file is


### PR DESCRIPTION
# fix(backups): MQTT local broker not starting after backup restore, and stale version info from backed-up fpp-info.json

## Problem 1: Local MQTT broker not running after restore

When a backup is restored via File Copy restore (`FROMREMOTE`/`FROMUSB` with the "Configuration" flag), the settings file is restored with `Service_MQTT_localbroker = 1`, but the actual mosquitto broker is never started. The restore process (`copystorage.php`) sets `rebootFlag = 1` and exits — it never calls `SetupLocalMQTTBroker()` to create the mosquitto config/password files or enable/start the systemd service.

On the subsequent reboot, `handle_boot_actions` is supposed to apply service settings, but it only runs when the `BootActions` setting is non-empty — which is almost never set on Raspberry Pi (only populated by cape-detection code in `CapeUtils.cpp`). So the boot-time service setup is skipped entirely.

When `fppd` starts and finds `MQTTHost = localhost`, it attempts to connect to port 1883, but mosquitto isn't listening → error 14 (`MOSQ_ERR_NO_CONN` / "Bad address") → "MQTT Init failed. Starting without MQTT."

**Fix:** After a successful configuration restore in `copystorage.php`, immediately apply the four service settings (`Service_MQTT_localbroker`, `Service_rsync`, `Service_smbd_nmbd`, `Service_vsftpd`) if they are enabled. This calls `SetupLocalMQTTBroker()` which creates the required config files, runs `systemctl enable` (making it persist across reboots), and starts the service immediately. The same pattern is applied to the other services via `ApplySetting()` → `ApplyServiceSetting()`.

## Problem 2: Stale version string from backed-up fpp-info.json

`fpp-info.json` is a runtime-generated file written by `MultiSync::WriteRuntimeInfoFile()` containing the system's IP, version, model, channel ranges, etc. During a Configuration restore, `copy_settings_to_storage.sh` rsyncs the entire media directory root, which includes `fpp-info.json`. This overwrites the new system's file with the source system's version string, so the web UI briefly displays the wrong version after a restore (until fppd reaches `WriteRuntimeInfoFile()` in its startup sequence and corrects it).

**Fix:** Add `--exclude=fpp-info.json` to the Configuration rsync command. This is consistent with the existing pattern — other runtime-generated directories (`cache/*`, `logs/*`, `tmp/*`) are already excluded. Every field in `fpp-info.json` is either compiled into the running fppd binary, detected at boot, or already persisted in the `settings` file.

## Files changed

- **`scripts/copy_settings_to_storage.sh`** — Add `--exclude=fpp-info.json` to the Configuration rsync
- **`www/copystorage.php`** — Add `require_once "common/settings.php"` and apply service settings after a successful configuration restore

## Additional Comments
This PR provided fixes for the issues referenced by @bobreese in his comment on [#2752](https://github.com/FalconChristmas/fpp/issues/2752#issuecomment-5105674257).