### PR TITLE
BBShiftString: drop frames the PRU can't take yet; warn when the sequence rate exceeds string capacity

### DIFF
--- a/src/non-gpl/BBShiftString/BBShiftString.cpp
+++ b/src/non-gpl/BBShiftString/BBShiftString.cpp
@@ -1346,6 +1346,71 @@ int BBShiftStringOutput::SendData(unsigned char* channelData) {
     if (falconV5Support) {
         falconV5Support->processListenerData();
     }
+
+    // ---- back-pressure gate --------------------------------------------------
+    // pumpFrameData() only snapshots pendingFrame once the firmware is ready for
+    // another frame (command == 0 && ring drained).  A frame staged before that
+    // point is simply overwritten and never rendered.  When the requested frame
+    // rate exceeds what the configured string length can physically clock out,
+    // that surplus of never-rendered frames is what eventually leaves the PRU
+    // ring misaligned (#2855).  Declining the frame while the previous one is
+    // still pending drives the surplus to zero at whatever rate the hardware
+    // actually sustains - frame dropping at the source, with no fixed divisor
+    // to mis-tune, and configurations already inside their budget are untouched
+    // (nothing is pending when the next frame arrives, so nothing is declined).
+    //
+    // Cannot wedge: we only decline while pendingSeq != pumpedSeq, so
+    // pumpFrameData() still enters its busy branch and its 250ms watchdog
+    // still runs.
+    //
+    // Gated to falconV5Support because that is the configuration where the
+    // misalignment was reproduced and where this fix has soak-time behind it;
+    // trivially widened later if wanted.
+    if (falconV5Support) {
+        bool taken = true;
+        if (m_pru1.maxStringLen) {
+            taken = taken && (m_pru1.pendingSeq.load(std::memory_order_acquire) ==
+                              m_pru1.pumpedSeq.load(std::memory_order_acquire));
+        }
+        if (m_pru0.maxStringLen) {
+            taken = taken && (m_pru0.pendingSeq.load(std::memory_order_acquire) ==
+                              m_pru0.pumpedSeq.load(std::memory_order_acquire));
+        }
+        static uint32_t bpOffered = 0;
+        static uint32_t bpDeclined = 0;
+        static bool bpWarned = false;
+        ++bpOffered;
+        if (!taken) {
+            ++bpDeclined;
+        }
+        if ((m_curFrame % 6000) == 0 && bpOffered) {
+            LogWarn(VB_CHANNELOUT,
+                    "BBShiftString: back-pressure gate declined %u of %u frames (%.1f%%)\n",
+                    bpDeclined, bpOffered, 100.0 * bpDeclined / bpOffered);
+            // Surface a persistent UI warning once the sequence rate is clearly
+            // beyond what the strings can output; clear it again when the rate
+            // drops back (e.g. a different sequence starts).  The thresholds
+            // are hysteresis: on at >=10% dropped, off again below 2%.
+            static const std::string BP_WARN =
+                "Sequence frame rate is higher than the configured pixel strings can output; frames are being dropped";
+            if (bpDeclined * 10 >= bpOffered) {
+                if (!bpWarned) {
+                    WarningHolder::AddWarning(61, BP_WARN);
+                    bpWarned = true;
+                }
+            } else if (bpWarned && bpDeclined * 50 <= bpOffered) {
+                WarningHolder::RemoveWarning(61, BP_WARN);
+                bpWarned = false;
+            }
+            bpOffered = 0;
+            bpDeclined = 0;
+        }
+        if (!taken) {
+            return m_channelCount;
+        }
+    }
+    // --------------------------------------------------------------------------
+
     sendData(m_pru0);
     sendData(m_pru1);
     // make sure memory is flushed before command is set to 1

--- a/src/non-gpl/BBShiftString/BBShiftString.h
+++ b/src/non-gpl/BBShiftString/BBShiftString.h
@@ -170,7 +170,10 @@ private:
         // zero while it is keeping up
         std::chrono::steady_clock::time_point stalledSince{};
         // pump-internal streaming state
-        uint32_t pumpedSeq = 0;
+        // atomic: the pump thread writes this while the output thread reads it
+        // in SendData's back-pressure gate.  The pump's own uses compile
+        // unchanged as implicit seq_cst operations.
+        std::atomic<uint32_t> pumpedSeq{ 0 };
         PumpFrame activeFrame;
         uint32_t activeOff = 0;
         bool pumpActive = false;


### PR DESCRIPTION
Follows up #2855 — opening this as requested.

## What this does

`SendData()` now declines a frame while the previous one is still pending (`pendingSeq != pumpedSeq`), and a persistent UI warning appears when the sequence rate is measurably beyond what the configured strings can output.

`pumpFrameData()` only snapshots `pendingFrame` once the firmware is ready for another frame (`command == 0 && ring drained`). A frame staged before that point is simply overwritten and never rendered. When the sequence frame rate exceeds what the string length can physically clock out, that surplus of never-rendered frames is what eventually leaves the PRU ring misaligned — the c6d86600 resync then heals the ring position, but the receiver picture stays wrong and telemetry stays frozen until fppd restarts.

Declining at the source drives the surplus to zero at whatever rate the hardware actually sustains — exactly the "fully dropping frames" behaviour you described, with no fixed divisor to mis-tune. Configurations inside their budget are untouched: nothing is pending when the next frame arrives, so nothing is declined.

`pumpedSeq` becomes `std::atomic<uint32_t>` so the output thread can read it against `pendingSeq` without a formal data race; the pump's own uses compile unchanged.

## The warning

Measured rather than computed: the declined fraction over each 6000-frame window *is* "how far past the budget you are", with no dependency on per-protocol bit timing. `WarningHolder` id 61, with hysteresis — on at ≥10% dropped, off again below 2% (e.g. when a lower-rate sequence starts):

> Sequence frame rate is higher than the configured pixel strings can output; frames are being dropped

The thresholds are judgement calls — happy to adjust.

## Evidence (K32-Max on PocketBeagle 2, FPP v10.0, FalconV5 SRx1 on 4 ports, 2002 px, longest string 700 px)

Controlled A/B on the same box, same evening, one variable: **stock failed at 3 min 31 s; the gated build ran 131 minutes clean.** Roughly six hours of clean soak since across repeated runs, `re-seated 0` throughout.

The declined fraction tracks `1 − achieved/offered` at every rate tested:

| offered | PRU-achieved | declined (measured) | 1 − achieved/offered |
| --- | --- | --- | --- |
| 40 fps | 40.0 | 0.0% | 0% |
| 66.7 fps | 45.8 | 31.1–31.2% | 31.3% |
| 100 fps | 44.0 | 55.8–56.0% | 56.0% |

Verified from the other side with a temporary counter on accepted `m_curFrame` gaps: at 40 fps every one of 6000 frames advanced exactly one step; at 66.7 the accepted-frame pattern matched the predicted 55/45 mix of 1- and 2-frame steps to three decimals. Content cadence behaves exactly as "drop the frames that don't fit" predicts.

## Notes

- The gate is inside `if (falconV5Support)` because that is the configuration where the misalignment reproduces and where the soak time is. The condition itself doesn't depend on V5 — trivially widened if you'd rather it cover all BBShiftString outputs.
- The two hunks are identical to what has been running on my show rig (v10.0) for the soaks above; anchors on master are unchanged, so this is the same code rebased.
