### PR TITLE
AES67 PTP Clock Sync & QoS Fixes

### DIFF
--- a/src/mediaoutput/AES67Manager.cpp
+++ b/src/mediaoutput/AES67Manager.cpp
@@ -354,9 +354,10 @@ void AES67Manager::OnPipeWireReady() {
 // participate in PTP as either grandmaster or follower (via BMCA).
 //
 // We launch ptp4l as a managed subprocess with an AES67-appropriate config:
-//   - Domain 0, two-step, 8 announces/sec, 8 syncs/sec
+//   - Domain 0, two-step, announce every 2s, 8 syncs/sec
 //   - Hardware timestamping when available (/dev/ptp0)
 //   - priority1=128 (default BMCA priority)
+//   - DSCP EF (46) on PTP event/general messages -- see AES67::PTP_DSCP
 //
 // phc2sys is also launched to synchronize the system clock to the PTP
 // hardware clock, so that GStreamer pipelines (which use the system clock)
@@ -393,15 +394,17 @@ bool AES67Manager::InitPTP() {
              << "clockClass\t\t248\n"
              << "clockAccuracy\t\t0xFE\n"
              << "offsetScaledLogVariance\t0xFFFF\n"
-             << "logAnnounceInterval\t-3\n"    // 8/sec (AES67 recommends -3)
+             << "logAnnounceInterval\t1\n"     // 1 announce/2s — matches announceReceiptTimeout cadence
              << "logSyncInterval\t\t-3\n"      // 8/sec (AES67 recommends -3)
-             << "logMinDelayReqInterval\t-3\n"
+             << "logMinDelayReqInterval\t0\n"
              << "announceReceiptTimeout\t3\n"
              << "syncReceiptTimeout\t0\n"
              << "transportSpecific\t0x0\n"
              << "network_transport\tUDPv4\n"
              << "delay_mechanism\t\tE2E\n"
              << "time_stamping\t\thardware\n"
+             << "dscp_event\t\t" << AES67::PTP_DSCP << "\n"   // EF (46) -- Sync/Delay_Req
+             << "dscp_general\t\t" << AES67::PTP_DSCP << "\n" // EF (46) -- Announce/Follow_Up/etc.
              << "# AES67 uses L2 multicast on 224.0.1.129/224.0.0.107\n";
         conf.close();
     }
@@ -453,15 +456,17 @@ bool AES67Manager::InitPTP() {
                      << "clockClass\t\t248\n"
                      << "clockAccuracy\t\t0xFE\n"
                      << "offsetScaledLogVariance\t0xFFFF\n"
-                     << "logAnnounceInterval\t-3\n"
+                     << "logAnnounceInterval\t1\n"
                      << "logSyncInterval\t\t-3\n"
-                     << "logMinDelayReqInterval\t-3\n"
+                     << "logMinDelayReqInterval\t0\n"
                      << "announceReceiptTimeout\t3\n"
                      << "syncReceiptTimeout\t0\n"
                      << "transportSpecific\t0x0\n"
                      << "network_transport\tUDPv4\n"
                      << "delay_mechanism\t\tE2E\n"
-                     << "time_stamping\t\tsoftware\n";
+                     << "time_stamping\t\tsoftware\n"
+                     << "dscp_event\t\t" << AES67::PTP_DSCP << "\n"
+                     << "dscp_general\t\t" << AES67::PTP_DSCP << "\n";
                 conf.close();
             }
         }
@@ -551,14 +556,111 @@ bool AES67Manager::IsPtp4lRunning() const {
     return (kill(m_ptp4lPid, 0) == 0);
 }
 
+// Runs a `pmc` management query against ptp4l's UDS socket and returns the
+// raw text output, or an empty string if ptp4l isn't running / pmc fails.
+static std::string RunPmcQuery(const std::string& tlv) {
+    struct PipeCloser {
+        void operator()(FILE* f) const {
+            if (f) pclose(f);
+        }
+    };
+    std::string cmd = "pmc -u -b 0 '" + tlv + "' 2>/dev/null";
+    std::unique_ptr<FILE, PipeCloser> pipe(popen(cmd.c_str(), "r"));
+    if (!pipe) {
+        return "";
+    }
+    std::string output;
+    char buffer[256];
+    while (fgets(buffer, sizeof(buffer), pipe.get()) != nullptr) {
+        output += buffer;
+    }
+    return output;
+}
+
+// Reformats a pmc clockIdentity like "aabbcc.fffe.ddeeff" into the dashed
+// EUI-64 form used elsewhere in this file ("AA-BB-CC-FF-FE-DD-EE-FF").
+static std::string FormatPmcClockId(const std::string& raw) {
+    std::string hex;
+    for (char c : raw) {
+        if (c != '.') hex += c;
+    }
+    if (hex.length() != 16) {
+        return raw;
+    }
+    std::string dashed;
+    for (size_t i = 0; i < hex.length(); i += 2) {
+        if (i) dashed += '-';
+        dashed += (char)toupper((unsigned char)hex[i]);
+        dashed += (char)toupper((unsigned char)hex[i + 1]);
+    }
+    return dashed;
+}
+
 std::string AES67Manager::GetPtp4lState() {
     if (!IsPtp4lRunning()) {
         return "not running";
     }
-    // Quick check via /proc — if ptp4l is in the process list, it's active.
-    // Full pmc (PTP management client) queries could be added later for
-    // detailed state (MASTER, SLAVE, LISTENING, etc.)
-    return "running";
+    // Query ptp4l's own port state (MASTER/SLAVE/LISTENING/PASSIVE/...) via pmc.
+    std::string output = RunPmcQuery("GET PORT_DATA_SET");
+    std::istringstream iss(output);
+    std::string line;
+    while (std::getline(iss, line)) {
+        std::istringstream ls(line);
+        std::string key;
+        ls >> key;
+        if (key == "portState") {
+            std::string val;
+            ls >> val;
+            if (!val.empty()) {
+                return val;
+            }
+        }
+    }
+    return "running (state unknown)";
+}
+
+// Queries the *actual* domain grandmaster via `pmc GET TIME_STATUS_NP` —
+// this is the remote/upstream clock ptp4l has selected via BMCA, which may
+// or may not be this node.  GetPTPClockId() (below) only ever returns this
+// node's own identity and must not be used to report "who is the master".
+bool AES67Manager::QueryPtp4lTimeStatus(bool& gmPresent, std::string& gmIdentity, int64_t& offsetNs) {
+    if (!IsPtp4lRunning()) {
+        return false;
+    }
+    std::string output = RunPmcQuery("GET TIME_STATUS_NP");
+    if (output.empty()) {
+        return false;
+    }
+    bool found = false;
+    std::istringstream iss(output);
+    std::string line;
+    while (std::getline(iss, line)) {
+        std::istringstream ls(line);
+        std::string key;
+        ls >> key;
+        if (key == "gmPresent") {
+            std::string val;
+            ls >> val;
+            gmPresent = (val == "true");
+            found = true;
+        } else if (key == "gmIdentity") {
+            std::string val;
+            ls >> val;
+            if (!val.empty()) {
+                gmIdentity = FormatPmcClockId(val);
+                found = true;
+            }
+        } else if (key == "master_offset") {
+            std::string val;
+            ls >> val;
+            try {
+                offsetNs = std::stoll(val);
+            } catch (...) {
+                // leave offsetNs untouched on parse failure
+            }
+        }
+    }
+    return found;
 }
 
 std::string AES67Manager::GetPTPClockId() {
@@ -647,6 +749,7 @@ bool AES67Manager::CreateSendPipeline(const AES67Instance& inst) {
         << "! udpsink name=usink host=" << inst.multicastIP
         << " port=" << inst.port
         << " ttl-mc=" << AES67::AUDIO_RTP_TTL
+        << " qos-dscp=" << AES67::AUDIO_DSCP
         << " auto-multicast=true sync=false";
 
     if (!inst.interface.empty()) {
@@ -1293,7 +1396,29 @@ void AES67Manager::SAPAnnounceLoop() {
     sapAddr.sin_port = htons(AES67::SAP_PORT);
     inet_pton(AF_INET, AES67::SAP_MCAST_ADDRESS, &sapAddr.sin_addr);
 
-    std::string ptpClockId = GetPTPClockId();
+    // SDP's ts-refclk must identify the domain's actual grandmaster (RFC 7273),
+    // not this node's own identity — otherwise a follower incorrectly
+    // advertises itself as the clock source.  Fall back to our own derived
+    // ID only if PTP is disabled or ptp4l hasn't selected a grandmaster yet.
+    //
+    // ptp4l needs a few seconds after startup to complete BMCA and adopt an
+    // upstream master -- until then it reports itself as its own grandmaster,
+    // so querying only once at thread-start can freeze the SDP on this node's
+    // own identity if that race is lost.  To self-correct once BMCA settles
+    // (and self-heal if the grandmaster ever changes later), re-query and
+    // rebuild the announced SDP on every announce cycle rather than once.
+    auto queryPtpClockId = [this]() -> std::string {
+        std::string clockId = GetPTPClockId();
+        if (m_config.ptpEnabled) {
+            bool gmPresent = false;
+            std::string realGmId;
+            int64_t gmOffsetNs = 0;
+            if (QueryPtp4lTimeStatus(gmPresent, realGmId, gmOffsetNs) && gmPresent && !realGmId.empty()) {
+                clockId = realGmId;
+            }
+        }
+        return clockId;
+    };
 
     // Build all SAP packets for send instances
     struct SAPEntry {
@@ -1301,24 +1426,29 @@ void AES67Manager::SAPAnnounceLoop() {
         std::vector<uint8_t> announcePacket;
         std::vector<uint8_t> deletePacket;
     };
-    std::vector<SAPEntry> entries;
+    auto buildEntries = [this](const std::string& ptpClockId) -> std::vector<SAPEntry> {
+        std::vector<SAPEntry> result;
+        for (const auto& inst : m_config.instances) {
+            if (!inst.enabled) continue;
+            if (!inst.sapEnabled) continue;
+            if (inst.mode != "send" && inst.mode != "both") continue;
 
-    for (const auto& inst : m_config.instances) {
-        if (!inst.enabled) continue;
-        if (!inst.sapEnabled) continue;
-        if (inst.mode != "send" && inst.mode != "both") continue;
+            std::string sourceIP = GetInterfaceIP(inst.interface.empty() ?
+                                                  m_config.ptpInterface : inst.interface);
+            uint16_t hash = ComputeSAPHash(inst);
+            std::string sdp = BuildSDP(inst, sourceIP, ptpClockId);
 
-        std::string sourceIP = GetInterfaceIP(inst.interface.empty() ?
-                                              m_config.ptpInterface : inst.interface);
-        uint16_t hash = ComputeSAPHash(inst);
-        std::string sdp = BuildSDP(inst, sourceIP, ptpClockId);
+            SAPEntry entry;
+            entry.hash = hash;
+            entry.announcePacket = BuildSAPPacket(sourceIP, hash, sdp, false);
+            entry.deletePacket = BuildSAPPacket(sourceIP, hash, sdp, true);
+            result.push_back(entry);
+        }
+        return result;
+    };
 
-        SAPEntry entry;
-        entry.hash = hash;
-        entry.announcePacket = BuildSAPPacket(sourceIP, hash, sdp, false);
-        entry.deletePacket = BuildSAPPacket(sourceIP, hash, sdp, true);
-        entries.push_back(entry);
-    }
+    std::string ptpClockId = queryPtpClockId();
+    std::vector<SAPEntry> entries = buildEntries(ptpClockId);
 
     if (entries.empty()) {
         LogWarn(VB_MEDIAOUT, "AES67 SAP: No SAP-enabled send instances — announcer has nothing to send\n");
@@ -1330,6 +1460,14 @@ void AES67Manager::SAPAnnounceLoop() {
 
     // Announce loop
     while (m_sapAnnounceRunning.load()) {
+        std::string currentPtpClockId = queryPtpClockId();
+        if (currentPtpClockId != ptpClockId) {
+            LogInfo(VB_MEDIAOUT, "AES67 SAP: PTP refclk changed (%s -> %s), rebuilding SDP\n",
+                    ptpClockId.c_str(), currentPtpClockId.c_str());
+            ptpClockId = currentPtpClockId;
+            entries = buildEntries(ptpClockId);
+        }
+
         for (const auto& entry : entries) {
             ssize_t sent = sendto(sock, entry.announcePacket.data(), entry.announcePacket.size(), 0,
                    (struct sockaddr*)&sapAddr, sizeof(sapAddr));
@@ -1671,6 +1809,7 @@ std::vector<AES67Manager::InlineRTPBranch> AES67Manager::AttachInlineRTPBranches
             "host", inst.multicastIP.c_str(),
             "port", inst.port,
             "ttl-mc", AES67::AUDIO_RTP_TTL,
+            "qos-dscp", AES67::AUDIO_DSCP,
             "auto-multicast", TRUE,
             "sync", FALSE,
             NULL);
@@ -1818,10 +1957,25 @@ AES67Manager::Status AES67Manager::GetStatus() {
             status.pipelines.push_back(ps);
         }
     }
-    // PTP status — check if ptp4l is running
-    status.ptpSynced = IsPtp4lRunning();
-    status.ptpGrandmasterId = GetPTPClockId();
-    status.ptpOffsetNs = 0;  // detailed offset from pmc could be added later
+    // PTP status — query ptp4l for the actual selected grandmaster (may be a
+    // remote/upstream clock) rather than assuming this node is the master.
+    {
+        bool gmPresent = false;
+        std::string gmId;
+        int64_t offsetNs = 0;
+        if (QueryPtp4lTimeStatus(gmPresent, gmId, offsetNs) && gmPresent && !gmId.empty()) {
+            status.ptpSynced = true;
+            status.ptpGrandmasterId = gmId;
+            status.ptpOffsetNs = offsetNs;
+        } else {
+            // ptp4l not running, or no grandmaster selected yet (e.g. still
+            // in LISTENING) — do not claim we're synced or report our own
+            // identity as if it were the grandmaster.
+            status.ptpSynced = false;
+            status.ptpGrandmasterId = "";
+            status.ptpOffsetNs = 0;
+        }
+    }
 
     // Discovered streams
     {

--- a/src/mediaoutput/AES67Manager.h
+++ b/src/mediaoutput/AES67Manager.h
@@ -53,6 +53,10 @@ constexpr int DEFAULT_PORT          = 5004;
 constexpr int DEFAULT_CHANNELS      = 2;
 constexpr int DEFAULT_LATENCY_MS    = 10;
 
+// DSCP codepoints (AES67-2018 / AES-R16 QoS recommendations)
+constexpr int AUDIO_DSCP             = 34;      // AF41 -- RTP audio (udpsink qos-dscp)
+constexpr int PTP_DSCP                = 46;     // EF   -- PTP event/general messages (ptp4l dscp_event/dscp_general)
+
 constexpr const char* DEFAULT_MULTICAST_IP = "239.69.0.1";
 constexpr const char* AUDIO_FORMAT         = "S24BE";
 constexpr const char* SAP_MCAST_ADDRESS    = "239.255.255.255";
@@ -241,8 +245,13 @@ private:
     bool InitPTP();
     void ShutdownPTP();
     bool IsPtp4lRunning() const;         // check if ptp4l process is alive
-    std::string GetPTPClockId();         // EUI-64 from interface MAC
-    std::string GetPtp4lState();         // query ptp4l state via pmc
+    std::string GetPTPClockId();         // EUI-64 from interface MAC (this node's own identity)
+    std::string GetPtp4lState();         // query ptp4l port state via pmc (MASTER/SLAVE/LISTENING/...)
+
+    // Query the actual PTP grandmaster (may be a remote clock, not this node)
+    // via `pmc GET TIME_STATUS_NP`.  Returns false if ptp4l isn't running or
+    // the query fails, leaving the out-params untouched.
+    bool QueryPtp4lTimeStatus(bool& gmPresent, std::string& gmIdentity, int64_t& offsetNs);
 
     // Pipeline watchdog — called from SAP thread to poll bus messages
     // and restart any pipeline that isn't in PLAYING state.


### PR DESCRIPTION
# AES67 PTP Clock Sync & QoS Fixes

**Scope:** `src/mediaoutput/AES67Manager.cpp`, `src/mediaoutput/AES67Manager.h`
**Related:** [FPP_Audio_Architecture.md](FPP_Audio_Architecture.md) (AES67 Audio-over-IP section)

## Summary

Field diagnosis on a production AES67 deployment (Raspberry Pi sending AES67 audio into a QSC Q-SYS Core 510i running firmware 10.4.1) surfaced four separate defects in `AES67Manager`'s PTP/AES67 implementation:

1. `ptp4l`'s AES67 profile used timing intervals that didn't match the QSC domain's actual cadence, preventing clock lock. The timing intervals used are out of the range of the AES67 specification. 
2. Neither the HTTP status API nor the SAP-advertised SDP ever queried `ptp4l` for the actual PTP grandmaster — both unconditionally reported the Pi's own identity, regardless of BMCA outcome.
3. Even after fixing (2), the SAP thread only queried the grandmaster once at thread-start, which loses a startup race against `ptp4l`'s own BMCA convergence and can freeze the wrong identity into the SDP indefinitely.
4. Neither PTP nor RTP audio traffic carried DSCP markings, so neither got QoS treatment on a congested/shared network. This results in loss of clocking and audio data, leading to grandmaster elections and dropped audio. 

Each is addressed independently below, with the observed symptom, root cause, and fix. All four were validated on the affected production device via `PTPTrackhound`, this repo's own `/api/aes67/status` endpoint, `tcpdump`, and log inspection.

---

## 1. `ptp4l` AES67 profile — announce/delay-request interval mismatch

**Symptom:** `ptp4l` never reached a stable `SLAVE` lock against the QSC grandmaster; offset stayed unconverged.

**Root cause:** The hardcoded AES67 profile in `InitPTP()` used the defaults `logAnnounceInterval -3`, `logMinDelayReqInterval -3` — i.e. 8 messages/sec, but the actual QSC PTP domain runs a slower cadence (`announceReceiptTimeout 3` implies the domain expects one Announce roughly every 2 seconds, not 8/sec). The mismatch prevented convergence.

FPP is configured to a SMPTE ST 2059‑2 message cadence and unmarked QoS while operating in an AES67 domain; announce interval −3 is outside the AES67 profile's permitted range of 0–4, which per IEEE 1588‑2008 §7.7.3.1 and §9.3.2.4.4 prevents the domain grandmaster from ever qualifying, causing the device to self-elect.


**Fix** (`InitPTP()`, both the hardware-timestamping and software-timestamping-fallback config blocks):

| Setting | Before | After | Why |
|---|---|---|---|
| `logAnnounceInterval` | `-3` (8/sec) | `1` (1 per 2s) | Matches the default value for AES67 spec and observed domain's actual Announce cadence and the existing `announceReceiptTimeout 3` |
| `logMinDelayReqInterval` | `-3` | `0` | Matches domain cadence (was previously inconsistent with the corrected announce rate) |
| `logSyncInterval` | `-3` | `-3` (unchanged) | Confirmed correct against the domain; pinned explicitly rather than left implicit |

**Note on `ptp_minor_version`:** the original diagnosis also flagged that `ptp4l` defaults to advertising PTPv2.1 into a domain of PTPv2.0 peers, and suggested pinning `ptp_minor_version 0` to eliminate it as a variable. This was implemented, deployed, and tested — it had **no measurable effect** on lock behavior (the announce/delay-request interval fix above was the actual fix). It has been removed from this change to keep the diff minimal and avoid carrying a config knob with no demonstrated purpose. If a future `linuxptp` version or peer clock population makes the v2.1/v2.0 distinction load-bearing, it's a one-line re-add (`dscp_event`/`dscp_general` block in `InitPTP()`).

---

## 2. Grandmaster misreporting — API status and SAP/SDP always claimed the Pi as master

**Symptom:** `ptp4l` was correctly locked as a `SLAVE` to the real grandmaster (confirmed independently via `PTPTrackhound`), but `/api/aes67/status` and the SAP-advertised SDP's `a=ts-refclk` line both reported the Pi's own clock identity, as if it were the grandmaster.

**Root cause:** Neither code path ever asked `ptp4l` who the grandmaster actually was.

- `GetStatus()` set `ptpGrandmasterId = GetPTPClockId()` — a function that derives an EUI-64 purely from the local interface's own MAC address. This is the Pi's own identity, always, regardless of `ptp4l`'s actual `MASTER`/`SLAVE` state.
- `GetPtp4lState()` was a stub that only checked process liveness (`kill(pid, 0)`), never actual port state.
- `ptpOffsetNs` was hardcoded to `0`.
- The SAP thread built its SDP's `a=ts-refclk:ptp=IEEE1588-2008:<id>:0` (RFC 7273) using that same `GetPTPClockId()` self-identity.

**Fix:** Added a real `pmc` (PTP management client) query path against `ptp4l`'s management socket:

- `RunPmcQuery()` — runs `pmc -u -b 0 '<TLV>'` and captures output.
- `QueryPtp4lTimeStatus()` — parses `GET TIME_STATUS_NP` for `gmPresent`, `gmIdentity`, `master_offset`; reformats the identity into this codebase's existing dashed-EUI-64 convention.
- `GetPtp4lState()` — now parses `GET PORT_DATA_SET`'s `portState` (`MASTER`/`SLAVE`/`LISTENING`/...) instead of returning a hardcoded string.

`GetStatus()` (the `/api/aes67/status` handler) now reports the real `gmIdentity`/offset from `QueryPtp4lTimeStatus()`, and reports `synced=false` with an empty grandmaster if no GM has been selected yet — rather than always claiming success.

The SAP thread's SDP builder now queries the same function for the `ts-refclk` value, falling back to `GetPTPClockId()` (self) only when PTP is disabled or `ptp4l` hasn't selected a grandmaster.

---

## 3. SAP/SDP grandmaster staleness — startup race against BMCA

**Symptom:** After fix (2) was deployed, the HTTP API correctly reported the real grandmaster, but the SAP-advertised SDP still showed the Pi's own identity.

**Root cause:** The SAP announcer thread (`SAPAnnounceLoop()`) queried the grandmaster and built its (pre-serialized) SDP/SAP packets **once**, at thread start. `ptp4l` needs a few seconds after its own startup to complete BMCA and adopt an upstream master — until that settles, it reports itself as its own grandmaster. Because the SAP thread starts as part of `ApplyConfig()` (at boot / config reload), it reliably lost this race, freezing the wrong identity into the SDP until the next full service restart.

**Fix:** Restructured `SAPAnnounceLoop()` to re-query the grandmaster and rebuild the SDP/SAP packets on **every** announce cycle (every `SAP_ANNOUNCE_INTERVAL_S`, currently 30s) rather than once. The rebuild only re-serializes when the identity actually changed. This both self-corrects shortly after startup once BMCA converges, and self-heals if the grandmaster changes later (e.g. a BMCA re-election) without requiring a service restart.

Verified in production: the corrected identity appeared in the SDP within one announce cycle of a service restart, logged as:
```
AES67 SAP: PTP refclk changed (<old-id> -> <new-id>), rebuilding SDP
```

---

## 4. DSCP / QoS tagging — PTP and audio traffic sent best-effort

**Symptom:** Neither PTP control traffic nor AES67 RTP audio carried any DSCP marking, so neither received QoS prioritization on the network.

**Fix:** Applied the AES67-2018 / AES-R16 recommended DSCP codepoints, defined as named constants in `AES67Manager.h`:

```cpp
constexpr int AUDIO_DSCP = 34;  // AF41 -- RTP audio
constexpr int PTP_DSCP   = 46;  // EF   -- PTP event/general messages
```

- **PTP → EF (46):** `InitPTP()`'s generated `ptp4l.conf` now sets `dscp_event` and `dscp_general` to `AES67::PTP_DSCP`, covering both event messages (Sync/Delay_Req) and general messages (Announce/Follow_Up/etc.).
- **Audio RTP → AF41 (34):** Both real audio-send paths now set GStreamer's `udpsink`/`multiudpsink` `qos-dscp` property to `AES67::AUDIO_DSCP`:
  - `CreateSendPipeline()` — the normal PipeWire-routed send pipeline (`gst_parse_launch` string).
  - `AttachInlineRTPBranches()` — the "zero-hop" inline branch attached directly to the playback pipeline's tee.

The receive side (`udpsrc`) requires no change — DSCP marking is a sender-side concern only.

Verified on the wire via `tcpdump -v`: PTP event/general packets show `tos 0xb8` (DSCP 46 << 2); AES67 RTP audio packets show `tos 0x88` (DSCP 34 << 2).

**Compatibility note:** `udpsink`'s `qos-dscp` property requires GStreamer ≥1.16 (`gst-plugins-good`). On older builds the property is silently ignored by `gst_parse_launch` rather than erroring — worth a `gst-inspect-1.0 udpsink | grep qos-dscp` sanity check on any platform this ships to.

---

## Testing performed

- `PTPTrackhound` confirmed `ptp4l` correctly locks `SLAVE` to the QSC grandmaster after fix (1).
- `curl /api/aes67/status` confirmed correct `grandmasterId`/`synced`/`offsetNs` after fix (2).
- `tcpdump` capture of SAP multicast (`239.255.255.255:9875`) confirmed the SDP's `a=ts-refclk` matches the real grandmaster after fix (3), both immediately post-restart and after the periodic re-check.
- `tcpdump -v` confirmed correct `tos` byte on both PTP (UDP 319/320) and AES67 RTP audio (UDP 5004) traffic after fix (4).

All four fixes were validated together, end-to-end, on the production device before this documentation was written.
