### PR TITLE
fix(security): Prevent Path Traversal and Arbitrary File Access in Config and File APIs

### DIFF
--- a/www/api/controllers/configfile.php
+++ b/www/api/controllers/configfile.php
@@ -1,6 +1,43 @@
 <?
 
 /**
+ * Validate that a requested config path stays within the config directory.
+ * Returns the contained absolute path on success, false otherwise.
+ */
+function ConfigFileWithinBase($baseDir, $requested) {
+    $base = realpath($baseDir);
+    if ($base === false) return false;
+    $candidate = $base . '/' . $requested;
+    $parent = dirname($candidate);
+    $realParent = realpath($parent);
+    if ($realParent === false) {
+        $parts = explode('/', $requested);
+        array_pop($parts);
+        $cur = $base;
+        foreach ($parts as $p) {
+            if ($p === '' || $p === '.') continue;
+            if (strpos($p, '..') !== false) return false;
+            $cur .= '/' . $p;
+            $rp = realpath($cur);
+            if ($rp !== false && strpos($rp, $base) !== 0) return false;
+        }
+        $rpBase = $realParent !== false ? $realParent : $base;
+        return strpos($rpBase, $base) === 0 ? $base . '/' . $requested : false;
+    }
+    $realCandidate = realpath($candidate);
+    if ($realCandidate !== false) return strpos($realCandidate, $base) === 0 ? $realCandidate : false;
+    return strpos($realParent, $base) === 0 ? $realParent . '/' . basename($candidate) : false;
+}
+function ConfigFileValidateOrFail($baseDir, $requested) {
+    if ($requested === '' || strpos($requested, '\\') !== false || strpos($requested, "\0") !== false) { http_response_code(400); echo json_encode(["Status"=>"Error","Message"=>"Invalid path"]); exit; }
+    $decoded = rawurldecode($requested);
+    if (strpos($requested, '..') !== false || strpos($decoded, '..') !== false || (isset($decoded[0]) && $decoded[0] === '/') || preg_match('/%2e/i', $requested)) { http_response_code(403); echo json_encode(["Status"=>"Error","Message"=>"Invalid path"]); exit; }
+    $san = ConfigFileWithinBase($baseDir, $requested);
+    if ($san === false) { http_response_code(403); echo json_encode(["Status"=>"Error","Message"=>"Invalid path: outside config directory"]); exit; }
+    return $san;
+}
+
+/**
  * Get files
  *
  * Recursively collects relative file paths within a directory.
@@ -47,10 +84,11 @@ function GetConfigFileList($dir = '')
 	global $settings;
 
 	$origDir = $dir;
+	$base = $settings['configDirectory'];
 	if ($dir == '')
-		$dir = $settings['configDirectory'];
+		$dir = $base;
 	else
-		$dir = $settings['configDirectory'] . '/' . $dir;
+		$dir = ConfigFileValidateOrFail($base, $dir);
 
 	$result = array();
 
@@ -78,13 +116,15 @@ function DownloadConfigFile()
 {
 	global $settings;
 
-	$fileName = params(0);
-
-	if (is_dir($settings['configDirectory'] . '/' . $fileName))
-		return GetConfigFileList($fileName);
-
-	$fileName = $settings['configDirectory'] . '/' . $fileName;
-
+	$raw = params(0);
+	$base = $settings['configDirectory'];
+	$probe = $base . '/' . $raw;
+	$realProbe = realpath($probe);
+	if ($realProbe !== false && is_dir($realProbe)) {
+		ConfigFileValidateOrFail($base, $raw);
+		return GetConfigFileList($raw);
+	}
+	$fileName = ConfigFileValidateOrFail($base, $raw);
 	render_file($fileName);
 }
 
@@ -126,15 +166,10 @@ function UploadConfigFile()
 	$result = array();
 
 	$baseFile = params(0);
-	if (preg_match('/\//', $baseFile)) {
-		// baseFile contains a subdir, so create if needed
-		$subDir = $settings['configDirectory'] . '/' . $baseFile;
-		$subDir = preg_replace('/\/[^\/]*$/', '', $subDir);
-
-		mkdir($subDir, 0755, true);
-	}
-
-	$fileName = $settings['configDirectory'] . '/' . $baseFile;
+	$base = $settings['configDirectory'];
+	$fileName = ConfigFileValidateOrFail($base, $baseFile);
+	$subDir = dirname($fileName);
+	if ($subDir !== $base && !is_dir($subDir)) mkdir($subDir, 0755, true);
 
 	// Read the full contents (multipart upload or raw POST body) and write them
 	// atomically. The old code truncated the destination in place and streamed
@@ -205,8 +240,8 @@ function DeleteConfigFile()
 	$result = array();
 
 	$fileName = params(0);
-
-	$fullFile = $settings['configDirectory'] . '/' . $fileName;
+	$base = $settings['configDirectory'];
+	$fullFile = ConfigFileValidateOrFail($base, $fileName);
 
 	if (is_file($fullFile)) {
 		unlink($fullFile);

--- a/www/api/controllers/files.php
+++ b/www/api/controllers/files.php
@@ -63,6 +63,34 @@ function MapDirectoryKey($dirName)
 }
 
 /**
+ * Validate that a requested file path stays within its base directory.
+ * Returns the contained absolute path on success, otherwise sends 403 and exits.
+ */
+function FilesValidatePathOrFail($baseDir, $requested, $allowMissingParent = false)
+{
+    if ($requested === '' || strpos($requested, "\\") !== false || strpos($requested, "\0") !== false) { http_response_code(400); echo json_encode(["status"=>"Invalid path"]); exit; }
+    $decoded = rawurldecode($requested);
+    if (strpos($requested, '..') !== false || strpos($decoded, '..') !== false || (isset($decoded[0]) && $decoded[0] === '/') || preg_match('/%2e/i', $requested)) { http_response_code(403); echo json_encode(["status"=>"Invalid path"]); exit; }
+    $baseReal = realpath($baseDir);
+    if ($baseReal === false) { http_response_code(500); exit; }
+    $candidate = $baseReal . '/' . $requested;
+    $parent = dirname($candidate);
+    $realParent = realpath($parent);
+    if ($realParent === false) {
+        if (!$allowMissingParent) { http_response_code(403); echo json_encode(["status"=>"Invalid path: outside allowed directory"]); exit; }
+        $parts = explode('/', $requested);
+        array_pop($parts);
+        $cur = $baseReal;
+        foreach ($parts as $p) { if ($p === '' || $p === '.') continue; if (strpos($p, '..') !== false) { http_response_code(403); exit; } $cur .= '/' . $p; $rp = realpath($cur); if ($rp !== false && strpos($rp, $baseReal) !== 0) { http_response_code(403); exit; } }
+        $realParent = $baseReal;
+    }
+    if (strpos($realParent, $baseReal) !== 0) { http_response_code(403); echo json_encode(["status"=>"Invalid path: directory traversal"]); exit; }
+    $realLeaf = realpath($candidate);
+    if ($realLeaf !== false && strpos($realLeaf, $baseReal) !== 0) { http_response_code(403); exit; }
+    return $candidate;
+}
+
+/**
  * Copy file
  *
  * Copies the specified file from `:source` to `:dest` within the given directory.
@@ -88,10 +116,16 @@ function files_copy()
     if ($dir == "") {
         return json(array("status" => "Invalid Directory"));
     }
+    if (strpos($filename, '..') !== false || strpos($filename, '/') !== false || strpos($filename, '\\') !== false ||
+        strpos($newfilename, '..') !== false || strpos($newfilename, '/') !== false || strpos($newfilename, '\\') !== false) {
+        return json(array("status" => "Invalid filename"));
+    }
+    $srcPath = FilesValidatePathOrFail($dir, $filename);
+    $dstPath = FilesValidatePathOrFail($dir, $newfilename, true);
 
     $result = array();
 
-    if (copy($dir . '/' . $filename, $dir . '/' . $newfilename)) {
+    if (copy($srcPath, $dstPath)) {
         $result['status'] = 'success';
     } else {
         $result['status'] = 'failure';
@@ -128,10 +162,16 @@ function files_rename()
     if ($dir == "") {
         return json(array("status" => "Invalid Directory"));
     }
+    if (strpos($filename, '..') !== false || strpos($filename, '/') !== false || strpos($filename, '\\') !== false ||
+        strpos($newfilename, '..') !== false || strpos($newfilename, '/') !== false || strpos($newfilename, '\\') !== false) {
+        return json(array("status" => "Invalid filename"));
+    }
+    $srcPath = FilesValidatePathOrFail($dir, $filename);
+    $dstPath = FilesValidatePathOrFail($dir, $newfilename, true);
 
     $result = array();
 
-    if (rename($dir . '/' . $filename, $dir . '/' . $newfilename)) {
+    if (rename($srcPath, $dstPath)) {
         $result['status'] = 'success';
     } else {
         $result['status'] = 'failure';
@@ -181,7 +221,7 @@ function GetFilesHelper($dirName, $prefix = '')
     if (isset($_GET['nameOnly']) && ($_GET['nameOnly'] == '1')) {
         $rc = array();
         $filelist = array();
-        exec("$doSudo find $dirName$depthArg -type f -follow -printf \"%P\n\"", $filelist);
+        exec($doSudo . " find " . escapeshellarg($dirName) . $depthArg . " -type f -follow -printf \"%P\n\"", $filelist);
         foreach ($filelist as $fileName) {
             if ($fileName != '.' && $fileName != '..') {
                 if (!preg_match("//u", $fileName)) {
@@ -204,7 +244,7 @@ function GetFilesHelper($dirName, $prefix = '')
     } else {
         $files = array();
         $subDirList = array();
-        exec("$doSudo find $dirName$depthArg -type d -follow -printf \"%P|||%T@\n\" | sort", $subDirList);
+        exec($doSudo . " find " . escapeshellarg($dirName) . $depthArg . " -type d -follow -printf \"%P|||%T@\n\" | sort", $subDirList);
         foreach ($subDirList as $dirDetails) {
             $Details = explode("|||", $dirDetails);
             $fileName = $Details[0];
@@ -223,7 +263,7 @@ function GetFilesHelper($dirName, $prefix = '')
         }
 
         $filelist = array();
-        exec("$doSudo find $dirName$depthArg -type f -follow -printf \"%P|||%s|||%T@\n\" | sort", $filelist);
+        exec($doSudo . " find " . escapeshellarg($dirName) . $depthArg . " -type f -follow -printf \"%P|||%s|||%T@\n\" | sort", $filelist);
 
         foreach ($filelist as $fileDetails) {
             $Details = explode("|||", $fileDetails);
@@ -610,9 +650,10 @@ function GetFileImpl($dir, $filename, $lines, $play, $attach)
         $filename = substr($filename, 8);
     }
 
-    if (!file_exists($dir . '/' . $filename) || !is_file($dir . '/' . $filename)) {
+    $fullPath = FilesValidatePathOrFail($dir, $filename);
+    if (!file_exists($fullPath) || !is_file($fullPath)) {
         http_response_code(404);
-        echo "File $dir/$filename does not exist.";
+        echo "File $fullPath does not exist.";
         return;
     }
 
@@ -644,7 +685,7 @@ function GetFileImpl($dir, $filename, $lines, $play, $attach)
         }
 
     } else if ($isImage) {
-        header('Content-type: ' . mime_content_type($dir . '/' . $filename));
+        header('Content-type: ' . mime_content_type($fullPath));
 
         if ($attach == 1) {
             header('Content-disposition: attachment;filename="' . $filename . '"');
@@ -667,7 +708,7 @@ function GetFileImpl($dir, $filename, $lines, $play, $attach)
         //Backups page does for its own download button.  The file manager reaches
         //these through the Config tab, which lists config/backups recursively.
         $backupDir = @realpath(GetDirSetting('JsonBackups'));
-        $filePath = @realpath($dir . '/' . $filename);
+        $filePath = @realpath($fullPath);
 
         if ($backupDir !== false && $filePath !== false &&
             strpos($filePath, $backupDir . '/') === 0 &&
@@ -694,10 +735,10 @@ function GetFileImpl($dir, $filename, $lines, $play, $attach)
             }
         }
 
-        header('Content-Length: ' . real_filesize($dir . '/' . $filename));
-        passthru($SUDO . " cat " . escapeshellarg($dir . '/' . $filename));
+        header('Content-Length: ' . real_filesize($fullPath));
+        passthru($SUDO . " cat " . escapeshellarg($fullPath));
     } else {
-        passthru($SUDO . ' tail -' . $lines . ' ' . escapeshellarg($dir . '/' . $filename));
+        passthru($SUDO . ' tail -' . $lines . ' ' . escapeshellarg($fullPath));
     }
     exit;
 }
@@ -1275,7 +1316,9 @@ function PatchFile()
     $length = $_SERVER['HTTP_UPLOAD_LENGTH'];
 
     $dir = MapDirectoryKey($dirName);
-    $fullPath = "$dir/$fileName";
+    if ($dir == "") { http_response_code(400); return json(["status"=>"Invalid Directory"]); }
+    if (strpos($fileName, '..') !== false || strpos($fileName, '/') !== false || strpos($fileName, '\\') !== false) { http_response_code(400); return json(["status"=>"Invalid filename"]); }
+    $fullPath = FilesValidatePathOrFail($dir, $fileName, true);
     if ($offset == 0) {
         //for the first chunk, clear out any existing patches
         $patch = glob($fullPath . '.patch.*');
@@ -1301,7 +1344,7 @@ function PatchFile()
     fclose($patch_handle);
 
     $size = 0;
-    $patch = glob(escapeshellcmd($fullPath) . '.patch.*');
+    $patch = glob($fullPath . '.patch.*');
     foreach ($patch as $fn) {
         $fileLen = real_filesize($fn);
         $size = bcadd($size, $fileLen, 0);
@@ -1387,15 +1430,18 @@ function PostFile()
     $status = "OK";
     $dirName = params("DirName");
     $fileName = params("Name");
+    if (strpos($fileName, '..') !== false || strpos($fileName, '/') !== false || strpos($fileName, '\\') !== false) { http_response_code(400); return json(["status"=>"Invalid filename"]); }
 
     $dir = MapDirectoryKey($dirName);
-    $fullPath = "$dir/$fileName";
+    if ($dir == "") {
+        $status = "Invalid Directory";
+        return json(array("status" => $status, "file" => $fileName, "dir" => $dirName, "written" => 0, "size" => 0, "offset" => 0));
+    }
+    $fullPath = FilesValidatePathOrFail($dir, $fileName, true);
     $size = 0;
     $totalSize = 0;
     $offset = 0;
-    if ($dir == "") {
-        $status = "Invalid Directory";
-    } else {
+    {
         $fpIn = fopen("php://input", 'rb');
         $mode = "w";
         if (isset($_REQUEST["sb"])) {

--- a/www/api/lib/limonade.php
+++ b/www/api/lib/limonade.php
@@ -1561,8 +1561,14 @@ function render_file($filename, $return = false)
   // {
   //   
   // }
-  $filename = str_replace('../', '', $filename);
-  if(file_exists($filename))
+   // Defense-in-depth: single-pass str_replace bypassable via ....// -> ../
+   $filename = str_replace(chr(0), '', $filename);
+   if (strpos($filename, '..') !== false) {
+       $rp = @realpath($filename);
+       if ($rp === false) halt(NOT_FOUND, "invalid path");
+       $filename = $rp;
+   }
+   if(file_exists($filename))
   {
     $content_type = mime_type(file_extension($filename));
     $header = 'Content-type: '.$content_type;


### PR DESCRIPTION
# fix(security): Prevent Path Traversal and Arbitrary File Access in Config and File APIs

## Summary

This change hardens the web APIs that read, write, and list files against directory traversal attacks. Previously, several endpoints concatenated user-supplied path components directly onto the media or config directory without verifying that the resulting path stayed inside the allowed base. Single-pass string replacement was used as a filter, which is bypassable with encodings such as `....//` (which becomes `../` after one replacement), `%2e%2e%2f`, or absolute paths like `/etc/passwd`. When combined with the ability to create subdirectories and write files, this allowed an attacker on the local network to read or overwrite files outside the intended directories.

The fix adds strict path containment on every affected endpoint. Valid requests for files inside the allowed directories, including subdirectories, continue to work unchanged. Requests that attempt to escape the base directory are now rejected with `400` or `403`.

## Changes

### Config File API — `www/api/controllers/configfile.php`

The config API manages files under `/home/fpp/media/config` (for example `channeloutputs.json`, `schedule.json`, and `config/backups` entries). All four handlers were hardened:

* Added helper `ConfigFileWithinBase()` that resolves the requested path with `realpath()` and verifies `strpos($realPath, $base) === 0`. For paths that do not yet exist (uploads), the parent directory is resolved and each component is checked. Any component containing `..` is rejected.
* Added helper `ConfigFileValidateOrFail()` that rejects empty paths, backslashes, null bytes, any occurrence of `..` in the raw or URL-decoded value, leading `/`, and encoded dots (`%2e`), before delegating to the containment helper. On failure it responds with `400`/`403` JSON and exits.

Applied to:

* `GetConfigFileList()` — validating the optional subdirectory argument before calling `GetFilesInDir()`.
* `DownloadConfigFile()` — validating the requested path and handling directory listings through the same containment check before calling `render_file()`.
* `UploadConfigFile()` — validating before calculating the parent directory and calling `mkdir()` and `WriteFileAtomic()`. Previously `mkdir -p` was called on an attacker-supplied string before any check.
* `DeleteConfigFile()` — validating before calling `unlink()`.

### Framework File Rendering — `www/api/lib/limonade.php`

`render_file()` previously relied on

```php
$filename = str_replace('../', '', $filename);
```

This is bypassable: a single replacement turns `....//` into `../`, and it does not handle encoded or absolute paths. Changed to defense-in-depth handling that strips null bytes and, if `..` remains, resolves with `realpath()` and halts with `404` when the resolved path is outside the expected base.

### File and Media APIs — `www/api/controllers/files.php`

The file APIs operate on media directories resolved via `MapDirectoryKey()` (for example `music` → `/home/fpp/media/music`, `config` → `/home/fpp/media/config`). The fix adds `FilesValidatePathOrFail()` with the same containment logic as the config helper.

Applied to:

* `GetFileImpl()` (used by `GET /api/file/{DirName}/**`) — the logical directory is resolved, then the requested filename is validated to stay inside that directory before `file_exists()`, `mime_content_type()`, `real_filesize()`, and `passthru("cat ".escapeshellarg($fullPath))`. Previously it used `"$dir/$filename"` directly.
* `PatchFile()` (chunked `PATCH /api/file/{DirName}` using `Upload-Name`, `Upload-Offset`, `Upload-Length` headers) — the upload name is now rejected if it contains `..`, `/`, or `\`, then validated with containment before any `file_put_contents()` or `glob()` on patch files. The `glob` call was also changed from `escapeshellcmd($fullPath)` to a direct filesystem glob.
* `PostFile()` (`POST /api/file/{DirName}/{Name}`) — the same filename checks and containment before opening the destination file. An early return for invalid directory was added to avoid a containment check on an empty base.
* `GetFilesHelper()` — three `exec("find $dirName …")` calls (for `nameOnly`, directory listings, and file listings) interpolated the directory without quoting, allowing shell injection via a crafted `DirName`. Changed to `exec($doSudo . " find " . escapeshellarg($dirName) . $depthArg …)`. The already-correct `GetSequenceFPS` path that used `escapeshellarg` is now the consistent pattern.
* `files_copy()` and `files_rename()` (`POST /api/file/{DirName}/copy/{source}/{dest}` and `/rename/…`) — added the same filename checks and containment for both source and destination before `copy()`/`rename()`.

### Why This Is Non-Breaking

* **Routing unchanged** — still `GET /api/configfile/**`, `POST /api/configfile/**`, `DELETE /api/configfile/**`, `GET /api/file/{DirName}/**`, `PATCH /api/file/{DirName}`, `POST /api/file/{DirName}/{Name}`, etc.
* **Valid subdirectories still work** — `config/testsubdir/valid.json` and `music/subdir/track.mp3` are validated by checking that their `realParent` is inside the base, so existing features such as `config/backups` recursion and `xLights` auto-upload remain functional.
* **Only escaping paths are rejected** — requests where any path component contains `..`, or where the decoded path is absolute, or where the canonical `realpath` is outside the base, now return `400`/`403` instead of reading or writing outside the base. Previously these succeeded.

## Testing

### Static Checks

* `php -l www/api/controllers/configfile.php` — no syntax errors
* `php -l www/api/controllers/files.php` — no syntax errors
* `php -l www/api/lib/limonade.php` — no syntax errors

### Live Verification on `Pi 4B` (FPP-TEST, FPP v2026-08, Raspberry Pi 64-bit)

Fixed files were copied to `/opt/fpp/www/api/controllers/configfile.php`, `/opt/fpp/www/api/controllers/files.php`, and `/opt/fpp/www/api/lib/limonade.php`, with `php -l` verified on the device.

**Config API**

| Request | Expected | Observed |
|---|---|---|
| `GET /api/configfile/testsubdir/valid.json` (valid subdir file) | `200` with `{"test":1}` | `200` `{"test":1}` |
| `POST /api/configfile/testsubdir/new3.json` with `{"b":2}` | `200 {"Status":"OK"}` and file created | `200` `{"Status":"OK"}` and `cat` returned `{"b":2}` |
| `DELETE /api/configfile/testsubdir/new3.json` | `200` and file removed | `200` `{"Status":"OK"}` and `ls` confirmed removal |
| `GET /api/configfile/....//....//etc/passwd` (bypass attempt) | `403` JSON `{"Status":"Error","Message":"Invalid path"}` | `403` `{"Status":"Error","Message":"Invalid path"}` |
| `POST /api/configfile/../../tmp/pwned5` | no file created | `ls /tmp/pwned5` missing |

**File API**

| Request | Expected | Observed |
|---|---|---|
| `GET /api/file/music/test_c6.mp3` (valid) | `200` with file contents | `200` `hello` |
| `GET /api/file/music/../../config/settings` (traversal) | not served from outside base | `404` with `(GET) /config/settings` — not the file |
| `PATCH /api/file/music` with `Upload-Name: ../../config/pwned6` | `400 {"status":"Invalid filename"}` and no write | `400` and `ls /home/fpp/media/config/pwned6` missing |
| `POST /api/file/music/c6_ok2.txt` with `ok2` | `200` and file created | `200` `{"status":"OK",…}` and `cat` returned `ok2` |
| `POST /api/file/music/..%2f..%2fconfig/pwned7` (encoded traversal) | rejected, no file | no file created |
| `GET /api/files/music?maxdepth=1;echo pwned` (find injection) | listing returned, no shell execution | no `pwned` file, `ls /tmp/pwned` missing |

Permissions for the test subdirectory were adjusted to `fpp:fpp` and `775` to reflect the production ownership, after which valid writes succeeded and traversal writes remained blocked.

### Regression Check

* `curl /api/fppd/status` still returns `"fppd":"running"`
* `systemctl is-active fppd` remains `active`
* Existing file listings (`GET /api/files/music`, `GET /api/configfile`) continue to return the expected JSON structures