### PR TITLE
fix(upgradeOS): Add pre-flight disk space checks before applying an FPP OS upgrade

### DIFF
--- a/SD/upgradeOS-part1.sh
+++ b/SD/upgradeOS-part1.sh
@@ -110,6 +110,31 @@ else
   fi
 fi
 
+# The rsync in upgradeOS-part2.sh copies a new root filesystem over the LIVE
+# one (bin etc lib opt root sbin usr var), so the running OS occupies the disk
+# throughout the copy. If the root filesystem is too full for the incoming OS,
+# the copy dies partway through and leaves a half-written root that will not
+# boot (issue #2816). Pre-flight check: the image itself is already on disk
+# (typically on this same filesystem), and the new OS is roughly the size of
+# the old one, so requiring at least 2x the image size free is a safe margin
+# for the in-place replacement plus the staging image.
+FREESPACE=$(df -Pk / | awk 'NR==2 {print $4}')
+if [[ $FREESPACE =~ ^[0-9]+$ ]]; then
+  FREESPACE_BYTES=$((FREESPACE * 1024))
+  REQUIRED=$((OURSIZE * 2))
+  if [ "$FREESPACE_BYTES" -lt "$REQUIRED" ];
+  then
+    echo "Not enough free space on the root filesystem to apply this OS image."
+    echo "Free: $((FREESPACE_BYTES / 1024 / 1024)) MB, required: $((REQUIRED / 1024 / 1024)) MB (2x image size)"
+    echo "Aborting upgrade. Free up space and try again."
+    exit 1;
+  else
+    echo "Sufficient free space on the root filesystem: $((FREESPACE_BYTES / 1024 / 1024)) MB free, $((REQUIRED / 1024 / 1024)) MB required"
+  fi
+else
+  echo "Could not determine free space on root filesystem, continuing"
+fi
+
 mount $1 /mnt
 
 ORIGTYPE=$(</etc/fpp/platform)

--- a/www/upgradeOS.php
+++ b/www/upgradeOS.php
@@ -195,6 +195,29 @@ if (!file_exists($full_fppos_path)) {
     UpgradeLog('os-upgrade', $baseFile, "Image ready: $full_fppos_path (" . filesize($full_fppos_path) . " bytes)");
 }
 
+// The fppos upgrade re-flashes the running root filesystem in place
+// (upgradeOS-part2.sh rsync's bin etc lib opt root sbin usr var over the live
+// root, with the running OS still on disk). If free space is low, that copy can
+// die partway through and a half-written root cannot boot. Refuse to start
+// unless the root filesystem has room for the image plus the new OS being
+// written; the UI-side 200MB guard in about.php is not enforced server-side and
+// is too small for the actual copy.
+if ($applyUpdate) {
+    $imageSize = filesize($full_fppos_path);
+    $rootFree = disk_free_space("/");
+    $requiredFree = 2 * $imageSize;
+    if ($rootFree !== false && $rootFree < $requiredFree) {
+        UpgradeEchoLog('os-upgrade', $baseFile, sprintf(
+            "Not enough free space on the root filesystem to apply %s: %s bytes free, %s bytes required (2x the image size).\n",
+            $baseFile,
+            number_format($rootFree),
+            number_format($requiredFree)
+        ));
+        UpgradeLog('os-upgrade', $baseFile, "Aborting - insufficient free space on root filesystem");
+        $applyUpdate = false;
+    }
+}
+
 if ($applyUpdate) {
     logStage("Applying OS image");
 


### PR DESCRIPTION
# fix(upgradeOS): Add pre-flight disk space checks before applying an FPP OS upgrade

## Summary

Prevents a nearly-full root filesystem from corrupting the device during an
fppOS upgrade. The OS upgrade is an in-place rootfs reflash
(`SD/upgradeOS-part2.sh` rsyncs `bin etc lib opt root sbin usr var` over the
live root with `--delete-during`), so if the disk fills mid-copy it leaves a
half-written root filesystem that will not boot (no SSH, no UI).

Reported in #2816: with `/home/fpp/media` running low on space, applying the
upgrade bricked the device. There was no server-side space check anywhere in
the flash path — the only guard was a client-side 200 MB check in
`www/about.php` that is easily bypassed and far too small for the actual copy.

## Changes

### `www/upgradeOS.php`
Adds a server-side pre-flight check that runs immediately before the image is
applied. It compares free space on the root filesystem (the rsync target) to
`2 × image size` and refuses to proceed if there is not enough room:

- Logs the reason to `logs/fpp_system_upgrades.log` and streams it to the
  upgrade dialog.
- Aborts via the existing `$applyUpdate = false` path — the flash never
  starts and no reboot is issued.
- Only enforces when the free-space value can be determined; if
  `disk_free_space()` returns `false` it logs and continues rather than
  blocking a legitimate upgrade.

### `SD/upgradeOS-part1.sh`
Defense-in-depth copy of the same check (`df -Pk /`, 2× image size) placed
*before* any mounting or destructive copy inside the flash script, so the
guard also protects paths that bypass the PHP layer (direct URL invocation,
remote/multisync upgrades):

- Exits cleanly with free/required MB printed if space is insufficient.
- Falls through (does not abort) if the free-space value cannot be parsed, so
  an unreadable `df` never blocks an upgrade.

## Background / root cause

- On both Raspberry Pi and BeagleBone, `/home/fpp/media` lives on the root
  filesystem by default (no separate media partition unless explicitly
  configured), so a full media directory means a full root filesystem.
- The `.fppos` image (~1–2 GB) is downloaded into
  `/home/fpp/media/upload/` — the same partition the new OS must be written
  onto — which can itself be what pushes the disk over the edge.
- `upgradeOS-part2.sh:150` copies the new OS over the running one with
  `--delete-during`; an ENOSPC mid-copy produces a torn root filesystem.

## Motivation

The 200 MB guard in `www/about.php:1239` is client-side JS only, keyed off
free space in the upload directory, and can be bypassed entirely (direct URL,
`multisync`, `curl`). No server-side or flash-script-side check existed.
These changes make the upgrade fail safely before the destructive copy instead
of leaving a device that cannot boot.

## Testing / verification

- `php -l www/upgradeOS.php` — no syntax errors.
- `bash -n SD/upgradeOS-part1.sh` — no syntax errors.
- `shellcheck` — no new diagnostics introduced by the added blocks
  (pre-existing warnings in the file are untouched).
- Existing behavior is unchanged when space is sufficient: the download,
  `--delete-during` rsync, boot-marker, and sysrq reboot paths are untouched.

## Compatibility

- No public APIs, class interfaces, or plugin-facing headers changed.
- Behavior when free space is adequate is identical to before.