### PR TITLE
fix(overlays): support multi-line text in overlay model Text effect

### DIFF
--- a/src/overlays/PixelOverlayEffects.cpp
+++ b/src/overlays/PixelOverlayEffects.cpp
@@ -565,6 +565,20 @@ public:
             disableWhenDone = true;
         }
 
+        // Normalize a literal "\n" (backslash followed by 'n', as typed into a
+        // single-line text field) into a real newline byte so it is treated the
+        // same as an actual embedded newline for both sizing and rendering below.
+        std::string normalizedMsg;
+        normalizedMsg.reserve(msg.length());
+        for (int x = 0; x < msg.length(); x++) {
+            if (msg[x] == '\\' && (x < msg.length() - 1) && msg[x + 1] == 'n') {
+                normalizedMsg += '\n';
+                x++;
+            } else {
+                normalizedMsg += msg[x];
+            }
+        }
+
         Magick::Image* image = new Magick::Image(Magick::Geometry(m->getWidth(), m->getHeight()), Magick::Color("black"));
         image->quiet(true);
         image->depth(8);
@@ -577,22 +591,18 @@ public:
 
         int lines = 1;
         int last = 0;
-        for (int x = 0; x < msg.length(); x++) {
-            if (msg[x] == '\n' || ((x < msg.length() - 1) && msg[x] == '\\' && msg[x + 1] == 'n')) {
+        for (int x = 0; x < normalizedMsg.length(); x++) {
+            if (normalizedMsg[x] == '\n') {
                 lines++;
-                std::string newM = msg.substr(last, x);
+                std::string newM = normalizedMsg.substr(last, x - last);
                 Magick::TypeMetric metrics;
                 image->fontTypeMetrics(newM, &metrics);
                 maxWid = std::max(maxWid, (int)metrics.textWidth());
                 totalHi += (int)metrics.textHeight();
-                if (msg[x] == '\n') {
-                    last = x + 1;
-                } else {
-                    last = x + 2;
-                }
+                last = x + 1;
             }
         }
-        std::string newM = msg.substr(last);
+        std::string newM = normalizedMsg.substr(last);
         Magick::TypeMetric metrics;
         image->fontTypeMetrics(newM, &metrics);
         maxWid = std::max(maxWid, (int)metrics.textWidth());
@@ -613,7 +623,7 @@ public:
                                            Magick::Color::scaleDoubleToQuantum(rb)));
             image->antiAlias(antialias);
             image->strokeAntiAlias(antialias);
-            image->annotate(msg, Magick::CenterGravity);
+            image->annotate(normalizedMsg, Magick::CenterGravity);
             Magick::Blob blob;
             image->write(&blob);
 
@@ -663,7 +673,7 @@ public:
                                            Magick::Color::scaleDoubleToQuantum(rb)));
             image2.antiAlias(antialias);
             image2.strokeAntiAlias(antialias);
-            image2.annotate(msg, Magick::CenterGravity);
+            image2.annotate(normalizedMsg, Magick::CenterGravity);
 
             double y = (m->getHeight() / 2.0) - ((totalHi) / 2.0);
             double x = (m->getWidth() / 2.0) - (maxWid / 2.0);


### PR DESCRIPTION
## Summary
- The overlay model "Text" effect already computed per-line width/height metrics for a literal `\n` (backslash+n) or a real newline byte, but never actually converted that into a real newline before calling ImageMagick's `annotate()` — so multi-line text was sized but rendered as a single line with stray characters.
- Also fixes an off-by-value bug in the metrics loop (`substr(last, x)` used an absolute index as a length instead of `x - last`), which miscalculated width/height for messages with 3+ lines.

## Fix
- `TextEffect::doText()` in `src/overlays/PixelOverlayEffects.cpp` now builds a normalized copy of the message, converting literal `\n` into a real `'\n'` byte, and uses that normalized string consistently for line-metrics calculation and both `annotate()` calls (centered and scrolling text paths).

## Test plan
- [x] Compiled cleanly via the project Makefile (`make overlays/PixelOverlayEffects.o`) on Raspberry Pi target flags.
- [ ] Manually verify in the FPP UI: configure an Overlay Model "Text" effect with a `\n` in the text field for both "Center" and a scrolling position, confirm it renders as separate lines instead of literal backslash-n characters.