### PR TITLE
fix(outputs): restore the pixel-string Testing dropdown from the backend

### DIFF
--- a/www/co-pixelStrings.php
+++ b/www/co-pixelStrings.php
@@ -161,6 +161,45 @@ function readCapes($cd, $capes)
         return $('#PixelStringPixelTiming').val();
     }
 
+    // Which "outputs" values identify a test started from THIS page. The same
+    // fppd test mode backs the panel dropdown too, and both report mode
+    // "Outputs" with a numeric "type" - so without checking which surface owns
+    // it, a panel test would set this dropdown and vice versa.
+    function PixelTestOutputTypes() {
+        return ['BBB Pixel Strings', 'DPI Pixels'];
+    }
+
+    /**
+     * Point the Testing dropdown at whatever test is actually running.
+     *
+     * fppd knows this at all times and reports it on api/testmode, but the
+     * dropdown was static markup that always loaded as "Off" while the test kept
+     * running. Worse than cosmetic: re-selecting "Off" fires no change event, so
+     * the running test could not be stopped from here in one click - the same
+     * reasoning as RestorePanelTestPatternState() in co-ledPanels.php.
+     */
+    function RestorePixelTestPatternState() {
+        $.ajax({
+            url: "api/testmode",
+            async: true,
+            dataType: 'json',
+            success: function (data) {
+                if (!data || !data.enabled || data.mode != "Outputs" ||
+                    !data.hasOwnProperty('type')) {
+                    return;
+                }
+                // Only claim a test this page's own outputs are running.
+                if (PixelTestOutputTypes().indexOf(String(data.outputs)) === -1) {
+                    return;
+                }
+                var val = String(data.type);
+                if ($("#PixelTestPatternType option[value='" + val + "']").length) {
+                    $("#PixelTestPatternType").val(val);
+                }
+            }
+        });
+    }
+
     function SetPixelTestPattern() {
         var val = $("#PixelTestPatternType").val();
         if (val != "0") {
@@ -2860,6 +2899,10 @@ function readCapes($cd, $capes)
             .done(data => selected_string_details.gpio = data)
             .fail(err => $.jGrowl('Error: Unable to retrieve GPIO pin info.', { themeState: 'danger' }));
         populateCapeList();
+
+        // The dropdown's options are static markup, so this needs nothing else
+        // loaded first - it only has to run after the select exists.
+        RestorePixelTestPatternState();
         loadPixelStringOutputs();
         // keep the max-fps estimate live as color order / null nodes / etc. change
         $('#PixelString').on('change', 'input, select', CalculatePixelStringMaxFPS);


### PR DESCRIPTION
Partial fix for #2847 — the pixel-string dropdown specifically. Deliberately **Refs**, not **Fixes**: that issue also covers retaining settings when a test *stops* (which needs an `fppd` change), and the equivalent gaps on the other test surfaces. This is the one piece that is self-contained and web-only.

---

Open **Channel Outputs** in a second browser while a pixel-string test is running and the Testing dropdown reads **Off**. It's static markup, and nothing asks `fppd` what's running.

That's worse than a wrong label: re-selecting "Off" fires no change event, so the running test can't be stopped from the page that started it.

`fppd` already reports the answer on `api/testmode` — captured from a box running a Port Number test:

```json
{"enabled":1,"mode":"Outputs","outputs":"BBB Pixel Strings","type":1,...}
```

`co-ledPanels.php` already solves exactly this for its own dropdown in `RestorePanelTestPatternState()`. This does the same for the pixel-string dropdown, on `document.ready` — the options are static markup, so it only has to run after the select exists.

**Gated on `outputs`.** Pixel, panel and PWM tests are all the same fppd test mode and all report `mode: "Outputs"` with a numeric `type`, so an ungated restore claims another surface's test. Worth noting the existing panel restore isn't gated — with a `BBB Pixel Strings` test running, calling it sets the panel dropdown to "Panel Layout". I've left that alone here rather than widening the change; happy to follow up if you'd like it fixed.

### Verified on FPP 10 hardware

BeagleBone 64, `10.x-master`, with a Port Number test running:

- fresh page load selects **Port Number**
- panel dropdown unaffected
- selecting **Off** stops the test (`enabled: 1` → `enabled: 0`)

Also checked that a panel test and a stopped test both leave this dropdown untouched.

### Scope

43 lines added, one file, no markup and no PHP changed — two JS functions and one call from the existing `document.ready`. No behaviour change when no test is running.
