### PR TITLE
feat(plugins): Show spinner on the Check for Updates button on the Plugins page

### DIFF
--- a/www/css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css
+++ b/www/css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css
@@ -15815,6 +15815,66 @@ body.has-touch .fppTableContents .ui-dialog-buttonset button,
 	background-color: transparent;
 }
 
+.pageContent .btn-outline-primary,
+.btn-outline-primary {
+	color: #0d6efd;
+	background-color: transparent;
+	background-image: none;
+	border-color: #0d6efd;
+}
+.pageContent .btn-outline-primary:hover,
+.btn-outline-primary:hover {
+	color: #fff;
+	background-color: #0d6efd;
+	border-color: #0d6efd;
+}
+.pageContent .btn-outline-primary:focus,
+.pageContent .btn-outline-primary.focus,
+.btn-outline-primary:focus,
+.btn-outline-primary.focus {
+	box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.5);
+}
+.pageContent .btn-outline-primary.disabled,
+.pageContent .btn-outline-primary.disableButtons,
+.pageContent .btn-outline-primary:disabled,
+.btn-outline-primary.disabled,
+.ui-dialog .btn-outline-primary.disableButtons,
+.modal .btn-outline-primary.disableButtons,
+.btn-outline-primary:disabled {
+	color: #0d6efd;
+	background-color: transparent;
+}
+
+.pageContent .btn-outline-warning,
+.btn-outline-warning {
+	color: #ffc107;
+	background-color: transparent;
+	background-image: none;
+	border-color: #ffc107;
+}
+.pageContent .btn-outline-warning:hover,
+.btn-outline-warning:hover {
+	color: #171720;
+	background-color: #ffc107;
+	border-color: #ffc107;
+}
+.pageContent .btn-outline-warning:focus,
+.pageContent .btn-outline-warning.focus,
+.btn-outline-warning:focus,
+.btn-outline-warning.focus {
+	box-shadow: 0 0 0 0.25rem rgba(255, 193, 7, 0.5);
+}
+.pageContent .btn-outline-warning.disabled,
+.pageContent .btn-outline-warning.disableButtons,
+.pageContent .btn-outline-warning:disabled,
+.btn-outline-warning.disabled,
+.ui-dialog .btn-outline-warning.disableButtons,
+.modal .btn-outline-warning.disableButtons,
+.btn-outline-warning:disabled {
+	color: #ffc107;
+	background-color: transparent;
+}
+
 .btn-rounded,
 .disableButtons.btn-rounded,
 .btn-rounded,

--- a/www/css/fpp-bootstrap/src/_buttons.scss
+++ b/www/css/fpp-bootstrap/src/_buttons.scss
@@ -71,6 +71,14 @@
 .btn-outline-danger {
 	@include fpp-btn-outline-variant($danger, $white);
 }
+.pageContent .btn-outline-primary,
+.btn-outline-primary {
+	@include fpp-btn-outline-variant($primary, $white);
+}
+.pageContent .btn-outline-warning,
+.btn-outline-warning {
+	@include fpp-btn-outline-variant($warning, $black);
+}
 .btn-rounded,
 .disableButtons.btn-rounded,
 .btn-rounded,

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -339,10 +339,27 @@
             FilterPlugins();
         }
 
+        // Busy state for the "Check for Update" button in the plugin detail
+        // modal: disabled with a spinning wheel / "Checking for Updates" label
+        // while the per-plugin check runs, mirroring SetCheckForUpdatesBusy on the
+        // Updates tab. No-ops when the button doesn't exist (dialog closed).
+        function SetDetailCheckBusy(plugin, busy) {
+            var $btn = $('#pluginDetailCheckBtn');
+            if (!$btn.length) return;
+            if (busy) {
+                $btn.prop('disabled', true);
+                $btn.html('<i class="fas fa-spinner fa-spin me-1"></i>Checking for Updates');
+            } else {
+                $btn.prop('disabled', false);
+                $btn.html('Check for Update');
+            }
+        }
+
         function CheckPluginForUpdates(plugin) {
             var url = 'api/plugin/' + plugin + '/updates';
 
             $('html,body').css('cursor', 'wait');
+            SetDetailCheckBusy(plugin, true);
             $.ajax({
                 url: url,
                 type: 'POST',
@@ -370,15 +387,19 @@
                             }
                         } else {
                             RowEl(plugin).removeClass('fppHasUpdate');
+                            SetDetailCheckBusy(plugin, false);
                             $.jGrowl('No updates available for ' + plugin, { themeState: 'detract' });
                         }
                         FilterPlugins();
                     }
-                    else
+                    else {
+                        SetDetailCheckBusy(plugin, false);
                         alert('ERROR: ' + data.Message);
+                    }
                 },
                 error: function () {
                     $('html,body').css('cursor', 'auto');
+                    SetDetailCheckBusy(plugin, false);
                     alert('Error, API call failed when checking plugin for updates');
                 }
             });
@@ -440,7 +461,6 @@
             if (bgUpdateSweep) {
                 bgUpdateSweep.cancelled = true;
                 bgUpdateSweep = null;
-                $('#updatesCheckSpinner').addClass('d-none');
             }
         }
 
@@ -450,12 +470,10 @@
             var sweep = { cancelled: false };
             bgUpdateSweep = sweep;
             var queue = installedPlugins.slice();
-            $('#updatesCheckSpinner').removeClass('d-none');
 
             function finish() {
                 if (bgUpdateSweep === sweep)
                     bgUpdateSweep = null;
-                $('#updatesCheckSpinner').addClass('d-none');
             }
             function next() {
                 if (sweep.cancelled || queue.length === 0) {
@@ -485,6 +503,20 @@
             next();
         }
 
+        // Toggle the "Check for Updates" button between its idle and busy states.
+        // Busy: disabled with a spinning wheel and "Checking for Updates" label.
+        // Idle: enabled with the sync icon and "Check for Updates" label.
+        function SetCheckForUpdatesBusy(busy) {
+            var $btn = $('#checkAllUpdatesBtn');
+            if (busy) {
+                $btn.prop('disabled', true);
+                $btn.html('<i class="fas fa-spinner fa-spin me-1"></i>Checking for Updates');
+            } else {
+                $btn.prop('disabled', false);
+                $btn.html('<i class="fas fa-sync-alt"></i> Check for Updates');
+            }
+        }
+
         function CheckAllPluginsForUpdates() {
             if (installedPlugins.length === 0) {
                 $.jGrowl('No plugins installed', { themeState: 'detract' });
@@ -493,7 +525,7 @@
             CancelBackgroundUpdateCheck();
 
             $('html,body').css('cursor', 'wait');
-            $('#checkAllUpdatesBtn').prop('disabled', true);
+            SetCheckForUpdatesBusy(true);
 
             CheckPluginsForUpdates(installedPlugins, function (plugin, hasUpdate) {
                 if (hasUpdate) {
@@ -501,7 +533,7 @@
                 }
             }, function (withUpdates, anyError) {
                 $('html,body').css('cursor', 'auto');
-                $('#checkAllUpdatesBtn').prop('disabled', false);
+                SetCheckForUpdatesBusy(false);
                 if (anyError) {
                     $.jGrowl('Completed checking plugins (some checks failed)', { themeState: 'warn' });
                 } else if (withUpdates.length > 0) {
@@ -532,7 +564,7 @@
             CancelBackgroundUpdateCheck();
             $('html,body').css('cursor', 'wait');
             $('#updateAllBtn').prop('disabled', true);
-            $('#checkAllUpdatesBtn').prop('disabled', true);
+            SetCheckForUpdatesBusy(true);
 
             CheckPluginsForUpdates(installedPlugins, function (plugin, hasUpdate) {
                 if (hasUpdate) {
@@ -546,7 +578,7 @@
         function UpdateAllChecksDone(withUpdates) {
             $('html,body').css('cursor', 'auto');
             $('#updateAllBtn').prop('disabled', false);
-            $('#checkAllUpdatesBtn').prop('disabled', false);
+            SetCheckForUpdatesBusy(false);
             FilterPlugins();
             if (withUpdates.length === 0) {
                 $.jGrowl('All plugins are up to date', { themeState: 'success' });
@@ -1675,11 +1707,11 @@
             var buttons = {};
             if (installed) {
                 if (IsSafeHttpUrl(data.pageUrl)) {
-                    buttons['Open'] = function () { CloseModalDialog('pluginDetailDialog'); window.open(data.pageUrl, 'pluginContent'); };
+                    buttons['Open'] = { class: 'btn-outline-primary', click: function () { CloseModalDialog('pluginDetailDialog'); window.open(data.pageUrl, 'pluginContent'); } };
                 }
-                buttons['Check for Update'] = { id: 'pluginDetailCheckBtn', click: function () { CheckPluginForUpdates(repo); } };
-                buttons['Reinstall'] = function () { CloseModalDialog('pluginDetailDialog'); ShowReinstallPluginPopup(repo, data.name); };
-                buttons['Uninstall'] = function () { CloseModalDialog('pluginDetailDialog'); ShowUninstallPluginPopup(repo, data.name); };
+                buttons['Check for Update'] = { id: 'pluginDetailCheckBtn', class: 'btn-outline-success', click: function () { CheckPluginForUpdates(repo); } };
+                buttons['Reinstall'] = { class: 'btn-outline-warning', click: function () { CloseModalDialog('pluginDetailDialog'); ShowReinstallPluginPopup(repo, data.name); } };
+                buttons['Uninstall'] = { class: 'btn-outline-danger', click: function () { CloseModalDialog('pluginDetailDialog'); ShowUninstallPluginPopup(repo, data.name); } };
             } else if (compatibleVersion >= 0 || untestedVersion >= 0) {
                 var idx = compatibleVersion < 0 ? untestedVersion : compatibleVersion;
                 // Match the card's wording: "Install anyway" when the only available
@@ -2405,8 +2437,6 @@
                                         <button type="button" class="nav-link text-nowrap" data-top-tab="updates" role="tab">
                                             <i class="far fa-arrow-alt-circle-up"></i> Updates
                                             <span class="badge bg-secondary ms-1" id="topCountUpdates">0</span>
-                                            <span class="spinner-border spinner-border-sm ms-1 d-none" id="updatesCheckSpinner"
-                                                role="status" aria-hidden="true" title="Checking for updates..."></span>
                                         </button>
                                     </li>
                                 </ul>


### PR DESCRIPTION
# feat(plugins): Show spinner on the Check for Updates button on the Plugins page

## Description

Adds a busy state to the "Check for Updates" button on the Plugins page, on the Updates tab. While an update check is running, the button is disabled and shows a spinning wheel with "Checking for Updates"; it restores to "Check for Updates" when the check completes.

Also update to button colors for consistency across Plugin Manager.

## Why

This resolves an edge case where a user with a slow internet connection could continuously click the "Check for Updates" button. Each click starts a fresh check against the `api/plugin/<name>/updates` endpoints (each one runs a `git fetch` server-side), which can take a while over a slow connection. There was no visual feedback that anything was happening, so the user was left hammering a button that had already kicked off work — getting no results and never knowing the check was still loading.

## Changes

- Added `SetCheckForUpdatesBusy()` in `www/plugins.php`, which toggles the button between its idle state (`<i class="fas fa-sync-alt"></i> Check for Updates`, enabled) and a busy state (disabled, `<i class="fas fa-spinner fa-spin"></i> Checking for Updates`).
- `CheckAllPluginsForUpdates()` now sets the busy state when a check starts and clears it when all checks settle (both success and error paths).
- `UpdateAllPlugins()` / `UpdateAllChecksDone()` use the same busy state for the pre-update check sweep so the button never appears idle while work is in flight.
- Added `SetDetailCheckBusy()` in `www/plugins.php`, which applies the same busy state to the **Check for Update** button in the plugin detail ("more info") dialog. `CheckPluginForUpdates()` sets it when the per-plugin check starts and clears it on success and error; when an update is found, the button is replaced with the **Update** button as before.
- Color-coded the detail ("more info") dialog action buttons via the `class` option `DoModalDialog` already supports, so they match the toolbar buttons on the Installed/Updates tabs: **Open** `btn-outline-primary` (blue), **Check for Update** `btn-outline-success` (green), **Reinstall** `btn-outline-warning` (yellow), **Uninstall** `btn-outline-danger` (red), **Close** stays the default white `.buttons` style.
- Fixed a CSS gap that made `btn-outline-primary` (blue) and `btn-outline-warning` (yellow) render white: FPP's custom `.buttons` base rule overrides `color`/`border-color` in source order, and `_buttons.scss` only re-declared `btn-outline-light/success/danger`. Added the missing `btn-outline-primary` and `btn-outline-warning` variants to `www/css/fpp-bootstrap/src/_buttons.scss` and the compiled `www/css/fpp-bootstrap/dist/fpp-bootstrap-5-3.css`. This also makes the toolbar's **Update All** (blue) and **Reinstall All** (yellow) buttons render their correct colors.
- Used the Font Awesome spinner (`fa-spinner fa-spin`) rather than Bootstrap's `spinner-border`, since that class is stripped out of FPP's compiled Bootstrap build (`fpp-bootstrap-5-3.css` does not contain it) and would not render.
- Disabling the button while a check runs also prevents double-clicks from firing a second check over a slow connection.