### PR TITLE
fix(multisync): Show WLED device name as clickable HTTP link in multisync hostname column

### DIFF
--- a/src/NetworkController.cpp
+++ b/src/NetworkController.cpp
@@ -455,6 +455,7 @@ bool NetworkController::DetectWLEDController(const std::string& ip, const std::s
         vendorURL = "https://github.com/Aircoookie/WLED";
 
         version = v["ver"].asString();
+        hostname = v["name"].asString();
         typeStr = v["arch"].asString();
         typeId = kSysTypeWLED;
         systemMode = BRIDGE_MODE;

--- a/www/multisync.php
+++ b/www/multisync.php
@@ -1756,7 +1756,7 @@
                 if ((data[i].fppModeString == 'remote') && (star != ""))
                     ipTxt = "<small>Select IPs for Unicast Sync</small><br>" + ipTxt + star;
 
-                var hostTxt = (fppConfig.hideExternalURLs || data[i].local || data[i].address == hostname)
+                var hostTxt = (!isWLED(data[i].typeId) && (fppConfig.hideExternalURLs || data[i].local || data[i].address == hostname))
                     ? hostname
                     : "<a target='host_" + data[i].address + "' href='" + wrapUrlWithProxy(data[i].address, "/") + "'>" + hostname + "</a>";
 
@@ -2360,6 +2360,20 @@
                         item.ipaddress = base.replace(endTag, endTag + wifiIcon) + extra;
                     } else {
                         item.ipaddress = base + wifiIcon + extra;
+                    }
+
+                    if (data.name) {
+                        var ipDash = ip.replace(/\./g, '_');
+                        var spanId = "fpp_" + ipDash + "_hostname";
+                        var spanStart = item.hostname.indexOf("id='" + spanId + "'");
+                        if (spanStart >= 0) {
+                            var tagEnd = item.hostname.indexOf(">", spanStart);
+                            var spanEnd = item.hostname.indexOf("</span>", tagEnd);
+                            if (tagEnd >= 0 && spanEnd >= 0) {
+                                var newContent = "<a target='host_" + ip + "' href='" + wrapUrlWithProxy(ip, "/") + "'>" + data.name + "</a>";
+                                item.hostname = item.hostname.substring(0, tagEnd + 1) + newContent + item.hostname.substring(spanEnd);
+                            }
+                        }
                     }
                 });
                 safeInitBody($tbl);


### PR DESCRIPTION
# fix(multisync): Show WLED device name as clickable HTTP link in multisync hostname column

## Problem

On the multisync page (`multisync.php`), WLED devices appear as a "Bridge" device type. In the hostname column, their raw IP address is shown as plain text (no link), unlike FPP players and remotes whose hostnames render as clickable HTTP links to their web UI.

This was caused by two issues:
1. `DetectWLEDController()` in the C++ discovery code never populated the `hostname` field from the WLED `/json/info` `name` field, leaving it set to the IP address.
2. The JavaScript link-condition logic explicitly skipped creating a link when the hostname equals the IP address (`data[i].address == hostname`), which was always the case for WLED devices.

## Changes

**`src/NetworkController.cpp`** — Populate `hostname` from the WLED device's configured name (`v["name"]` from `/json/info`) during HTTP discovery, so the multisync systems list carries the friendly name instead of the raw IP.

**`www/multisync.php`** (two changes):

- **Line 1759** — Exclude WLED devices from the "skip link when hostname == address" check so they always render a clickable HTTP link in the hostname column. This serves as a fallback for older fppd versions without the C++ fix.

- **`getWLEDControllerStatus()`** — During status polling, update the hostname span to show the WLED device name (from `data.name`) as a clickable link to the IP. This ensures the name appears promptly after page load even without the C++ fix.

## Result

WLED devices now show their configured name (e.g., "Living Room Light") in the multisync hostname column as a clickable link to `http://<ip>/`, consistent with how FPP players and remotes display their hostnames.

## Screenshots

### Before:
<img width="1235" height="381" alt="ss_before" src="https://github.com/user-attachments/assets/39853a5c-0564-4560-9037-27536f1f59d8" />

### After:
<img width="1235" height="381" alt="ss_after" src="https://github.com/user-attachments/assets/8ccbf255-32ce-4e9d-8beb-6ddce9e3944b" />