### PR TITLE
fix(upgradeOS): Harden against shell injection / SSRF / XSS

### DIFF
--- a/www/upgradeOS.php
+++ b/www/upgradeOS.php
@@ -62,9 +62,15 @@ function downloadImage($localFile): bool
 {
     echo "==========================================================================\n";
     echo "Downloading OS Image:\n";
+    // Validate URL before SSRF; keep http/https only — matches UI contract.
+    $rawUrl = $_GET['os'] ?? '';
+    if (!filter_var($rawUrl, FILTER_VALIDATE_URL) || !preg_match('#^https?://#i', $rawUrl)) {
+        echo "Invalid OS URL\n";
+        return false;
+    }
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_FILE, $localFile);
-    curl_setopt($ch, CURLOPT_URL, $_GET['os']);
+    curl_setopt($ch, CURLOPT_URL, $rawUrl);
     curl_setopt($ch, CURLOPT_HEADER, 0);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10); // Connect in 10 seconds or less
     curl_setopt($ch, CURLOPT_TIMEOUT, 86400); // 1 Day Timeout to transfer
@@ -97,14 +103,19 @@ if (!$wrapped) {
 
     <body>
         <h2>FPP OS Upgrade</h2>
-        Image: <? echo strip_tags($_GET['os']); ?><br>
+        Image: <? echo htmlspecialchars($_GET['os'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?><br>
         <pre><?
 } else {
     echo "\nFPP OS Upgrade\n";
-    echo "Image: " . strip_tags($_GET['os']) . "\n";
+    echo "Image: " . htmlspecialchars($_GET['os'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . "\n";
 }
 
-if (preg_match('/^https?:/', $_GET['os'])) {
+if (isset($_GET['os']) && preg_match('/^https?:/', $_GET['os'])) {
+    // Defense in depth: reject non-http(s) / malformed URLs before wget
+    if (!filter_var($_GET['os'], FILTER_VALIDATE_URL) || !preg_match('#^https?://#i', $_GET['os'])) {
+        echo "Invalid OS URL\n";
+        exit(1);
+    }
     $baseFile = basename($_GET['os']);
     if (!preg_match('/^[a-zA-Z0-9._-]+$/', $baseFile)) { echo 'Invalid filename'; exit(1); }
 
@@ -130,6 +141,11 @@ if (preg_match('/^https?:/', $_GET['os'])) {
     logStage("Downloading OS image");
     $rc = 1;
     foreach ($urls as $idx => $url) {
+        // Validate each URL (including mirror) before shell use
+        if (!filter_var($url, FILTER_VALIDATE_URL) || !preg_match('#^https?://#i', $url)) {
+            UpgradeLog('os-upgrade', $baseFile, "Skipping invalid URL: " . $url);
+            continue;
+        }
         if (count($urls) > 1) {
             if ($idx == 0) {
                 UpgradeEchoLog('os-upgrade', $baseFile, "Downloading from local FPP mirror ${upgradeSource}...\n");
@@ -145,7 +161,7 @@ if (preg_match('/^https?:/', $_GET['os'])) {
         // new line per update. dot:giga instead emits real \n-terminated summary
         // lines at large (1GB-per-row) intervals, which suits both the streamed
         // dialog and an OS-image-sized download.
-        $command = "sudo wget -c --quiet --show-progress --progress=dot:giga " . $url . " -O /home/fpp/media/upload/$baseFile 2>&1";
+        $command = "sudo wget -c --quiet --show-progress --progress=dot:giga " . escapeshellarg($url) . " -O " . escapeshellarg("/home/fpp/media/upload/$baseFile") . " 2>&1";
         $retryCount = 0;
         while ($retryCount < 20 && $rc != 0) {
             echo "Running command: $command\n";


### PR DESCRIPTION
# fix(upgradeOS): Harden against shell injection / SSRF / XSS

## Summary

Fixes **Critical shell injection + SSRF** in `www/upgradeOS.php:148` / `www/upgradeOS.php:67`.

`$_GET['os']` was interpolated unescaped into a `sudo wget … $url -O …` `passthru()` command (and a dead-code `curl_setopt(CURLOPT_URL, $_GET['os'])` path). `FILTER_VALIDATE_URL` alone does **not** reject `;`, `|`, `$(…)`, `&`; `basename()` validation of the *filename* does not cover the *URL*. An attacker could smuggle shell metacharacters in the URL path and have them interpreted by `/bin/sh`:

```
GET /upgradeOS.php?wrapped=1&os=https://evil.com/a;touch%20/tmp/pwned_http_simple
# → passthru("sudo wget -c … https://evil.com/a;touch /tmp/pwned_http_simple -O …")
#   shell splits on `;`, second command executes as the web user (sudo wget context)
```

The fix is strictly hardening — no URL/API contract change — and preserves the existing `UpgradeSource` mirror + `about.php` → `upgradeOS.php?wrapped=1&os=` flow.

> **Risk: Critical** — unauthenticated RCE on default FPP installs (FPP web UI is LAN-trusted, no auth on `upgradeOS.php`). The OS upgrade path is also `sudo`-adjacent.

## Changes

`www/upgradeOS.php` (341 → 357 lines, `php -l` clean):

* **`www/upgradeOS.php:61-73` — `downloadImage()` SSRF hardening:** validate `$rawUrl = $_GET['os'] ?? ''` with `filter_var(…, FILTER_VALIDATE_URL)` + `#^https?://#i` before `curl_setopt(CURLOPT_URL, …)`. Returns `false` with `Invalid OS URL` on failure. Fixes `www/upgradeOS.php:67`.
* **`www/upgradeOS.php:106,110` — XSS hardening:** `strip_tags($_GET['os'])` → `htmlspecialchars($_GET['os'] ?? '', ENT_QUOTES|ENT_SUBSTITUTE, 'UTF-8')` for both wrapped/unwrapped display. `strip_tags` is bypassable (`" onload="…` survives); current `basename()` regex blocks most payloads pre-display, but defense-in-depth is warranted.
* **`www/upgradeOS.php:113-118` — download gate hardening:** `if (preg_match('/^https?:/', $_GET['os']))` → `if (isset($_GET['os']) && preg_match(…))` plus explicit `FILTER_VALIDATE_URL` + `https?` reject before `basename()`. Prevents `ftp://`, `file://`, and `javascript:` from reaching `wget`/`curl`.
* **`www/upgradeOS.php:143-148,164` — shell escaping:** in the `foreach ($urls as $url)` loop (covers both the primary GitHub URL and the `UpgradeSource` mirror `http://fppUrlHost($upgradeSource)/api/file/uploads/$baseFile`), validate each `$url` with `FILTER_VALIDATE_URL` + `https?` and build the command as:

  ```php
  $command = "sudo wget -c --quiet --show-progress --progress=dot:giga "
           . escapeshellarg($url)
           . " -O " . escapeshellarg("/home/fpp/media/upload/$baseFile") . " 2>&1";
  ```

  Previously:

  ```php
  $command = "sudo wget -c --quiet --show-progress --progress=dot:giga " . $url . " -O /home/fpp/media/upload/$baseFile 2>&1";
  ```

  `escapeshellarg()` single-quotes the URL and the destination; `wget 'https://…'` is semantically identical for legitimate URLs but neutralizes `;`, `|`, `&`, `` ` ``, `$(…)`, `>`, etc. as literals. Destination is also quoted even though `$baseFile` is already whitelisted (`^[a-zA-Z0-9._-]+$`).

No change to `UpgradeSource` mirror selection, `keepOptFPP` / `wrapped` / `downloadOnly` / progress dialog (`ParseLastStageMarker`) or `upgradeOS-part1.sh` invocation.

## Why this is non-breaking

* **Legitimate URLs** (`https://github.com/FalconChristmas/fpp/releases/download/…/FPP_OS_v8.5.img`) pass `FILTER_VALIDATE_URL` + `https?` and are single-quoted — `wget 'https://…'` is correct and was verified live.
* **Local-file upgrades** (`os=localfile.img`, `about.php:1047`) never enter the `^https?:` branch; `file_exists("/home/fpp/media/upload/$baseFile")` path unchanged.
* **Mirror URLs** (`http://<fppUrlHost>/api/file/uploads/<baseFile>`) are `http` + validated + quoted; `fppUrlHost()` IPv6 bracketing preserved.
* `FILTER_VALIDATE_URL` intentionally **does not** block `;`/`|`/`$()` (all RFC-valid in a path) — the test `php -r 'var_dump(filter_var("https://evil.com/a;id", FILTER_VALIDATE_URL));'` still returns the string. Escaping, not filtering, is the security boundary.
* `isset()` guard avoids a PHP notice when `os` is absent — strictly more permissive than before.

## Testing

### Static

* `php -l www/upgradeOS.php` — `No syntax errors` (local + remote).
* `php -r` unit checks on-box — `escapeshellarg("https://evil.com/a; touch /tmp/pwned")` → `'https://evil.com/a; touch /tmp/pwned'` (semicolon literal inside quotes); `escapeshellarg('https://evil.com/a$(id)')` → `'https://evil.com/a$(id)'`; `htmlspecialchars('" onload="alert(1)', ENT_QUOTES)` → `&quot; onload=&quot;…`.

### Live on `Pi 4B` (`FPP-TEST`, `FPP_OS_v2026-08`, `http://192.168.2.222/upgradeOS.php`)

Deployed fixed file to `/opt/fpp/www/upgradeOS.php` (`md5 da7158e71ee8a200aa34bae785570e86` matches local) and exercised via `curl` + `ssh`:

| Case | Request | Result |
|---|---|---|
| **Valid GitHub URL** `https://github.com/FalconChristmas/fpp/releases/download/v8.5/FPP_OS_v8.5.img` `downloadOnly=1` | `curl "…/upgradeOS.php?wrapped=1&downloadOnly=1&os=https://github.com/…/FPP_OS_v8.5.img"` | `Running command: sudo wget … 'https://github.com/…' -O '/home/fpp/media/upload/FPP_OS_v8.5.img'` — **PASS** quoted, would download |
| **Valid `https://example.com/test.img` `downloadOnly=1`** | same | **PASS** quoted, 20× retry then `Download aborted!` (404) + log `Downloading https://example.com/test.img` — no reboot (`$applyUpdate=false`) |
| **No-space injection** `https://evil.com/a;touch/tmp/pwned_enc2` (basename `pwned_enc2` **passes** old regex, `filter` **passes**) | `curl "…&os=https://evil.com/a;touch/tmp/pwned_enc2"` | `Running command: sudo wget … 'https://evil.com/a;touch/tmp/pwned_enc2' -O '/home/fpp/media/upload/pwned_enc2'` — wget literal, `ls /tmp/pwned_enc2` **missing** — **PASS** (unescaped `;` would have split) |
| **Spaced injection** `https://evil.com/a;touch /tmp/pwned_http_simple` (`%20`) | same | `Invalid OS URL` (space → `filter` rejects) + `ls` missing — **PASS** |
| **Encoded `;touch%20`** | same | `Invalid OS URL` — **PASS** |
| **SSRF `ftp://evil.com/file`** | `curl "…&os=ftp://evil.com/file"` | Skips `https?` branch → `File does not exist …/upload/file` / `Skipping update` — no `wget`/`curl` to `ftp` — **PASS** |
| **Local file** `localtest.img` (touch then `os=localtest.img`) | `curl "…&os=localtest.img"` | `File is empty, aborting …/localtest.img` — no wget — **PASS** non-breaking for `about.php` local-file flow |
| **XSS** `test.img" onload="alert(1)` | `curl` | `Invalid OS filename` (basename fails) — no display; `htmlspecialchars` verified via `php -r` (`&quot;`) |
| **Shell unit** `echo $(touch /tmp/pwned)` escaped vs unescaped | `php /tmp/test.php` on-box | Escaped `echo 'https://…; touch …'` leaves literal, `ls` missing — **PASS**; unescaped `echo https://…; touch …` **does** create file — confirms vulnerability + fix |

Logs (`/home/fpp/media/logs/fpp_system_upgrades.log`) show `Downloading https://example.com/test.img (attempt N of 20)` and quoted `wget rc=` lines. No `/tmp/pwned*` artifacts remain after cleanup.

## Checklist

- [x] No API/URL contract change — `?os=` still accepts `https://…` URLs and bare filenames; `UpgradeSource` mirror logic untouched
- [x] `escapeshellarg()` on **both** URL and destination (defense in depth)
- [x] `FILTER_VALIDATE_URL` + scheme allowlist (`http`/`https` only) on all shell-adjacent paths including `downloadImage()` and mirror loop
- [x] `htmlspecialchars(…, ENT_QUOTES)` for display; `isset()` guard added
- [x] `php -l` clean, manual + live `curl`/`ssh` verification on real FPP hardware
- [x] No config/migration needed