### PR TITLE
fix(security): Empty-Command Crash (fppd) and Crash-Report Command Injection

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -124,6 +124,9 @@ char* ProcessCommand(char* command, char* response) {
     char* saveptr = nullptr; // for thread-safe strtok_r below
     LogExcess(VB_COMMAND, "CMD: %s\n", command);
     s = strtok_r(command, ",", &saveptr);
+    if (!s) {
+        s = command; // empty/all-delimiter command; graceful "Invalid command" path below
+    }
     strncpy(CommandStr, s, sizeof(CommandStr)); // s can be 256 bytes long
     CommandStr[sizeof(CommandStr) - 1] = '\0';
 

--- a/src/fppd.cpp
+++ b/src/fppd.cpp
@@ -589,7 +589,17 @@ static void handleCrash(int s, siginfo_t* si, void* ctx) {
 #endif
             char zfName[256];
             std::string SystemUUID = getSetting("SystemUUID", "unknown");
-            snprintf(zfName, sizeof(zfName), "crashes/fpp-%s-%s-%s-%s.zip", sysType, getFPPVersion(), SystemUUID.c_str(), tbuffer);
+            char safeUUID[64];
+            unsigned int uuidLen = 0;
+            for (const char* p = SystemUUID.c_str(); *p != '\0' && uuidLen < sizeof(safeUUID) - 1; ++p) {
+                unsigned char c = *p;
+                bool safe = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '-' || c == '_' || c == '.';
+                if (safe) {
+                    safeUUID[uuidLen++] = c;
+                }
+            }
+            safeUUID[uuidLen] = '\0';
+            snprintf(zfName, sizeof(zfName), "crashes/fpp-%s-%s-%s-%s.zip", sysType, getFPPVersion(), safeUUID, tbuffer);
 
             // Use script to generate crash report with passwords redacted
             char scriptCmd[512];


### PR DESCRIPTION
# fix(security): Empty-Command Crash (fppd) and Crash-Report Command Injection

> Fix NULL-pointer crash on empty control commands and sanitize crash-report filename against shell injection

## Summary

Two security issues in `fppd` are resolved:

1. **NULL-pointer crash (DoS)** — sending an empty or all-delimiter command to the control command path (`ProcessCommand`) caused a NULL dereference, crashing `fppd`.
2. **Crash-handler command injection (privileged RCE)** — the `SystemUUID` setting (overwritable via the unauthenticated `SetSetting` path) was interpolated unquoted into shell commands executed by the crash handler, allowing an attacker to run arbitrary commands as root when `fppd` crashed.

## Motivation

- A remote attacker (or any local process with access to the control sockets) could crash `fppd` on demand by sending an empty command packet, taking down lighting control and any scheduled playback.
- The crash-report path runs as root (in the fatal-signal handler). Because `SystemUUID` is a remotely-settable setting, a hostile value such as `` `id`; touch /tmp/pwned`` was executed verbatim by `system()` inside the handler, yielding unauthenticated root command execution.

## Changes

### `src/command.cpp` — `ProcessCommand()`

Previously:

```cpp
s = strtok_r(command, ",", &saveptr);
strncpy(CommandStr, s, sizeof(CommandStr)); // s can be 256 bytes long
```

`strtok_r` returns `NULL` when `command` is empty or contains only delimiters, so the `strncpy` dereferenced a NULL pointer. Now:

```cpp
s = strtok_r(command, ",", &saveptr);
if (!s) {
    s = command; // empty/all-delimiter command; graceful "Invalid command" path below
}
strncpy(CommandStr, s, sizeof(CommandStr)); // s can be 256 bytes long
```

With `CommandStr` empty, execution falls through to the existing catch-all `else` that responds `"Invalid command: ''"`, so the request is handled gracefully instead of crashing.

### `src/fppd.cpp` — crash report handler

`SystemUUID` is now sanitized to a strict `[A-Za-z0-9._-]` allow-list into a bounded local buffer before being used to build the crash report filename and shell commands:

```cpp
char zfName[256];
std::string SystemUUID = getSetting("SystemUUID", "unknown");
char safeUUID[64];
unsigned int uuidLen = 0;
for (const char* p = SystemUUID.c_str(); *p != '\0' && uuidLen < sizeof(safeUUID) - 1; ++p) {
    unsigned char c = *p;
    bool safe = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '-' || c == '_' || c == '.';
    if (safe) {
        safeUUID[uuidLen++] = c;
    }
}
safeUUID[uuidLen] = '\0';
snprintf(zfName, sizeof(zfName), "crashes/fpp-%s-%s-%s-%s.zip", sysType, getFPPVersion(), safeUUID, tbuffer);
```

This covers both `system()` call sites in the handler:

- `/opt/fpp/scripts/generate_crash_report <log> <zfName>`
- `curl https://dankulp.com/crashUpload/index.php -F userfile=@<zfName>`

## Why it's non-breaking

- **Crash fix:** Only the NULL-token case changes behavior; valid commands are parsed exactly as before. All callers pass valid, non-NULL command buffers (the 4096-byte domain-socket array and the MultiSync `CommandPkt.command` flexible array member), so the fallback `s = command` is always safe. `strncpy` remains bounded, so no over-read even on unterminated packet data.
- **Injection fix:** Real `SystemUUID` values (RFC 4122 UUIDs) are alphanumeric plus dashes and pass the allow-list unchanged, so crash filenames are byte-for-byte identical to before. The sanitizer uses self-contained ASCII range checks (no `<ctype.h>` dependency), so both PCH and NOPCH builds compile, and it allocates nothing — consistent with the handler's existing `snprintf`/`system` usage.

## Testing

- Reviewed callers of `ProcessCommand` (`command.cpp:372`, `MultiSync.cpp:2969`) to confirm valid buffers and graceful NULL-return handling.
- Verified empty-command input now reaches the catch-all `"Invalid command"` response path.
- Verified sanitizer bounds: writes at most 63 chars + NUL into a 64-byte buffer.
- Verified both `system()` sinks now receive a sanitized filename.

## Breaking changes

None. Public headers and plugin-facing APIs are untouched.