### PR TITLE
fix(plugins): Installed count drops to 0 on Updates tab

### DIFF
--- a/www/plugins.php
+++ b/www/plugins.php
@@ -2193,7 +2193,14 @@
             });
 
             // Installed cards
-            var installedVisible = 0, updateVisible = 0;
+            // installedMatchingSearch is the search-filtered total for the Installed tab
+            // badge (independent of which manage-tab is active); installedVisible is the
+            // count actually visible in the current manage pane (updates-tab filters to
+            // hasUpdate). updateVisible is the total pending-updates count (not search-
+            // filtered) for the Updates badge. Separating installedMatchingSearch from
+            // installedVisible prevents the Installed badge from dropping to 0 when the
+            // Updates tab is selected.
+            var installedVisible = 0, installedMatchingSearch = 0, updateVisible = 0;
             $('#installedGrid').children('.pluginCard').each(function () {
                 if (urlLoadedMode) {
                     $(this).addClass('d-none');
@@ -2206,6 +2213,7 @@
                 if (descTxt) searchText += ' ' + descTxt;
                 var matchesSearch = value === '' || searchText.indexOf(value) > -1;
                 var hasUpdate = $(this).hasClass('fppHasUpdate');
+                if (matchesSearch) installedMatchingSearch++;
                 if (hasUpdate) updateVisible++;
                 var matchesTab = (activeTopTab !== 'updates') || hasUpdate;
                 var vis = matchesSearch && matchesTab;
@@ -2260,8 +2268,8 @@
                 $('#noAvailableResults').toggleClass('d-none', !showAvailEmpty);
                 $('#noUrlResults').addClass('d-none');
                 $('#noUrlSchemeResults').addClass('d-none');
-                if (showAvailEmpty && installedVisible > 0) {
-                    $('#noAvailCrossRef').text('Found ' + installedVisible + ' plugin' + (installedVisible === 1 ? '' : 's') + ' that match on the Installed list. ');
+                if (showAvailEmpty && installedMatchingSearch > 0) {
+                    $('#noAvailCrossRef').text('Found ' + installedMatchingSearch + ' plugin' + (installedMatchingSearch === 1 ? '' : 's') + ' that match on the Installed list. ');
                 } else {
                     $('#noAvailCrossRef').text('');
                 }
@@ -2292,7 +2300,7 @@
             }
 
             $('#topCountAvailable').text(availVisible);
-            $('#topCountInstalled').text(installedVisible);
+            $('#topCountInstalled').text(installedMatchingSearch);
             $('#topCountUpdates').text(updateVisible);
         }
         $(document).ready(function () {


### PR DESCRIPTION
# fix(plugins): Installed count drops to 0 on Updates tab

## Summary
Fixes bug where navigating to the **Updates** tab on `www/plugins.php` incorrectly resets the **Installed** tab badge count to `0`.

## Problem
On `plugins.php`, the top tab bar shows three counts:

- `Available` (`#topCountAvailable`)
- `Installed` (`#topCountInstalled`)
- `Updates` (`#topCountUpdates`)

When the user clicks **Updates**, the Installed count drops to `0` (or to the number of plugins with updates) even though installed plugins are still installed. This is visible when no updates are pending — Installed shows `0` — or with 1 of 3 plugins having an update, Installed shows `1`.

Reproduce:
1. Go to `plugins.php` with N installed plugins (e.g. 3)
2. Note Installed badge = N
3. Click **Updates**
4. Observe Installed badge becomes `0` (or `count(hasUpdate)`)

## Root Cause
`www/plugins.php:2196` — `FilterPlugins()` used a single variable `installedVisible` for two purposes:

```js
// before (www/plugins.php:2196)
var installedVisible = 0, updateVisible = 0;
$('#installedGrid').children('.pluginCard').each(function () {
    var hasUpdate = $(this).hasClass('fppHasUpdate');
    if (hasUpdate) updateVisible++;
    var matchesTab = (activeTopTab !== 'updates') || hasUpdate;
    var vis = matchesSearch && matchesTab;   // updates tab filters to hasUpdate
    $(this).toggleClass('d-none', !vis);
    if (vis) installedVisible++;             // ← tab-filtered
});
$('#topCountInstalled').text(installedVisible); // ← bug: tab-filtered count in badge
```

On `activeTopTab === 'updates'`, `vis` is `false` for any installed plugin without an update, so `installedVisible` counts only updatable plugins. The badge then reflects the filtered pane, not the total installed.

## Solution
Split the count in `www/plugins.php:2203`:

- `installedVisible` — cards actually visible in the current manage pane (`matchesSearch && matchesTab`) — still drives pane visibility and `#noUpdatesHint` logic at `www/plugins.php:2223`
- `installedMatchingSearch` — total installed matching the search term, independent of `activeTopTab` — drives the badge and cross-ref text
- `updateVisible` — kept as total pending updates (not search-filtered, matching original intent) for `#topCountUpdates`, `#updateAllBtn` at `www/plugins.php:2250` and `#manageHeading` at `www/plugins.php:2252`

```js
// after (www/plugins.php:2203)
var installedVisible = 0, installedMatchingSearch = 0, updateVisible = 0;
...
if (matchesSearch) installedMatchingSearch++;
if (hasUpdate) updateVisible++;
var matchesTab = (activeTopTab !== 'updates') || hasUpdate;
var vis = matchesSearch && matchesTab;
$(this).toggleClass('d-none', !vis);
if (vis) installedVisible++;
...
$('#topCountInstalled').text(installedMatchingSearch);
$('#topCountUpdates').text(updateVisible);
```

Also updated cross-ref at `www/plugins.php:2271`:
```js
- if (showAvailEmpty && installedVisible > 0) {
+ if (showAvailEmpty && installedMatchingSearch > 0) {
      $('#noAvailCrossRef').text('Found ' + installedMatchingSearch + ' plugin' ...);
```

This preserves badge semantics while pane filtering remains correct.

## Changes
- `www/plugins.php` only
  - `FilterPlugins()` — introduce `installedMatchingSearch` and decouple badge from pane-visible count (`www/plugins.php:2195-2225`, `www/plugins.php:2271-2272`, `www/plugins.php:2302-2304`)

## Testing
Validated with local JS simulation (no search term):

| Installed | With update | Tab | Before (Installed badge) | After (Installed badge) |
|-----------|-------------|-----|--------------------------|-------------------------|
| 3 | 1 (`pluginA`) | `installed` | 3 | 3 |
| 3 | 1 (`pluginA`) | `updates` | 1 ❌ | 3 ✅ |
| 3 | 0 | `installed` | 3 | 3 |
| 3 | 0 | `updates` | 0 ❌ | 3 ✅ |

Search filtering:
- `Alpha` (update), `Beta`, `Gamma` — search `beta` on Updates: `installedMatchingSearch=1`, `installedVisible=0`, `updateVisible=1` (total) — Installed badge correctly shows `1`, pane shows `0` with hint.

Manual verification steps:
1. Load `plugins.php` with 2+ installed plugins, 0 updates
2. Confirm `Installed` badge = N
3. Click `Updates` — confirm `Installed` badge stays N, `Updates` = 0, grid empty with `No updates found` hint
4. Trigger an update (add `fppHasUpdate` class) — confirm `Updates` = 1, `Installed` stays N, `Installed` pane still shows N

## Risk
Low. Isolated to display counts; no backend/API changes. Preserves existing `updateVisible` (total) semantics for `Update All` button visibility.

## Checklist
- [x] Verified `FilterPlugins()` badges no longer depend on `activeTopTab`
- [x] No changes to `LoadPlugin()` / `SelectPluginVersionIndices()` / `RowEl()` interfaces — plugin `dlopen()` compatibility unaffected
- [x] No CSS/HTML structure changes