### PR TITLE
fix(UI): Save UI Password button visibility on settings-ui tab

### DIFF
--- a/www/settings-ui.php
+++ b/www/settings-ui.php
@@ -101,6 +101,8 @@ function SaveUIPasswordSettings() {
 $( document ).ready(function() {
     if ($('#passwordEnable').val() == '1') {
         $('.passwordEnableChild').show();
+    } else {
+        $('.passwordEnableChild').hide();
     }
 
     // Replace the auto-generated onChange handlers for the UI password settings
@@ -111,6 +113,14 @@ $( document ).ready(function() {
 
             if (typeof window['Update' + name + 'Children'] === 'function') {
                 window['Update' + name + 'Children'](0);
+            }
+
+            if (name == 'passwordEnable') {
+                if ($('#passwordEnable').val() == '1') {
+                    $('.passwordEnableChild').show();
+                } else {
+                    $('.passwordEnableChild').hide();
+                }
             }
 
             MarkUIPasswordDirty();
@@ -153,7 +163,7 @@ PrintSetting('passwordEnable');
 PrintSetting('password');
 PrintSetting('passwordVerify');
 ?>
-            <div class='row'>
+            <div class='row passwordEnableChild' style='display: none;'>
                 <div class="printSettingLabelCol col-md-4 col-lg-3 col-xxxl-2"></div>
                 <div class='printSettingFieldCol col-md'>
                     <input type='button' class='buttons btn-success' id='saveUIPasswordBtn'


### PR DESCRIPTION
# Fix Save UI Password button visibility on settings-ui tab

## Summary
Makes the **Save UI Password** button on `settings.php#settings-ui` show/hide together with the Username, Password, and Verify Password fields when the **UI password** (`passwordEnable`) dropdown is changed.

Fixes the issue where the button remained visible when the dropdown was set to `No Password (Default)` while the credential fields correctly hid.

## Problem
* `www/settings-ui.php` used a generic settings staging flow that deliberately overrides the auto-generated `passwordEnableChanged` handler (from `www/settings.json:2548` `ConfirmPasswordEnable` in `www/js/fpp.js:1164`) to batch-save the password and enable flag.
* The overridden handler called `UpdatepasswordEnableChildren(0)` which only toggles the declarative children `password` / `passwordVerify` rows (`www/settings.json:2559` + `www/common.php:1504` `PrintSettingSelectInternal` / `PrintSettingChildrenFunction`).
* The Username row and the Save button row are **manual** HTML (`<div class='row passwordEnableChild'>`) outside `settings.json` and were controlled separately via `$('.passwordEnableChild')` in `www/js/fpp.js:1186` `ConfirmPasswordEnable`. The staged handler in `www/settings-ui.php` never toggled this class after the initial `$(document).ready` check, so changing the dropdown left the button (and previously the username row) in the wrong visibility state.

## Solution
**File: `www/settings-ui.php`**

1. **Button row – add to child group** (`www/settings-ui.php:166`):
   ```diff
   - <div class='row'>
   + <div class='row passwordEnableChild' style='display: none;'>
   ```
   Now the Save button is part of the same `passwordEnableChild` group as the Username row, so a single `show()`/`hide()` controls both. Hidden by default, matching the username row.

2. **Initial state – handle both values** (`www/settings-ui.php:101-106`):
   ```js
   if ($('#passwordEnable').val() == '1') {
       $('.passwordEnableChild').show();
   } else {
       $('.passwordEnableChild').hide();
   }
   ```
   Previously only the `== '1'` case was handled, relying on the inline `display: none`.

3. **Dropdown change – sync manual children** (`www/settings-ui.php:118-124`):
   ```js
   if (name == 'passwordEnable') {
       if ($('#passwordEnable').val() == '1') {
           $('.passwordEnableChild').show();
       } else {
           $('.passwordEnableChild').hide();
       }
   }
   ```
   Inside the staged `passwordEnableChanged` replacement (which already calls `UpdatepasswordEnableChildren(0)` for the `password`/`passwordVerify` rows and `MarkUIPasswordDirty()`), the manual `passwordEnableChild` group is now also toggled. This restores the behavior of `www/js/fpp.js:1164` `ConfirmPasswordEnable` within the staged-save flow.

Result: `passwordEnable == '0'` → Username, Password, Verify Password, **and** Save UI Password button all hidden. `passwordEnable == '1'` → all shown.

## Testing
* Load `settings.php#settings-ui` with `passwordEnable = 0` → button hidden.
* Change dropdown to `Enter a Password` → Username, Password, Verify Password **and** Save UI Password button appear.
* Change back to `No Password` → all four elements hide.
* Reload page in both states → visibility persists correctly via `$(document).ready` check.
* Verified `password` / `passwordVerify` rows still toggle via the declarative `children` mechanism (`www/settings.json:2559`).

## Notes
* No changes to `www/settings.json`, `www/common.php`, or `www/js/fpp.js` – fix is scoped to the `settings-ui` tab's staging overrides.
* No plugin compatibility impact; `passwordEnableChild` is a local CSS class.
* Follows existing pattern used by `osPasswordEnableChild` in `www/js/fpp.js:1249`.

## Checklist
- [x] Tested on `settings.php#settings-ui` (0 → 1 → 0)
- [x] No new dependencies
- [x] No `settings.json` schema changes

## Additional Comments

This PR closes #2878.