### PR TITLE
fix(ddp): DDP input heap buffer overflow and out-of-bounds read in channel bridging

### DIFF
--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -879,6 +879,12 @@ void Sequence::SetBridgeData(uint8_t* data, int startChannel, int len, uint64_t 
     if (!m_bridgeData) {
         m_bridgeData = (uint8_t*)calloc(1, FPPD_MAX_CHANNEL_NUM);
     }
+    // Guard against out-of-range bridging data so it cannot write past
+    // m_bridgeData (FPPD_MAX_CHANNEL_NUM). Unsigned arithmetic avoids overflow.
+    if (startChannel < 0 || len < 0 ||
+        ((unsigned long long)startChannel + (unsigned long long)len) > (unsigned long long)FPPD_MAX_CHANNEL_NUM) {
+        return;
+    }
     memcpy(&m_bridgeData[startChannel], data, len);
 
     std::unique_lock<std::mutex> lock(m_bridgeRangesLock);

--- a/src/e131bridge.cpp
+++ b/src/e131bridge.cpp
@@ -859,6 +859,17 @@ bool Bridge_StoreDDPData(uint8_t* bridgeBuffer, long long packetTime) {
         uint32_t len = bridgeBuffer[8] << 8;
         len += bridgeBuffer[9];
 
+        // Drop the packet if the length or channel map is out of bounds. Reading
+        // `len` bytes from the receive buffer, or writing beyond the bridge buffer
+        // (FPPD_MAX_CHANNEL_NUM), would corrupt memory. 64-bit arithmetic avoids
+        // uint32 overflow of the channel+length sum.
+        int ddpOffset = tc ? 14 : 10;
+        if ((uint64_t)len > (uint64_t)(BUFSIZE + 1 - ddpOffset) ||
+            (uint64_t)chan + (uint64_t)len > (uint64_t)FPPD_MAX_CHANNEL_NUM) {
+            ddpErrors++;
+            return push;
+        }
+
         uint32_t sn = bridgeBuffer[1] & 0xF;
         if (sn) {
             bool isErr = false;
@@ -882,8 +893,7 @@ bool Bridge_StoreDDPData(uint8_t* bridgeBuffer, long long packetTime) {
         ddpMinChannel = std::min(ddpMinChannel, chan + 1);
         ddpMaxChannel = std::max(ddpMaxChannel, chan + len);
 
-        int offset = tc ? 14 : 10;
-        SetBridgeData(&bridgeBuffer[offset],
+        SetBridgeData(&bridgeBuffer[ddpOffset],
                       chan,
                       len,
                       packetTime);


### PR DESCRIPTION
# fix(ddp): DDP input heap buffer overflow and out-of-bounds read in channel bridging

## Summary

Fixes a remotely-triggerable heap-corruption vulnerability in the DDP channel-input path. The DDP fields in an incoming packet (`chan` and `len`) were used **without validation** as the offset/size for an unbounded `memcpy` into the bridge buffer, so a single crafted packet on the DDP input port could cause:

- a **heap out-of-bounds write** (`chan + len` up to ~4 GB, into an 8,388,616-byte `m_bridgeData`), and
- an **out-of-bounds read** of up to 64 KB past the 1,501-byte receive buffer.

This is the same bug class that could be reached (with config-controlled values) on the E1.31 and ArtNet paths; those are additionally hardened by a defensive bounds check.

## Changes

| File | Change |
|------|--------|
| `src/e131bridge.cpp` | `Bridge_StoreDDPData()`: validate the packet before reading. The packet is dropped when the length exceeds the receive buffer (`len > BUFSIZE + 1 - offset`, prevent OOB source read) or when the channel map exceeds the bridge buffer (`chan + len > FPPD_MAX_CHANNEL_NUM`, computed in 64-bit to avoid uint32 overflow, prevent OOB heap write). `ddpErrors` is incremented; the `push` flag is preserved. |
| `src/Sequence.cpp` | `SetBridgeData()`: add a defensive bounds guard (`startChannel < 0`, `len < 0`, or `startChannel + len > FPPD_MAX_CHANNEL_NUM`) that ignores out-of-range data. This protects all three bridge callers (DDP, E1.31, and ArtNet) even if a future caller omits front-end validation. |

## Verification

- **Non-breaking for valid traffic:** legitimate DDP packets (max payload ~1491 when accounting for the timecode offset, and channel maps within 8 MB) are unaffected.
- **Only malformed packets are dropped:** there is no legitimate scenario where a bridge range exceeds `FPPD_MAX_CHANNEL_NUM`, so the drop only affects data that previously corrupted memory.
- **Push/pull flow unchanged:** the `push` return is preserved; only invalid packets are dropped.
- **No regression in config-driven paths:** an out-of-range configured universe is now ignored instead of performing a corrupting write.
- **Static review:** no dangling references; `Sequence.h` (source of `FPPD_MAX_CHANNEL_NUM`) is included at `e131bridge.cpp:43`; `BUFSIZE = 1500` is a file-level define; `uint64_t`/`uint32_t` were already in use in the file.
- **Compile check of the guard logic:** isolated translation unit compiled with `clang++ -std=c++20 -Wall -Wextra -O2`; assertions for valid edge cases (near-top-of-buffer channel, max-length packets) and every overflow/OOB case all pass.