### PR TITLE
feat(plugins) Developer UI: show open issue/PR counts on plugin cards and detail dialog

### DIFF
--- a/www/api/controllers/plugin.php
+++ b/www/api/controllers/plugin.php
@@ -1257,6 +1257,263 @@ function GetPluginPopularity()
 	return json(array('period' => PLUGIN_POPULARITY_PERIOD, 'counts' => new stdClass(), 'source' => 'unavailable'));
 }
 
+// --- Plugin GitHub issue/PR stats (Developer UI) ---------------------------
+// Open-issue and open-PR counts for each plugin repo, shown in the bottom-right
+// corner of the plugin card in Developer UI mode. Counts come from GitHub's
+// issue-search API, which can answer a whole GROUP of repos in one request
+// instead of one request per repo -- the per-repo pattern is what produces a
+// flood of 404s when a repo is renamed/removed or the device has no route to
+// api.github.com (every miss is a 404 + a wasted request). Issues and PRs come
+// back in the SAME issues-search result set (a PR is an issue carrying a
+// pull_request field), so one untyped `state:open` query per group yields both
+// counts. Fail-soft throughout, matching the popularity proxy: any network or
+// rate-limit problem yields a stale disk cache if we have one, else an empty
+// map, and the UI then hides the corner -- it never surfaces an error.
+define('PLUGIN_GITHUB_STATS_TTL', 6 * 60 * 60);   // 6h shared per-box cache (counts move slowly)
+define('PLUGIN_GITHUB_STATS_CHUNK', 15);          // repos per search query: bounds q length + a dead repo's blast radius
+define('PLUGIN_GITHUB_STATS_MAX_REPOS', 100);     // sanity cap on one request
+define('PLUGIN_GITHUB_STATS_MAX_PAGES', 5);       // cap pagination (500 items per group)
+
+function PluginGitHubStatsCacheFile()
+{
+	global $settings;
+	$base = isset($settings['mediaDirectory']) ? $settings['mediaDirectory'] : '/home/fpp/media';
+	return $base . '/tmp/pluginGithubStats.cache.json';
+}
+
+// One search API request. Returns http status, curl errno/message and body.
+function GitHubStatsSearchPage($url)
+{
+	$res = array('http' => 0, 'errno' => 0, 'error' => '', 'body' => '');
+	if (function_exists('curl_init')) {
+		$ch = curl_init($url);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 3);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 8);
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+		curl_setopt($ch, CURLOPT_USERAGENT, 'FPP-PluginGitHubStats');
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/vnd.github+json'));
+		$body = curl_exec($ch);
+		$res['http'] = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		$res['errno'] = (int)curl_errno($ch);
+		$res['error'] = (string)curl_error($ch);
+		curl_close($ch);
+		$res['body'] = is_string($body) ? $body : '';
+		return $res;
+	}
+
+	$ctx = stream_context_create(array('http' => array(
+		'timeout' => 8,
+		'follow_location' => 1,
+		'ignore_errors' => 1,
+		'user_agent' => 'FPP-PluginGitHubStats',
+		'header' => "Accept: application/vnd.github+json\r\n",
+	)));
+	$body = @file_get_contents($url, false, $ctx);
+	if ($body === false) {
+		$res['error'] = 'file_get_contents failed';
+		return $res;
+	}
+	$res['body'] = $body;
+	if (isset($http_response_header)) {
+		foreach ($http_response_header as $h) {
+			if (preg_match('#^HTTP/\S+\s+(\d{3})#', $h, $m)) {
+				$res['http'] = (int)$m[1];
+			}
+		}
+	}
+	return $res;
+}
+
+// Fetch every open issue AND open PR for the repos named in $orQuery (a
+// space-separated "repo:owner/name repo:..." string), paginating until all
+// results are seen. Returns array('ok'=>true, 'items'=>array(array('repo'=>..,'isPull'=>bool))) or
+// array('ok'=>false, 'http'=>.., 'errno'=>.., 'error'=>..) on a hard failure.
+function GitHubStatsSearchAll($orQuery)
+{
+	$items = array();
+	$page = 1;
+	$fetched = 0;
+	$total = null;
+	while ($page <= PLUGIN_GITHUB_STATS_MAX_PAGES) {
+		$url = 'https://api.github.com/search/issues?q=' .
+			rawurlencode('state:open ' . $orQuery) .
+			'&per_page=100&page=' . $page;
+		$res = GitHubStatsSearchPage($url);
+		if ((int)$res['http'] !== 200) {
+			return array('ok' => false, 'http' => $res['http'], 'errno' => $res['errno'], 'error' => $res['error']);
+		}
+		$body = json_decode($res['body'], true);
+		if (!is_array($body) || !isset($body['items']) || !is_array($body['items'])) {
+			return array('ok' => false, 'http' => $res['http'], 'errno' => 0, 'error' => 'invalid search response');
+		}
+		if ($total === null) {
+			$total = (int)$body['total_count'];
+		}
+		foreach ($body['items'] as $it) {
+			if (!is_array($it)) continue;
+			$repo = '';
+			if (isset($it['repository_url']) && preg_match('#/repos/([^/]+/[^/]+)$#', $it['repository_url'], $m)) {
+				$repo = strtolower($m[1]);
+			}
+			if ($repo !== '') {
+				$items[] = array('repo' => $repo, 'isPull' => isset($it['pull_request']) && is_array($it['pull_request']));
+			}
+		}
+		$fetched += count($body['items']);
+		if ($fetched >= $total || $total === 0) {
+			break;
+		}
+		$page++;
+	}
+	return array('ok' => true, 'items' => $items);
+}
+
+// Fetch counts for one chunk of repos, merging into $result (lowercased repo =>
+// array('openIssues'=>int, 'openPRs'=>int)). Returns false when a hard failure
+// (rate limit / offline) should stop all further fetching; true otherwise --
+// including the per-repo fallback, which only ever hides data for the genuinely
+// broken repos rather than failing the whole request.
+function PluginGitHubStatsFetchChunk($repos, &$result)
+{
+	$lower = array();
+	foreach ($repos as $r) {
+		$lower[] = strtolower($r);
+	}
+	$orQuery = implode(' ', array_map(function ($r) { return 'repo:' . $r; }, $lower));
+	$res = GitHubStatsSearchAll($orQuery);
+
+	if ($res['ok']) {
+		foreach ($res['items'] as $item) {
+			$repo = $item['repo'];
+			if (!isset($result[$repo])) {
+				$result[$repo] = array('openIssues' => 0, 'openPRs' => 0);
+			}
+			if ($item['isPull']) $result[$repo]['openPRs']++;
+			else $result[$repo]['openIssues']++;
+		}
+		foreach ($lower as $r) {
+			if (!isset($result[$r])) {
+				$result[$r] = array('openIssues' => 0, 'openPRs' => 0);
+			}
+		}
+		return true;
+	}
+
+	// A 422 means at least one repo in the chunk is not searchable (renamed,
+	// removed, or private) -- GitHub rejects the WHOLE query. Retry one repo at
+	// a time so a single dead repo can't hide stats for the rest of the chunk;
+	// a repo that 422s by itself is treated as "no data" (and cached) rather
+	// than an error. Any non-422 failure here means "stop fetching entirely".
+	if ((int)$res['http'] === 422) {
+		foreach ($lower as $r) {
+			$one = GitHubStatsSearchAll('repo:' . $r);
+			if ($one['ok']) {
+				if (!isset($result[$r])) {
+					$result[$r] = array('openIssues' => 0, 'openPRs' => 0);
+				}
+				foreach ($one['items'] as $item) {
+					if ($item['repo'] !== $r) continue;
+					if ($item['isPull']) $result[$r]['openPRs']++;
+					else $result[$r]['openIssues']++;
+				}
+			} elseif ((int)$one['http'] !== 422) {
+				return false; // rate-limited / offline mid-fallback: give up
+			} else {
+				$result[$r] = array('openIssues' => 0, 'openPRs' => 0); // genuinely gone
+			}
+		}
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Get open issue / open PR counts for a list of GitHub repos.
+ *
+ * Developer-UI helper for the plugin cards. Accepts a comma-separated list of
+ * `owner/name` repos and returns per-repo `{ openIssues, openPRs }`. Counts are
+ * proxied from GitHub's issue-search API (one aggregate query per group of
+ * repos, cached per box), never one request per plugin -- which is what floods
+ * the device with 404s when there is no network or a repo is gone. Fail-soft:
+ * on any upstream problem it serves a stale cache if present, else an empty map
+ * (`source: unavailable`); the UI then hides the corner counts.
+ *
+ * @route GET /api/plugin/githubStats
+ * @param string repos Comma-separated `owner/name` GitHub repos.
+ * @response 200 { "repos": { "FalconChristmas/fpp-brightness": { "openIssues": 7, "openPRs": 1 } }, "source": "live|cache|partial|unavailable" }
+ */
+function GetPluginGitHubStats()
+{
+	$requested = array();
+	$raw = isset($_GET['repos']) ? $_GET['repos'] : '';
+	foreach (explode(',', $raw) as $r) {
+		$r = trim($r);
+		// "owner/name.git" (a srcURL fragment) refers to the same repo as
+		// "owner/name"; a ".git" repo in a search query fails the whole query.
+		$r = preg_replace('/\.git$/i', '', $r);
+		if ($r === '' || preg_match('#^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$#', $r) !== 1) continue;
+		$requested[strtolower($r)] = true;
+		if (count($requested) >= PLUGIN_GITHUB_STATS_MAX_REPOS) break;
+	}
+	if (count($requested) === 0) {
+		return json(array('repos' => new stdClass(), 'source' => 'unavailable'));
+	}
+
+	$cacheFile = PluginGitHubStatsCacheFile();
+	$cache = array();
+	if (file_exists($cacheFile)) {
+		$tmp = json_decode(@file_get_contents($cacheFile), true);
+		if (is_array($tmp)) $cache = $tmp;
+	}
+
+	$result = array();
+	$toFetch = array();
+	foreach ($requested as $r => $v) {
+		if (isset($cache[$r]) && is_array($cache[$r]) &&
+			isset($cache[$r]['ts']) && (time() - (int)$cache[$r]['ts']) < PLUGIN_GITHUB_STATS_TTL) {
+			$result[$r] = array(
+				'openIssues' => max(0, (int)$cache[$r]['openIssues']),
+				'openPRs'    => max(0, (int)$cache[$r]['openPRs']),
+			);
+		} else {
+			$toFetch[$r] = true;
+		}
+	}
+
+	$hadLive = false;
+	$freshNow = array();
+	if (count($toFetch) > 0) {
+		$chunks = array_chunk(array_keys($toFetch), PLUGIN_GITHUB_STATS_CHUNK);
+		foreach ($chunks as $chunk) {
+			if (!PluginGitHubStatsFetchChunk($chunk, $result)) break;
+			$hadLive = true;
+		}
+		// Persist every repo we actually resolved this request (live results AND
+		// the zero-filled fallback for dead repos) so the next page load within
+		// the TTL is served without touching GitHub again.
+		$freshNow = array_intersect(array_keys($toFetch), array_keys($result));
+	}
+	if (count($freshNow) > 0) {
+		foreach ($freshNow as $r) {
+			$cache[$r] = array(
+				'openIssues' => max(0, (int)$result[$r]['openIssues']),
+				'openPRs'    => max(0, (int)$result[$r]['openPRs']),
+				'ts'         => time(),
+			);
+		}
+		@file_put_contents($cacheFile, json_encode($cache));
+	}
+
+	$covered = count($result);
+	if ($covered === 0) {
+		return json(array('repos' => new stdClass(), 'source' => 'unavailable'));
+	}
+	$source = ($covered < count($requested)) ? 'partial' : ($hadLive ? 'live' : 'cache');
+	return json(array('repos' => $result, 'source' => $source));
+}
+
 /**
  * Proxy-fetch a plugin icon image
  *

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -205,6 +205,7 @@ dispatch_get('/plugin', 'GetInstalledPlugins');
 dispatch_post('/plugin', 'InstallPlugin');
 dispatch_post('/plugin/fetchInfo', 'FetchPluginInfoProxy');
 dispatch_get('/plugin/popularity', 'GetPluginPopularity'); // keep above /plugin/:RepoName
+dispatch_get('/plugin/githubStats', 'GetPluginGitHubStats'); // keep above /plugin/:RepoName
 dispatch_get('/plugin/fetchImage', 'PluginFetchImage'); // keep above /plugin/:RepoName
 dispatch_get('/plugin/:RepoName', 'GetPluginInfo');
 dispatch_get('/plugin/:RepoName/icon', 'PluginServeIcon');

--- a/www/api/openapi.json
+++ b/www/api/openapi.json
@@ -6370,6 +6370,47 @@
         }
       }
     },
+    "/api/plugin/githubStats": {
+      "get": {
+        "tags": [
+          "plugin"
+        ],
+        "summary": "plugin/githubStats",
+        "description": "Get open issue / open PR counts for a comma-separated list of `owner/name` GitHub repos, proxied + cached from GitHub's issue-search API. Developer UI helper for the plugin cards; fails soft (empty map) when GitHub is unreachable.",
+        "parameters": [
+          {
+            "name": "repos",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated `owner/name` GitHub repositories."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "repos": {
+                    "FalconChristmas/fpp-brightness": {
+                      "openIssues": 7,
+                      "openPRs": 1
+                    }
+                  },
+                  "source": "live|cache|partial|unavailable"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/plugin/{RepoName}": {
       "parameters": [
         {

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -1080,6 +1080,191 @@
             }, 300);
         }
 
+        // --- GitHub issue/PR counts (Developer UI) ---
+        // In Developer UI mode each plugin card shows its repo's open issue and
+        // open pull request counts in the bottom-right corner. Counts come from
+        // the same-origin backend proxy (api/plugin/githubStats), which groups
+        // repos into ONE GitHub issue-search query per chunk rather than one
+        // request per plugin -- per-repo requests are what produce a flood of
+        // 404s when a repo is gone or the device has no network. The backend
+        // fails soft (stale disk cache, else empty), so when network access is
+        // unavailable the response is empty and we simply never draw the corner.
+        var IS_DEVELOPER_UI = (parseInt(settings["uiLevel"]) || 0) >= 3;
+        var pluginGitHubRepos = {};   // repoName -> "owner/repo" (GitHub srcURL only, lowercase)
+        var pluginGitHubStats = {};   // "owner/repo" -> { openIssues, openPRs } -- ONLY resolved repos
+        var githubStatsRequested = {}; // "owner/repo" -> true once asked, so unresolved repos are not re-requested
+        var pluginDetailDialogRepo = null; // repo shown in the open detail modal, so its footer badge can be patched
+        var githubStatsFetching = false;
+        var githubStatsFailed = false; // latched after a network failure: never retry this session
+
+        // GitHub owner/repo for a plugin's source repo ('' when not a GitHub repo).
+        // Normalized to lowercase so keys match the backend, which lowercases
+        // every repo in its response (GitHub repo names are case-insensitive).
+        function GitHubRepoOf(data) {
+            var u = data && data.srcURL;
+            if (!u) return '';
+            try {
+                var parsed = new URL(u);
+                if (parsed.host.toLowerCase() !== 'github.com') return '';
+                var seg = parsed.pathname.split('/').filter(function (x) { return x.length > 0; });
+                if (seg.length < 2) return '';
+                // srcURL often ends in ".git" (e.g. .../fpp-brightness.git); the
+                // GitHub repo name has no extension, and a ".git" repo in a
+                // search query fails the whole query.
+                return (seg[0] + '/' + seg[1].replace(/\.git$/i, '')).toLowerCase();
+            } catch (e) {
+                return '';
+            }
+        }
+
+        // Corner badge HTML for a repo ('' when we have no data for it).
+        function GitHubStatsBadgeHtml(repo) {
+            var s = repo && pluginGitHubStats[repo];
+            if (!s) return '';
+            var issues = parseInt(s.openIssues, 10) || 0;
+            var prs = parseInt(s.openPRs, 10) || 0;
+            return '<span class="fpp-tag gap-1 pluginGitHubStats" title="' + issues +
+                ' open issue' + (issues === 1 ? '' : 's') + ', ' + prs +
+                ' open pull request' + (prs === 1 ? '' : 's') + '">' +
+                '<i class="fas fa-exclamation-circle"></i> ' + issues +
+                ' <i class="fas fa-code-branch ms-1"></i> ' + prs + '</span>';
+        }
+
+        // The badge, wrapped for inline placement at the right end of the action
+        // button row ('' when we have no data for the repo). ms-auto pushes it to
+        // the far right of the same flex line as the buttons; align-items-center on
+        // the actions row keeps it vertically centered with them.
+        function GitHubStatsRowHtml(repo) {
+            var badge = GitHubStatsBadgeHtml(repo);
+            if (!badge) return '';
+            return '<div class="ms-auto pluginGitHubStatsRow">' + badge + '</div>';
+        }
+
+        // Stamp the counts onto already-rendered cards (called once counts
+        // arrive; cards rendered after that get the corner inline in LoadPlugin).
+        // Only touches cards whose repo we have counts for -- cards without data
+        // keep no corner, which is what hides the feature when offline.
+        function PatchPluginGitHubStats() {
+            if (!IS_DEVELOPER_UI) return;
+            $('#pluginGrid, #installedGrid, #incompatibleGrid').children('.pluginCard').each(function () {
+                var repoName = ($(this).attr('id') || '').replace(/^row-/, '');
+                var repo = pluginGitHubRepos[repoName];
+                if (!repo) return;
+                var badge = GitHubStatsBadgeHtml(repo);
+                var $actions = $(this).find('.pluginCardActions').first();
+                if (!$actions.length) return;
+                var $badge = $actions.find('.pluginGitHubStatsRow').first();
+                if (!$badge.length) {
+                    if (!badge) return;  // nothing to show yet
+                    $badge = $('<div class="ms-auto pluginGitHubStatsRow"></div>');
+                    $actions.append($badge);
+                }
+                $badge.find('.pluginGitHubStats').remove();
+                if (badge) $badge.append(badge);
+                else $badge.remove();
+            });
+
+            // Keep an open detail dialog's footer badge in sync too (a card can be
+            // opened before its counts arrive).
+            if (pluginDetailDialogRepo && $('#pluginDetailDialog').length) {
+                var dRepo = pluginGitHubRepos[pluginDetailDialogRepo];
+                var dBadge = GitHubStatsBadgeHtml(dRepo);
+                var $dBadge = $('#pluginDetailDialog .modal-footer .pluginDetailGitHubStats').first();
+                if (dBadge) {
+                    if (!$dBadge.length) {
+                        $dBadge = $('<span class="pluginDetailGitHubStats me-auto"></span>');
+                        $('#pluginDetailDialog .modal-footer').prepend($dBadge);
+                    }
+                    $dBadge.html(dBadge);
+                } else if ($dBadge.length) {
+                    $dBadge.remove();
+                }
+            }
+        }
+
+        var githubStatsDebounce = null;
+        var githubStatsDebounceStart = 0;
+        // Debounce (idle) vs max-wait: plugins trickle in as their pluginInfo.json
+        // files resolve, but we must not wait for ALL of them -- the first GitHub
+        // query should start while the rest are still loading (the backend cache
+        // makes the follow-up for stragglers cheap). So the timer is never
+        // restarted past GITHUB_STATS_MAX_WAIT from the first pending repo.
+        var GITHUB_STATS_DEBOUNCE = 150;
+        var GITHUB_STATS_MAX_WAIT = 600;
+        function ScheduleGitHubStatsFetch() {
+            if (!IS_DEVELOPER_UI || githubStatsFailed || githubStatsFetching) return;
+            // Nothing left to fetch (every known repo already has counts or was
+            // already requested)? Stop scheduling; LoadPlugin re-arms this for
+            // late-arriving plugins.
+            var needs = false;
+            for (var repoName in pluginGitHubRepos) {
+                if (!pluginGitHubRepos.hasOwnProperty(repoName)) continue;
+                var repo = pluginGitHubRepos[repoName];
+                if (repo && !pluginGitHubStats[repo] && !githubStatsRequested[repo]) { needs = true; break; }
+            }
+            if (!needs) return;
+            var now = Date.now();
+            if (!githubStatsDebounce) githubStatsDebounceStart = now;
+            var elapsed = now - githubStatsDebounceStart;
+            var wait = GITHUB_STATS_DEBOUNCE;
+            if (elapsed >= GITHUB_STATS_MAX_WAIT) {
+                wait = 0;
+            } else if (elapsed + GITHUB_STATS_DEBOUNCE > GITHUB_STATS_MAX_WAIT) {
+                wait = GITHUB_STATS_MAX_WAIT - elapsed;
+            }
+            clearTimeout(githubStatsDebounce);
+            githubStatsDebounce = setTimeout(FetchPluginGitHubStats, wait);
+        }
+
+        function FetchPluginGitHubStats() {
+            githubStatsDebounce = null;
+            githubStatsDebounceStart = 0;
+            if (!IS_DEVELOPER_UI || githubStatsFailed || githubStatsFetching) return;
+            var missing = [];
+            for (var repoName in pluginGitHubRepos) {
+                if (!pluginGitHubRepos.hasOwnProperty(repoName)) continue;
+                var repo = pluginGitHubRepos[repoName];
+                if (repo && !pluginGitHubStats[repo] && !githubStatsRequested[repo] && missing.indexOf(repo) < 0)
+                    missing.push(repo);
+            }
+            if (missing.length === 0) {
+                PatchPluginGitHubStats();
+                return;
+            }
+            // Remember we asked, so a repo the backend can't resolve (offline /
+            // dead repo) is not re-requested this session -- its corner simply
+            // stays hidden rather than being shown as a bogus 0/0.
+            for (var m = 0; m < missing.length; m++)
+                githubStatsRequested[missing[m]] = true;
+            githubStatsFetching = true;
+            $.ajax({
+                url: 'api/plugin/githubStats?repos=' + encodeURIComponent(missing.join(',')),
+                dataType: 'json',
+                success: function (data) {
+                    githubStatsFetching = false;
+                    var repos = (data && data.repos) || {};
+                    for (var k in repos) {
+                        if (!repos.hasOwnProperty(k)) continue;
+                        pluginGitHubStats[k] = {
+                            openIssues: repos[k].openIssues,
+                            openPRs: repos[k].openPRs
+                        };
+                    }
+                    PatchPluginGitHubStats();
+                    // A plugin that finished loading after this fetch started may
+                    // have added a repo; the backend's per-box cache keeps the
+                    // follow-up cheap.
+                    ScheduleGitHubStatsFetch();
+                },
+                error: function () {
+                    // Network unavailable: leave every corner hidden, latch so
+                    // we do not keep firing requests for plugins still loading.
+                    githubStatsFetching = false;
+                    githubStatsFailed = true;
+                }
+            });
+        }
+
         // Top-10 Popular strip for the active category ("All" spans every category).
         // Excludes already-installed plugins and ones that can't be installed on this box
         // (no compatible or untested version) — the strip is a discovery surface for
@@ -1330,7 +1515,19 @@
             }
             buttons['Close'] = function () { CloseModalDialog('pluginDetailDialog'); };
 
-            DoModalDialog({ id: 'pluginDetailDialog', class: 'modal-lg', title: titleIcon + data.name, body: body, backdrop: true, keyboard: true, buttons: buttons });
+            // Developer UI: GitHub issue/PR counts at the far left of the footer,
+            // vertically level with the action buttons (me-auto pushes the buttons
+            // to the right). Passed as the footer's leading content (buttons are
+            // appended after it), so it only appears when we have data -- hidden
+            // offline.
+            var detailStats = '';
+            if (IS_DEVELOPER_UI) {
+                var dBadge = GitHubStatsBadgeHtml(pluginGitHubRepos[repo]);
+                if (dBadge) detailStats = '<span class="pluginDetailGitHubStats me-auto">' + dBadge + '</span>';
+            }
+            pluginDetailDialogRepo = repo;
+
+            DoModalDialog({ id: 'pluginDetailDialog', class: 'modal-lg', title: titleIcon + data.name, body: body, backdrop: true, keyboard: true, footer: detailStats, buttons: buttons });
         }
 
         // Category name/icon for a plugin, validated against the loaded taxonomy so
@@ -1398,6 +1595,16 @@
             var untestedVersion = versionSel.untested;
             var isPrivate = (data.private || pluginInfoUseCredentials[data.repoName]);
             var official = IsOfficialPlugin(data);
+            // Developer UI: record the plugin's GitHub repo so the issue/PR
+            // corner can be filled in. Private repos are skipped (GitHub won't
+            // search them, and a private repo would poison the aggregate query).
+            if (IS_DEVELOPER_UI && !isPrivate) {
+                var ghRepo = GitHubRepoOf(data);
+                if (ghRepo) {
+                    pluginGitHubRepos[data.repoName] = ghRepo;
+                    ScheduleGitHubStatsFetch();
+                }
+            }
             var pcatName = data.__category || pluginCategoryOf[(data.repoName || '').toLowerCase()] || pluginCategoryOf[(data.name || '').toLowerCase()] || 'Other';
             var pcatObj = pluginCategoryByName[pcatName] || OTHER_CATEGORY;
             // Available grid order: usable here first, then "install anyway", then
@@ -1478,7 +1685,8 @@
             var cardAuthorHtml = PluginAuthorHtml(data);
             if (cardAuthorHtml) html += '<div class="text-secondary small mb-1 pluginAuthor"><i class="fas fa-user"></i> ' + cardAuthorHtml + '</div>';
             html += '<p class="card-text pluginCardDesc small flex-grow-1">' + data.description + '</p>';
-            html += '<div class="pluginCardActions d-flex flex-wrap gap-2 mt-2" onclick="event.stopPropagation();">' + actions + '</div>';
+            html += '<div class="pluginCardActions d-flex flex-wrap gap-2 mt-2 align-items-center" onclick="event.stopPropagation();">' +
+                actions + GitHubStatsRowHtml(pluginGitHubRepos[data.repoName]) + '</div>';
             html += '</div></div></div>';
 
             if (installed) {


### PR DESCRIPTION
# feat(plugins) Developer UI: show open issue/PR counts on plugin cards and detail dialog

> Show open GitHub issue/PR counts on plugin cards and detail dialog (Developer UI only)

## Summary

Adds a small corner badge to each plugin card and to the plugin detail dialog showing the number of open GitHub issues and open pull requests. The badge is only rendered when the FPP UI Mode is set to **Developer** (`uiLevel >= 3`), and is hidden entirely when the device has no route to `api.github.com` (offline) — it never surfaces an error or floods the network with per-repo 404s.

This is an enhancement for developers with multiple plugins and contributors of official plugins so that they can keep track of open issues and pull requests. This enhancement comes after a tightening in plugin submission guidelines and can help FPP developers with filtering out bad and unmaintained plugins.

## Motivation

Developers browsing the plugin catalog want to see, at a glance, how actively a plugin is maintained (how many open issues / pending PRs it has). Direct browser fetches to GitHub are blocked by the page CSP, and a naive "one request per repo" approach produces a flood of 404s whenever a repo is renamed/removed or the device is offline. This change proxies counts through a same-origin FPP backend endpoint that aggregates many repos into a single GitHub search query and caches results per box.

## Changes

### Backend

- **New endpoint** `GET /api/plugin/githubStats?repos=owner/name,...` in `www/api/controllers/plugin.php`:
  - `GetPluginGitHubStats()` — parses/lowercases the repo list, strips a trailing `.git`, serves from a 6h shared disk cache (`{media}/tmp/pluginGithubStats.cache.json`) when fresh, otherwise fetches live from GitHub.
  - `GitHubStatsSearchPage()` / `GitHubStatsSearchAll()` — queries the GitHub issues-search API. Issues and PRs come back in the same result set (a PR is an issue with a `pull_request` field), so one untyped `state:open` aggregate query yields both counts for a whole group of repos.
  - `PluginGitHubStatsFetchChunk()` — batches repos (15 per chunk, ≤100 total, ≤5 pages). If a dead/renamed repo 422s the whole chunk, it retries per repo so one dead repo cannot hide stats for the rest; individually-422 repos are zero-filled and cached as "gone".
  - **Fail-soft**: on rate-limit/offline failures it serves the stale cache if present, else an empty map with `source: unavailable`; the UI then hides the badge.
  - Response: `{ "repos": { "owner/name": { "openIssues": n, "openPRs": n } }, "source": "live|cache|partial|unavailable" }`.
- **Route** registered in `www/api/index.php` (above `/plugin/:RepoName`).
- **Docs** added to `www/api/openapi.json`.

### Frontend (`www/plugins.php`)

- **Developer-UI gating**: `IS_DEVELOPER_UI = (uiLevel || 0) >= 3` controls all badge rendering/fetching.
- `GitHubRepoOf()` — extracts `owner/repo` from a plugin's `srcURL` (GitHub only), lowercased and `.git`-stripped so keys match the backend.
- `pluginGitHubRepos` / `pluginGitHubStats` / `githubStatsRequested` maps track which repos are known, resolved, and already asked — unresolved repos keep their badge hidden instead of showing a bogus 0/0, and are never re-requested.
- `ScheduleGitHubStatsFetch()` — 150ms debounce capped at 600ms from the first pending repo, so the first (cold) GitHub query runs in parallel with the remaining `pluginInfo.json` loads; follow-ups for stragglers are served from the backend cache.
- `FetchPluginGitHubStats()` — batches all unresolved repos into one AJAX call; latches `githubStatsFailed` on a network error so it never retries that session.
- **Card badge**: `GitHubStatsBadgeHtml()` / `GitHubStatsRowHtml()` render an `.fpp-tag` (issue + branch icons) placed inline at the right end of the action-button row (`ms-auto`, vertically centered).
- **Detail dialog**: the same counts render at the far left of the modal footer (`me-auto`), level with the action buttons, Developer-only. `pluginDetailDialogRepo` lets `PatchPluginGitHubStats()` inject/refresh the badge live if a dialog is open when counts arrive.

## Testing

- `php -l` clean on all modified PHP files; `node --check` clean on the extracted inline script.
- End-to-end fetch verified against GitHub (all 69 plugin repos resolve with real counts); dead-repo 422 fallback exercised; offline → `unavailable` with no cache write; stale cache served offline.
- Node simulation of the scheduling logic confirms the 600ms max-wait cap batches plugin arrivals and fires the first fetch early.

## Notes / Considerations

- Counts are cached per box for 6 hours (they move slowly); the first request after cache expiry is the only one that hits GitHub live.
- API rate-limit risk is bounded: one aggregate query per 15-repo chunk (plus a per-repo fallback only when a chunk 422s), capped by the shared cache.
- Behavior is unchanged for non-Developer UI modes.

# Screenshots
<img width="1491" height="865" alt="ss_devpluginissues" src="https://github.com/user-attachments/assets/56d19a81-7ff0-4fe9-9b8f-09c5be81d5d2" />