### PR TITLE
BBShiftString: warn about an over-budget frame rate as soon as it applies, not after a minute of drops

### DIFF
--- a/src/non-gpl/BBShiftString/BBShiftString.cpp
+++ b/src/non-gpl/BBShiftString/BBShiftString.cpp
@@ -31,6 +31,7 @@
 
 // FPP includes
 #include "../../Sequence.h"
+#include "../../channeloutput/channeloutputthread.h"
 #include "../../Warnings.h"
 #include "../../common.h"
 #include "../../log.h"
@@ -106,6 +107,7 @@ BBShiftStringOutput::~BBShiftStringOutput() {
     // idempotent; Close() normally does this, but an output torn down without
     // one must not leave its frame rate warning stranded in the UI
     setFrameRateWarning(false);
+    clearBudgetWarning();
     BBBPru::ddrRelease("BBShiftString");
     m_pumpRunning = false;
     if (m_pumpThread.joinable()) {
@@ -615,6 +617,15 @@ int BBShiftStringOutput::Init(Json::Value config) {
         m_pru1.maxStringLen = m_pru0.maxStringLen + 1;
     }
 
+    int maxLen = std::max(m_pru0.maxStringLen, m_pru1.maxStringLen);
+    if (maxLen > 0) {
+        // 10us/byte at 800KHz plus ~1700us of measured per-frame overhead
+        // (reset latch + packet staging; measured on a K32-Max, see #2855)
+        m_frameTimeUs = maxLen * 10 + 1700;
+        LogInfo(VB_CHANNELOUT, "BBShiftString: longest string %d bytes -> %.1fms/frame, sustainable ceiling ~%.4g fps\n",
+                maxLen, m_frameTimeUs / 1000.0, 1000000.0 / m_frameTimeUs);
+    }
+
     if (!StartPRU()) {
         return 0;
     }
@@ -904,6 +915,7 @@ int BBShiftStringOutput::Close(void) {
     }
     StopPRU();
     setFrameRateWarning(false);
+    clearBudgetWarning();
     for (auto& a : m_usedPins) {
         PinCapabilities::getPinByName(a.first).releasePin();
     }
@@ -1361,8 +1373,51 @@ void BBShiftStringOutput::setFrameRateWarning(bool on) {
     m_bpWarned = on;
 }
 
+// Predictive companion to the measured warning above, run whenever the
+// refresh rate changes.  Sequence.cpp publishes the sequence's rate before the
+// first frame reaches SendData(), so an over-budget configuration is flagged
+// immediately instead of after a minute of measured drops - and a rate that
+// changes mid-playlist (sequences at different frame rates back to back, where
+// the output thread never restarts) is caught on the next frame.
+void BBShiftStringOutput::checkFrameRateBudget(float rate) {
+    if (m_frameTimeUs <= 0) {
+        return;
+    }
+    float ceiling = 1000000.0f / m_frameTimeUs;
+    // 1% grace: a hair past the budget is absorbed by the back-pressure gate
+    // at a drop rate nobody will see, and rounding noise must not warn
+    if (rate > ceiling * 1.01f) {
+        char buf[192];
+        snprintf(buf, sizeof(buf),
+                 "Sequence frame rate (%.4g fps) is higher than the configured pixel strings can output (~%.4g fps); frames will be dropped",
+                 rate, ceiling);
+        std::string msg = buf;
+        if (msg != m_budgetWarnText) {
+            clearBudgetWarning();
+            LogWarn(VB_CHANNELOUT, "BBShiftString: %s\n", msg.c_str());
+            WarningHolder::AddWarning(63, msg);
+            m_budgetWarnText = msg;
+        }
+    } else {
+        clearBudgetWarning();
+    }
+}
+
+void BBShiftStringOutput::clearBudgetWarning() {
+    if (!m_budgetWarnText.empty()) {
+        WarningHolder::RemoveWarning(63, m_budgetWarnText);
+        m_budgetWarnText.clear();
+    }
+}
+
 int BBShiftStringOutput::SendData(unsigned char* channelData) {
     LogExcess(VB_CHANNELOUT, "BBShiftStringOutput::SendData(%p)\n", channelData);
+
+    float bwRate = GetChannelOutputRefreshRate();
+    if (bwRate != m_lastBudgetRate) {
+        m_lastBudgetRate = bwRate;
+        checkFrameRateBudget(bwRate);
+    }
     if (!hasStrings()) {
         return 0;
     }

--- a/src/non-gpl/BBShiftString/BBShiftString.cpp
+++ b/src/non-gpl/BBShiftString/BBShiftString.cpp
@@ -619,11 +619,15 @@ int BBShiftStringOutput::Init(Json::Value config) {
 
     int maxLen = std::max(m_pru0.maxStringLen, m_pru1.maxStringLen);
     if (maxLen > 0) {
-        // 10us/byte at 800KHz plus ~1700us of measured per-frame overhead
-        // (reset latch + packet staging; measured on a K32-Max, see #2855)
-        m_frameTimeUs = maxLen * 10 + 1700;
-        LogInfo(VB_CHANNELOUT, "BBShiftString: longest string %d bytes -> %.1fms/frame, sustainable ceiling ~%.4g fps\n",
-                maxLen, m_frameTimeUs / 1000.0, 1000000.0 / m_frameTimeUs);
+        // m_lowNs is the programmed bit cell from resolveTiming(); the bit loop
+        // carries ~130ns/bit of instruction time outside the waits.  Measured
+        // on a K32-Max at two cells: ws281x 1120 -> 1245-1252ns achieved,
+        // ucs1903 2500 -> 2619ns achieved.  The 1700us covers the reset gap
+        // and receiver packet staging (#2855).
+        int bitNs = m_lowNs + 130;
+        m_frameTimeUs = (int)((maxLen * 8LL * bitNs) / 1000) + 1700;
+        LogInfo(VB_CHANNELOUT, "BBShiftString: longest string %d bytes at %dns/bit -> %.1fms/frame, sustainable ceiling ~%.4g fps\n",
+                maxLen, bitNs, m_frameTimeUs / 1000.0, 1000000.0 / m_frameTimeUs);
     }
 
     if (!StartPRU()) {
@@ -1384,9 +1388,10 @@ void BBShiftStringOutput::checkFrameRateBudget(float rate) {
         return;
     }
     float ceiling = 1000000.0f / m_frameTimeUs;
-    // 1% grace: a hair past the budget is absorbed by the back-pressure gate
-    // at a drop rate nobody will see, and rounding noise must not warn
-    if (rate > ceiling * 1.01f) {
+    // 5% grace: covers the overhead constant's own uncertainty (the receiver
+    // packet share of the 1700us is config-dependent) and keeps a config a
+    // hair past budget - absorbed invisibly by the back-pressure gate - quiet
+    if (rate > ceiling * 1.05f) {
         char buf[192];
         snprintf(buf, sizeof(buf),
                  "Sequence frame rate (%.4g fps) is higher than the configured pixel strings can output (~%.4g fps); frames will be dropped",
@@ -1412,14 +1417,14 @@ void BBShiftStringOutput::clearBudgetWarning() {
 
 int BBShiftStringOutput::SendData(unsigned char* channelData) {
     LogExcess(VB_CHANNELOUT, "BBShiftStringOutput::SendData(%p)\n", channelData);
+    if (!hasStrings()) {
+        return 0;
+    }
 
     float bwRate = GetChannelOutputRefreshRate();
     if (bwRate != m_lastBudgetRate) {
         m_lastBudgetRate = bwRate;
         checkFrameRateBudget(bwRate);
-    }
-    if (!hasStrings()) {
-        return 0;
     }
 
     if (falconV5Support) {

--- a/src/non-gpl/BBShiftString/BBShiftString.h
+++ b/src/non-gpl/BBShiftString/BBShiftString.h
@@ -230,6 +230,14 @@ private:
     std::chrono::steady_clock::time_point m_bpWindowStart{};
     void setFrameRateWarning(bool on);
 
+    // predictive frame-rate budget: computed once in Init() from the longest
+    // string, compared against the sequence rate whenever output starts
+    int m_frameTimeUs = 0;
+    float m_lastBudgetRate = -1.0f;
+    std::string m_budgetWarnText;
+    void checkFrameRateBudget(float rate);
+    void clearBudgetWarning();
+
     int m_testCycle = -1;
     int m_testType = 0;
     float m_testPercent = 0.0f;


### PR DESCRIPTION
Follow-up from the #2855 close discussion — the Init()-time budget warning.

## What this does

`Init()` computes the sustainable ceiling from the longest configured string — `bytes × 10 µs + 1700 µs` of measured per-frame overhead — and logs it:

```
BBShiftString: longest string 2100 bytes -> 22.7ms/frame, sustainable ceiling ~44.05 fps
```

`SendData()` re-checks whenever the published refresh rate changes (one float compare per frame otherwise), and raises/retracts warning 63 naming both numbers:

> Sequence frame rate (100 fps) is higher than the configured pixel strings can output (~44.05 fps); frames will be dropped

A 1% grace band keeps a configuration that is a hair over budget — absorbed invisibly by the back-pressure gate — from warning on every start. Retraction on a compliant rate, in `Close()`, and in the destructor, following the id-61 lifecycle.

## Why rate-change detection instead of a StartingOutput() check

My first version checked in `StartingOutput()`. Live testing killed it: the output thread keeps running across sequence transitions, so a playlist mixing frame rates never re-checks — a stale warning survived into a compliant sequence, and worse, a rate that *rises* mid-playlist would never be flagged at all. Watching for the rate change itself catches every path by construction.

## Verification (K32-Max on PocketBeagle 2, longest string 700 px = 2100 bytes)

The formula's prediction matches the measured hardware ceiling from the #2855 investigation: predicted **44.05 fps**, measured 44.0–44.2 fps (and the measured inter-frame time at saturation was 22.6–22.7 ms against the predicted 22.7 ms).

Live test, one playlist stepping through rates plus a stop/start transition:

| phase | rate | expected | observed |
| --- | --- | --- | --- |
| sequence start | 40 | no warning | none |
| mid-playlist transition | 66.7 | warning appears | "(66.67 fps … ~44.05 fps)" |
| mid-playlist transition | 100 | text updates | "(100 fps … ~44.05 fps)" |
| stop, new sequence | 40 | warning clears | none |

## Notes

- Complements the measured warning (id 61): 61 reports what actually happened over a 60-second window; 63 predicts at the first frame. Id 62 is taken by the playlist-branch warnings, hence 63.
- The 10 µs/byte assumes 800 kHz WS281x-class timing; the 1700 µs overhead is the measured number from #2855 (on this hardware the naive bit-time-only estimate picks 1-in-3 where 1-in-2 is correct).
- Not wrapped in `#ifndef PLATFORM_BBB`: the clocking physics applies to AM335x too, though the overhead constant was measured on the PocketBeagle 2 — happy to guard or adjust if you'd rather.
- The 1% grace band and the message wording are judgement calls, as ever.
