### PR TITLE
feat(multisync): add JBoards controller support

### DIFF
--- a/docs/ControlProtocol.txt
+++ b/docs/ControlProtocol.txt
@@ -141,6 +141,8 @@ buf[9] = App/Hardware Type
            - 0xC1 - xSchedule
            - 0xC2 - ESPixelStick - ESP8266
            - 0xC3 - ESPixelStick - ESP32
+           - 0xC4 - Baldrick
+           - 0xC5 - JBoards
            - 0xFB - WLED
            - 0xFC - DIYLEDExpress
            - 0xFD - HinksPix

--- a/src/MultiSync.cpp
+++ b/src/MultiSync.cpp
@@ -188,7 +188,9 @@ void MultiSyncSystem::update(MultiSyncSystemType type,
     // learned via the UDP MultiSync protocol so that FPP remotes discovered
     // via HTTP (e.g. on a network segment where multicast is blocked - the
     // very case this mode exists for) are still targeted.
-    this->supportsUnicast = (this->type < kSysTypeFalconController) &&
+    // JBoards also qualifies: a MultiSync remote that does not run fppd.
+    this->supportsUnicast = ((this->type < kSysTypeFalconController) ||
+                             (this->type == kSysTypeJBoards)) &&
                             (this->fppMode == REMOTE_MODE);
 }
 
@@ -736,6 +738,8 @@ std::string MultiSync::GetTypeString(MultiSyncSystemType type, bool local) {
         return "ESPixelStick-ESP32";
     case kSysTypeBaldrick:
         return "Baldrick";
+    case kSysTypeJBoards:
+        return "JBoards";
     case kSysTypeMacOS:
         return "MacOS";
     case kSysTypeFPPArmbian:

--- a/src/MultiSync.h
+++ b/src/MultiSync.h
@@ -114,6 +114,7 @@ typedef enum systemType {
     kSysTypeESPixelStick = 0xC2,
     kSysTypeESPixelStickESP32 = 0xC3,
     kSysTypeBaldrick = 0xC4,
+    kSysTypeJBoards = 0xC5,
     kSysTypeNonMultiSyncCapable = 0xF0,
     kSysTypeWLED = 0xFB,
     kSysTypeDIYLEDExpress = 0xFC,

--- a/src/NetworkController.cpp
+++ b/src/NetworkController.cpp
@@ -62,6 +62,9 @@ NetworkController* NetworkController::DetectControllerViaHTML(const std::string&
     if (nc->DetectBaldrickController(ip, html)) {
         return nc;
     }
+    if (nc->DetectJBoardsController(ip, html)) {
+        return nc;
+    }
     if (nc->DetectAlphaPixController(ip, html)) {
         return nc;
     }
@@ -336,6 +339,72 @@ bool NetworkController::DetectBaldrickController(const std::string& ip,
 
         if (hostname != "") {
             DumpControllerInfo();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool NetworkController::DetectJBoardsController(const std::string& ip,
+                                                const std::string& html) {
+    LogExcess(VB_SYNC, "Checking if %s is a JBoards controller\n", ip.c_str());
+
+    if (!contains(html, "JBoards - LED Controller"))
+        return false;
+
+    LogExcess(VB_SYNC, "%s is potentially a JBoards controller, checking further\n", ip.c_str());
+
+    vendor = "JBoards";
+    vendorURL = "https://pixelpropshop.com";
+    typeId = kSysTypeJBoards;
+    typeStr = "JBoards";
+    systemMode = BRIDGE_MODE;
+
+    std::string url = buildHttpURL(ip, "/api/system/info");
+    std::string resp;
+
+    if (urlGet(url, resp)) {
+        Json::Value v = LoadJsonFromString(resp);
+
+        hostname = v["HostName"].asString();
+        version = v["Version"].asString();
+
+        std::string variant = v["Variant"].asString();
+        if (variant != "") {
+            typeStr = variant;
+        }
+
+        if (v.isMember("channelRanges")) {
+            ranges = v["channelRanges"].asString();
+        }
+        if (v.isMember("uuid")) {
+            uuid = v["uuid"].asString();
+        }
+
+        std::string md = v["Mode"].asString();
+        if (md == "bridge") {
+            systemMode = BRIDGE_MODE;
+        } else if (md == "player") {
+            systemMode = PLAYER_MODE;
+        } else if (md == "remote") {
+            systemMode = REMOTE_MODE;
+        }
+
+        if (v.isMember("majorVersion")) {
+            majorVersion = v["majorVersion"].asInt();
+            minorVersion = v["minorVersion"].asInt();
+        } else if (version != "") {
+            majorVersion = atoi(version.c_str());
+            std::size_t verDot = version.find(".");
+            if (verDot != std::string::npos) {
+                minorVersion = atoi(version.substr(verDot + 1).c_str());
+            }
+        }
+
+        if (hostname != "") {
+            DumpControllerInfo();
+
             return true;
         }
     }

--- a/src/NetworkController.h
+++ b/src/NetworkController.h
@@ -39,6 +39,7 @@ private:
     bool DetectSanDevicesController(const std::string& ip, const std::string& html);
     bool DetectESPixelStickController(const std::string& ip, const std::string& html);
     bool DetectBaldrickController(const std::string& ip, const std::string& html);
+    bool DetectJBoardsController(const std::string& ip, const std::string& html);
     bool DetectAlphaPixController(const std::string& ip, const std::string& html);
     bool DetectHinksPixController(const std::string& ip, const std::string& html);
     bool DetectDIYLEDExpressController(const std::string& ip, const std::string& html);

--- a/www/api/controllers/stats.php
+++ b/www/api/controllers/stats.php
@@ -415,6 +415,8 @@ function addMultiSyncUUID(&$data)
             $urlHost = fppUrlHost($ip);
             if ($tid >= 160 && $tid < 170) {
                 $curl = curl_init("http://" . $urlHost . "/update/identity");
+            } else if ($tid == 197) {
+                $curl = curl_init("http://" . $urlHost . "/api/system/info");
             } else {
                 $curl = curl_init("http://" . $urlHost . "/api/fppd/status");
             }

--- a/www/api/controllers/system.php
+++ b/www/api/controllers/system.php
@@ -575,6 +575,8 @@ function SystemGetStatus()
                     $curl = curl_init("http://" . $urlHost . "/json/info");
                 } else if ($type == "Baldrick") {
                     $curl = curl_init("http://" . $urlHost . "/system_state");
+                } else if ($type == "JBoards") {
+                    $curl = curl_init("http://" . $urlHost . "/api/system/status");
                 } else if ($type == "FV3") {
                     $curl = curl_init("http://" . $urlHost . "/status.xml");
                 } else if ($type == "FV4") {

--- a/www/multisync.php
+++ b/www/multisync.php
@@ -243,6 +243,7 @@
         const wledPoller    = new AutoRefreshController();
         const geniusPoller  = new AutoRefreshController();
         const baldrickPoller = new AutoRefreshController();
+        const jboardsPoller = new AutoRefreshController();
 
         var unavailables = [];
         var reorderModeActive = false;
@@ -306,6 +307,8 @@
             WLED:          new Set([0xFB]),
             // 0xC4 = 196
             BALDRICK:      new Set([0xC4]),
+            // 0xC5 = 197
+            JBOARDS:       new Set([0xC5]),
         };
 
         function isDeviceType(typeId, category) {
@@ -325,6 +328,7 @@
         function isGenius(typeId)         { return isDeviceType(typeId, 'GENIUS'); }
         function isWLED(typeId)           { return isDeviceType(typeId, 'WLED'); }
         function isBaldrick(typeId)       { return isDeviceType(typeId, 'BALDRICK'); }
+        function isJBoards(typeId)        { return isDeviceType(typeId, 'JBOARDS'); }
 
         // ============================================================
         // SECTION: Utilities
@@ -1621,6 +1625,7 @@
             var wledIpAddresses = [];
             var geniusIpAddresses = [];
             var baldrickIpAddresses = [];
+            var jboardsIpAddresses = [];
             var falconV4Addresses = [];
             var falconV3Addresses = [];
 
@@ -1867,12 +1872,15 @@
                     geniusIpAddresses.push(ip);
                 } else if (isBaldrick(data[i].typeId)) {
                     baldrickIpAddresses.push(ip);
+                } else if (isJBoards(data[i].typeId)) {
+                    jboardsIpAddresses.push(ip);
                 }
             }
             getFPPSystemStatus(fppIpAddresses, false);
             getWLEDControllerStatus(wledIpAddresses, false);
             getGeniusControllerStatus(geniusIpAddresses, false);
             getBaldrickControllerStatus(baldrickIpAddresses, false);
+            getJBoardsControllerStatus(jboardsIpAddresses, false);
             getFalconControllerStatus(falconV3Addresses, falconV4Addresses, false);
 
             var extraRemotes = [];
@@ -2494,6 +2502,67 @@
         }
 
         // ============================================================
+        // SECTION: JBoards polling
+        // ============================================================
+
+        async function getJBoardsControllerStatus(ipAddresses, refreshing = false) {
+            ips = "";
+            if (Array.isArray(ipAddresses)) {
+                jboardsPoller.cancel();
+                ipAddresses.forEach(function (entry) {
+                    ips += "&ip[]=" + entry;
+                });
+            } else {
+                ips = "&ip[]=" + ipAddresses;
+            }
+            if (ips == "") {
+                return;
+            }
+            try {
+                const r = await fetch("api/system/status?type=JBoards" + ips);
+                const alldata = await r.json();
+                var $tbl = $('#fppSystemsTable');
+                Object.entries(alldata).forEach(function (entry) {
+                    var ip = entry[0], data = entry[1];
+                    if (data == null || data == "" || data == "null") {
+                        return;
+                    }
+
+                    var rowId = hostRows[ip.replace(/\./g, '_')];
+                    var item = $tbl.bootstrapTable('getRowByUniqueId', rowId);
+                    if (!item) return;
+
+                    if (data.status_name) {
+                        var status = data.status_name.charAt(0).toUpperCase() +
+                                     data.status_name.slice(1);
+                        if (data.current_playlist && data.current_playlist.playlist) {
+                            status += ":<br>" + data.current_playlist.playlist;
+                        }
+                        item.status = status;
+                    }
+                    item.elapsed = data.time_elapsed ? data.time_elapsed : '';
+
+                    if (data.host_description &&
+                        item.hostname.indexOf("class='hostDescriptionSM'></small>") >= 0) {
+                        item.hostname = item.hostname.replace(
+                            "class='hostDescriptionSM'></small>",
+                            "class='hostDescriptionSM'>" + data.host_description + "</small>"
+                        );
+                    }
+
+                    if (data.version) {
+                        item.version = data.version;
+                    }
+                });
+                safeInitBody($tbl);
+            } finally {
+                if (Array.isArray(ipAddresses) && $('#MultiSyncRefreshStatus').is(":checked") && !isUserInteracting()) {
+                    jboardsPoller.schedule(() => getJBoardsControllerStatus(ipAddresses, true));
+                }
+            }
+        }
+
+        // ============================================================
         // SECTION: Refresh orchestration
         // ============================================================
 
@@ -2503,11 +2572,12 @@
             wledPoller.cancel();
             geniusPoller.cancel();
             baldrickPoller.cancel();
+            jboardsPoller.cancel();
         }
 
         function RefreshStats() {
             var $tbl = $('#fppSystemsTable');
-            var ips = [], gips = [], wips = [], bips = [], fv3ips = [], fv4ips = [];
+            var ips = [], gips = [], wips = [], bips = [], jips = [], fv3ips = [], fv4ips = [];
             var seenRows = {};
 
             Object.keys(hostRows).forEach(function (key) {
@@ -2540,6 +2610,8 @@
                     gips.push(ip);
                 } else if (isBaldrick(typeId)) {
                     bips.push(ip);
+                } else if (isJBoards(typeId)) {
+                    jips.push(ip);
                 }
             });
 
@@ -2547,6 +2619,7 @@
             getGeniusControllerStatus(gips, true);
             getWLEDControllerStatus(wips, true);
             getBaldrickControllerStatus(bips, true);
+            getJBoardsControllerStatus(jips, true);
             getFalconControllerStatus(fv3ips, fv4ips, true);
         }
 
@@ -3927,7 +4000,9 @@
                 'Falcon': 'Falcon',
                 'FalconV4': 'FalconV4',
                 'ESPixelStick': 'ESPixelStick',
+                'Baldrick': 'Baldrick',
                 'Genius': 'Genius',
+                'JBoards': 'JBoards',
                 'SanDevices': 'SanDevices',
                 'WLED': 'WLED',
                 'Unknown': 'Unknown'
@@ -3948,7 +4023,9 @@
                     case 'falcon': return isFalcon(typeId);
                     case 'falconv4': return isFalconV4(typeId);
                     case 'espixelstick': return isESPixelStick(typeId);
+                    case 'baldrick': return isBaldrick(typeId);
                     case 'genius': return isGenius(typeId);
+                    case 'jboards': return isJBoards(typeId);
                     case 'sandevices': return isSanDevices(typeId);
                     case 'wled': return isWLED(typeId);
                     case 'unknown': return isUnknownController(typeId);


### PR DESCRIPTION
JBoards controllers play FSEQ files locally and stay in step off MultiSync
packets.

Allocate 0xC5 in the "other systems" block.

supportsUnicast gains JBoards alongside the existing "below 0x80" test, so a
JBoard in Remote mode can be a unicast sync target. No existing type changes
behaviour.

HTTP discovery gains DetectJBoardsController, reading /api/system/info for identity. The multisync page gets the
type classifier, the platform filter entry and a status poller.

Also adds the Baldrick platform filter entry, missed when that controller was
added, and the 0xC4/0xC5 rows in ControlProtocol.txt.

Happy to use a different id if `0xC5` isn't the preferred slot.
