### PR TITLE
fix(audio): make HDMI (vc4-hdmi) audio output work end-to-end on single-HDMI (Pi Zero 2 W / Pi 3)

### DIFF
--- a/src/boot/FPPINIT_Audio.cpp
+++ b/src/boot/FPPINIT_Audio.cpp
@@ -271,7 +271,7 @@ static std::string buildSimplePipeWireGroupsConf(int card, const std::string& cI
         // device advertises, defaulting to the universally-safe S16LE.
         std::string fmt = "S16LE";
         std::string hwParams = execAndReturn("timeout 2 /usr/bin/aplay -D hw:" + cId +
-                                             " --dump-hw-params /dev/zero 2>&1 | head -40");
+                                                " --dump-hw-params /dev/zero 2>&1 | head -40");
         std::smatch fmtMatch;
         if (std::regex_search(hwParams, fmtMatch, std::regex(R"(FORMAT[^:]*:\s+(.+))"))) {
             std::string fmtLine = fmtMatch[1].str();
@@ -281,6 +281,27 @@ static std::string buildSimplePipeWireGroupsConf(int card, const std::string& cI
                 fmt = "S24_32LE";
             } else if (fmtLine.find("S24_3LE") != std::string::npos) {
                 fmt = "S24LE";
+            }
+        }
+        // Some cards expose only IEC958_SUBFRAME_LE passthrough on raw hw: with
+        // no standard PCM format (e.g. the Pi Zero W2 / Pi 3 vc4-hdmi card under
+        // KMS). PipeWire's SPA ALSA plugin cannot open a passthrough-only hw:
+        // device, so no sink is created and the fpp_group_default combine-stream
+        // ends up with no target, making GStreamer fail with "Failed to connect".
+        // sysdefault: routes through ALSA's dmix/plug layer (which downconverts
+        // IEC958 to normal PCM), so use it whenever hw: lacks a PCM format but
+        // sysdefault: provides one.
+        std::string alsaPath = "hw:" + cId;
+        bool hasPcmFmt = hwParams.find("S16_LE") != std::string::npos ||
+                         hwParams.find("S24_LE") != std::string::npos ||
+                         hwParams.find("S32_LE") != std::string::npos;
+        if (!hasPcmFmt && hwParams.find("IEC958_SUBFRAME_LE") != std::string::npos) {
+            std::string sysParams = execAndReturn("timeout 2 /usr/bin/aplay -D sysdefault:" + cId +
+                                                    " --dump-hw-params /dev/zero 2>&1 | head -40");
+            if (sysParams.find("S16_LE") != std::string::npos ||
+                sysParams.find("S24_LE") != std::string::npos ||
+                sysParams.find("S32_LE") != std::string::npos) {
+                alsaPath = "sysdefault:" + cId;
             }
         }
         const std::string desc = getAlsaCardProductName(card, cId) + " (" + cId + ")";
@@ -293,7 +314,7 @@ static std::string buildSimplePipeWireGroupsConf(int card, const std::string& cI
         c << "      node.name = \"" << nodeName << "\"\n";
         c << "      node.description = \"" << desc << "\"\n";
         c << "      media.class = \"Audio/Sink\"\n";
-        c << "      api.alsa.path = \"hw:" << cId << "\"\n";
+        c << "      api.alsa.path = \"" << alsaPath << "\"\n";
         c << "      api.alsa.period-size = " << perSize << "\n";
         c << "      api.alsa.headroom = 256\n";
         c << "      audio.format = \"" << fmt << "\"\n";
@@ -608,7 +629,20 @@ void setupAudio() {
     auto cardIsDeadHDMI = [&](const std::string& k) {
         if (!lineHasHDMI(cardLines[k])) return false;
         if (cards[k].starts_with("vc4hdmi")) {
-            return !hdmiStatus[cards[k]];
+            // hdmiStatus is keyed by a synthesized connector index ("vc4hdmi0",
+            // "vc4hdmi1" on dual-HDMI boards). Single-HDMI boards (e.g. Pi Zero
+            // 2 W, Pi 3) register the card as plain "vc4hdmi", which never
+            // matches an "NN" index key; the std::map read then yields false and
+            // the card is wrongly declared "no HDMI connected" even when a
+            // display is attached, causing setupAudio to permanently revert
+            // AudioOutput back to card 0. When there is no per-port status for
+            // this card, fall back to the any-HDMI-connected signal (same
+            // semantics as the legacy bcm2835 HDMI branch below).
+            auto it = hdmiStatus.find(cards[k]);
+            if (it != hdmiStatus.end()) {
+                return !it->second;
+            }
+            return !anyHDMIConnected;
         }
         // legacy bcm2835 HDMI shares the physical port; if any HDMI is
         // connected, assume this device may work, otherwise treat as dead.


### PR DESCRIPTION
# fix(audio): make HDMI (vc4-hdmi) audio output work end-to-end on single-HDMI (Pi Zero 2 W / Pi 3)

## Problem

On a Raspberry Pi Zero 2 W (and other single-HDMI Pi boards whose HDMI ALSA card id is `vc4hdmi` with no numeric index), selecting the HDMI output as the **Audio Output Device**, rebooting, then playing media does not work:

1. The `AudioOutput = "vc4hdmi"` selection is silently discarded at boot and the device falls back to the onboard `bcm283` Headphones card, even with an HDMI display connected.
2. When the HDMI selection is forced to stick, playback fails with `Could not start media playback (pipeline failed to start) (Warning ID: 30)`.

Both are boot/audio-setup defects in `src/boot/FPPINIT_Audio.cpp`, and both are fixed together here.

## Root cause 1 — HDMI audio selection is reverted at boot

`setupAudio()` builds an `hdmiStatus` map keyed by a **synthesized connector index**:

```cpp
std::string k = "vc4hdmi" + std::to_string(hdmiIdx);   // -> "vc4hdmi0", "vc4hdmi1", ...
```

and later, in the `cardIsDeadHDMI` check for vc4-hdmi cards, looks up the **actual ALSA card id**:

```cpp
if (cards[k].starts_with("vc4hdmi")) {
    return !hdmiStatus[cards[k]];   // std::map miss -> false -> treated as "no HDMI"
}
```

On single-HDMI boards the ALSA card id is plain `vc4hdmi` (`/proc/asound/cards`), which never matches a `vc4hdmi<N>` key. The `std::map` read returns `false`, so the card is wrongly declared "no HDMI connected" even with a display attached. `setupAudio` then walks to the fallback card and permanently writes it back:

```cpp
FPP - Audio device 1 has no HDMI connected, switching to card 0 (Headphones)
FPP - Persisting selected audio device as ID 'Headphones'
```

## Root cause 2 — the selected card's adapter cannot be opened by PipeWire

Once the selection sticks, the Simple-PipeWire C++ generator (`buildSimplePipeWireGroupsConf`) always emitted the ALSA adapter as `api.alsa.path = "hw:vc4hdmi"`. On the Pi Zero W2 vc4-hdmi card under KMS, the raw `hw:` device exposes **only `IEC958_SUBFRAME_LE`** passthrough — no standard PCM format (`aplay -D hw:vc4hdmi` reports `FORMAT: IEC958_SUB_LE`). PipeWire's SPA ALSA plugin cannot open a passthrough-only `hw:` device, so the `fpp_alsa_vc4hdmi` sink is never created, the `fpp_group_default` combine-stream has no target, and GStreamer's `pipewiresink target-object=fpp_group_default` fails to connect:

```
GStreamer sync error (src=pwsink): Failed to connect
Failed to set GStreamer pipeline to PLAYING
```

## Fix

Single change set in `src/boot/FPPINIT_Audio.cpp`:

1. **Dead-HDMI detection:** fall back to the existing global `anyHDMIConnected` signal when a vc4-hdmi card has no per-port status entry, mirroring the legacy `bcm2835` HDMI branch:

```cpp
if (cards[k].starts_with("vc4hdmi")) {
    auto it = hdmiStatus.find(cards[k]);
    if (it != hdmiStatus.end()) {
        return !it->second;        // vc4hdmi0/vc4hdmi1: exact per-port status (unchanged)
    }
    return !anyHDMIConnected;      // "vc4hdmi" (no index): fall back to any-connected
}
```

2. **Adapter path for IEC958-only devices** (`buildSimplePipeWireGroupsConf`): detect when `hw:` exposes no standard PCM format but does expose `IEC958_SUBFRAME_LE`, probe `sysdefault:<cardId>` (which routes through ALSA's dmix/plug layer and downconverts passthrough to PCM), and if it provides PCM formats, emit the adapter as `api.alsa.path = "sysdefault:<cardId>"` instead of `"hw:<cardId>"`.

## Why this is non-breaking

- **Dual-HDMI Pi 4** (`vc4hdmi0`/`vc4hdmi1`): exact per-port lookup preserved via the matching key — behavior unchanged.
- **BeagleBone / PocketBeagle**: no HDMI ALSA card (branch never reached) and cables expose native PCM on `hw:` (adapter path unchanged).
- **Headphones / USB / beagle/BBB capes**: emit the regular `hw:` adapter, as before. The `sysdefault:` alternate is chosen only for cards whose `hw:` device is IEC958-only.
- **Genuinely-disconnected single-HDMI**: old and new both return "dead" (`!anyHDMIConnected` is `true`), so the fallback-to-card-0 behavior and the kernel-panic guard are retained.
- Both paths compile for `PLATFORM_PI` and `PLATFORM_BBB`.

## Verification

On the Pi Zero 2 (`FPP OS Image v2026-08`, kernel `6.18.42-v7+`, `pipewire-simple`):

1. Set `AudioOutput = "vc4hdmi"`, rebuilt `fppinit`, rebooted.
2. Confirmed `AudioOutput` **survives the reboot** as `vc4hdmi` (previously it reverted to `Headphones`; the log line `Audio device 1 has no HDMI connected, switching to card 0` disappeared despite `/sys/class/drm/card0-HDMI-A-1/status` reporting `connected`).
3. Confirmed `AudioCard0Type = "unknown"` (setupAudio selected card 1, the vc4hdmi, not the fallback).
4. Generated `97-fpp-audio-groups.conf` now contains `api.alsa.path = "sysdefault:vc4hdmi"`; cache and dest match so it persists.
5. All PipeWire services start cleanly (`fpp-pipewire` `NRestarts=0`); `fpp_group_default` is present as an `Audio/Sink`.
6. `gst-launch-1.0 ... ! pipewiresink target-object=fpp_group_default sync=true` reaches PLAYING/EOS with no error (previously failed to connect), using both `audiotestsrc` and the device's actual MP3 file.

## Additional Comments

This PR closes #2802.