### PR TITLE
fix(security): harden MultiSync rsync + storage scripts against shell injection

### DIFF
--- a/scripts/copy_settings_to_storage.sh
+++ b/scripts/copy_settings_to_storage.sh
@@ -7,7 +7,46 @@ COMPRESS=$5 # Whether data is sent compressed to spend up network transfers
 DELETE=$6
 shift 6
 
-BASEDIRECTION=$(echo $DIRECTION | cut -c1-4)
+# Validate DIRECTION — strict enum to prevent injection of shell flags.
+if ! [[ "$DIRECTION" =~ ^(TOUSB|FROMUSB|TOLOCAL|FROMLOCAL|TOREMOTE|FROMREMOTE)$ ]]; then
+    echo "Invalid direction: $DIRECTION" >&2
+    exit 1
+fi
+# Validate COMPRESS/DELETE — only yes/no.
+if ! [[ "$COMPRESS" =~ ^(yes|no)$ ]]; then COMPRESS="no"; fi
+if ! [[ "$DELETE" =~ ^(yes|no)$ ]]; then DELETE="no"; fi
+# Validate DPATH — only allow safe backup folder names (no "..", no shell metachars).
+# Empty DPATH is allowed (means root of USB/backups).
+if [[ "$DPATH" == *".."* ]] || [[ "$DPATH" == *";"* ]] || [[ "$DPATH" == *"&"* ]] || [[ "$DPATH" == *"|"* ]] || [[ "$DPATH" == *"\`"* ]] || [[ "$DPATH" == *'$'* ]]; then
+    echo "Invalid path: $DPATH" >&2
+    exit 1
+fi
+if [[ -n "$DPATH" ]] && ! [[ "$DPATH" =~ ^[A-Za-z0-9._/-]*$ ]]; then
+    echo "Invalid path: $DPATH" >&2
+    exit 1
+fi
+# Validate DEVICE and RSTORAGE per direction.
+# For USB directions DEVICE is a block device (sda1, mmcblk0p1, nvme0n1p1); for REMOTE it's IP/hostname.
+is_block_device() { [[ "$1" =~ ^(sd[a-z][0-9]+|mmcblk[0-9]+p[0-9]+|nvme[0-9]+n[0-9]+p[0-9]+)$ ]]; }
+is_host() { [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]] || [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$1" =~ ^[0-9a-fA-F:]+$ ]]; }
+if [[ "$DIRECTION" == "TOUSB" || "$DIRECTION" == "FROMUSB" ]]; then
+    if ! is_block_device "$DEVICE"; then
+        echo "Invalid device: $DEVICE" >&2
+        exit 1
+    fi
+elif [[ "$DIRECTION" == "TOREMOTE" || "$DIRECTION" == "FROMREMOTE" ]]; then
+    if ! is_host "$DEVICE"; then
+        echo "Invalid remote host: $DEVICE" >&2
+        exit 1
+    fi
+    if [[ -n "$RSTORAGE" && "$RSTORAGE" != "none" ]] && ! is_block_device "$RSTORAGE"; then
+        echo "Invalid remote storage: $RSTORAGE" >&2
+        exit 1
+    fi
+fi
+# TOLOCAL/FROMLOCAL use DPATH only, DEVICE is ignored — no check needed.
+
+BASEDIRECTION=$(echo "$DIRECTION" | cut -c1-4)
 REMOTE_COMPRESS=""
 
 IgnoreWarnings() {
@@ -15,7 +54,7 @@ IgnoreWarnings() {
 }
 
 if [ "$DIRECTION" == "TOUSB" -o "$DIRECTION" == "FROMUSB" ]; then
-    FSTYPE=$(file -sL /dev/$DEVICE)
+    FSTYPE=$(file -sL -- "/dev/$DEVICE")
     EXTRA_ARGS=""
 
     # FAT/exFAT have no on-disk ownership, so it must be set at mount time to match
@@ -25,68 +64,93 @@ if [ "$DIRECTION" == "TOUSB" -o "$DIRECTION" == "FROMUSB" ]; then
     FPP_UID=$(id -u fpp)
     FPP_GID=$(id -g fpp)
 
-    mkdir -p /tmp/smnt
+    mkdir -p -- /tmp/smnt
     if [[ "$FSTYPE" =~ "BTRFS" ]]; then
-        mount -t btrfs -o noatime,nodiratime,compress=zstd,nofail /dev/$DEVICE /tmp/smnt
+        mount -t btrfs -o noatime,nodiratime,compress=zstd,nofail -- "/dev/$DEVICE" /tmp/smnt
     elif [[ "$FSTYPE" =~ "ext4" ]]; then
-        mount -t ext4 -o noatime,nodiratime,nofail /dev/$DEVICE /tmp/smnt
+        mount -t ext4 -o noatime,nodiratime,nofail -- "/dev/$DEVICE" /tmp/smnt
     elif [[ "$FSTYPE" =~ "FAT" ]]; then
         EXTRA_ARGS="--no-perms"
-        mount -t auto -o noatime,nodiratime,exec,nofail,uid=$FPP_UID,gid=$FPP_GID /dev/$DEVICE /tmp/smnt
+        mount -t auto -o noatime,nodiratime,exec,nofail,uid="$FPP_UID",gid="$FPP_GID" -- "/dev/$DEVICE" /tmp/smnt
     elif [[ "$FSTYPE" =~ "DOS" ]]; then
         EXTRA_ARGS="--no-perms"
-        mount -t auto -o noatime,nodiratime,exec,nofail,uid=$FPP_UID,gid=$FPP_GID /dev/$DEVICE /tmp/smnt
+        mount -t auto -o noatime,nodiratime,exec,nofail,uid="$FPP_UID",gid="$FPP_GID" -- "/dev/$DEVICE" /tmp/smnt
     else
-        mount -t ext4 -o noatime,nodiratime,nofail /dev/$DEVICE /tmp/smnt
+        mount -t ext4 -o noatime,nodiratime,nofail -- "/dev/$DEVICE" /tmp/smnt
     fi
 fi
 
 if [ "$DIRECTION" == "TOUSB" ]; then
     SOURCE=/home/fpp/media
-    DEST=/tmp/smnt/$DPATH
-    mkdir -p $DEST
+    DEST="/tmp/smnt/$DPATH"
+    # Containment: ensure DEST stays under /tmp/smnt
+    DEST_REAL=$(realpath -m -- "$DEST")
+    if [[ "$DEST_REAL" != /tmp/smnt* ]]; then
+        echo "Invalid destination path: $DPATH" >&2
+        exit 1
+    fi
+    DEST="$DEST_REAL"
+    mkdir -p -- "$DEST"
 elif [ "$DIRECTION" == "FROMUSB" ]; then
     DEST=/home/fpp/media
-    SOURCE=/tmp/smnt/$DPATH
+    SOURCE="/tmp/smnt/$DPATH"
+    SOURCE_REAL=$(realpath -m -- "$SOURCE")
+    if [[ "$SOURCE_REAL" != /tmp/smnt* ]]; then
+        echo "Invalid source path: $DPATH" >&2
+        exit 1
+    fi
+    SOURCE="$SOURCE_REAL"
 elif [ "$DIRECTION" == "TOLOCAL" ]; then
     SOURCE=/home/fpp/media
-    DEST=/home/fpp/media/backups/$DPATH
-    mkdir -p $DEST
+    DEST="/home/fpp/media/backups/$DPATH"
+    DEST_REAL=$(realpath -m -- "$DEST")
+    if [[ "$DEST_REAL" != /home/fpp/media/backups* ]]; then
+        echo "Invalid destination path: $DPATH" >&2
+        exit 1
+    fi
+    DEST="$DEST_REAL"
+    mkdir -p -- "$DEST"
 elif [ "$DIRECTION" == "FROMLOCAL" ]; then
-    SOURCE=/home/fpp/media/backups/$DPATH
+    SOURCE="/home/fpp/media/backups/$DPATH"
+    SOURCE_REAL=$(realpath -m -- "$SOURCE")
+    if [[ "$SOURCE_REAL" != /home/fpp/media/backups* ]]; then
+        echo "Invalid source path: $DPATH" >&2
+        exit 1
+    fi
+    SOURCE="$SOURCE_REAL"
     DEST=/home/fpp/media
 elif [ "$DIRECTION" == "TOREMOTE" ]; then
     SOURCE=/home/fpp/media
     # Destination is as normal will go to the specified FPP Storage Device by default
-    DEST=${DEVICE}::media/backups/$DPATH
+    DEST="${DEVICE}::media/backups/$DPATH"
 
     # rsync won't create destination subdirectories for us, so create
     # a temp local subdir tree and sync it over to the remote
-    mkdir -p /home/fpp/media/tmp/backups/$DPATH
+    mkdir -p -- "/home/fpp/media/tmp/backups/$DPATH"
 
     #If a remote storage device has been specified and it's not empty none (which is the default FPP storage), get the remote host to mount it so we can then copy to it
     if [ "$RSTORAGE" != "" ]  && [ "$RSTORAGE" != "none" ]
       then
         # Call the backup API to mount the specified device
         # Build up these variables so the can be called easier (now and unmount at end of script)
-        REMOTE_MOUNT=$(curl --location --request POST -H "Content-Type:application/json" "$DEVICE/api/backups/devices/mount/$RSTORAGE/remote_filecopy")
+        REMOTE_MOUNT=$(curl --location --request POST -H "Content-Type:application/json" -- "$DEVICE/api/backups/devices/mount/$RSTORAGE/remote_filecopy")
         echo " "
         echo -n "Remote Host: $DEVICE reported..."
         echo "$REMOTE_MOUNT" | grep -Po '"Message": *\K"[^"]*"'
         echo " "
         # Remote storage device will be mounted to /mnt/remote_filecopy (at the destination), so adjust the destination to accommodate this.
-        DEST=${DEVICE}::remote_filecopy/$DPATH
+        DEST="${DEVICE}::remote_filecopy/$DPATH"
         # Going to a different storage device so modify the directory and copy over the base directory structure
-        rsync -a /home/fpp/media/tmp/backups/* ${DEVICE}::remote_filecopy 2>&1 | IgnoreWarnings
-        rm -rf /home/fpp/media/tmp/backups
+        rsync -a -- "/home/fpp/media/tmp/backups"/* -- "${DEVICE}::remote_filecopy" 2>&1 | IgnoreWarnings
+        rm -rf -- /home/fpp/media/tmp/backups
     else
         # Not going to a different storage device so copy over the new directory structure as normal (this will go into the specified default FPP Storage)
-        rsync -a /home/fpp/media/tmp/backups/* ${DEVICE}::media/backups/ 2>&1 | IgnoreWarnings
-        rm -rf /home/fpp/media/tmp/backups
+        rsync -a -- "/home/fpp/media/tmp/backups"/* -- "${DEVICE}::media/backups/" 2>&1 | IgnoreWarnings
+        rm -rf -- /home/fpp/media/tmp/backups
     fi
 
 elif [ "$DIRECTION" == "FROMREMOTE" ]; then
-    SOURCE=${DEVICE}::media/backups/$DPATH
+    SOURCE="${DEVICE}::media/backups/$DPATH"
     DEST=/home/fpp/media
 
     #If a remote storage device has been specified and it's not empty none (which is the default FPP storage), get the remote host to mount it so we can then pull from it
@@ -94,13 +158,13 @@ elif [ "$DIRECTION" == "FROMREMOTE" ]; then
       then
         # Call the backup API to mount the specified device
         # Build up these variables so the can be called easier (now and unmount at end of script)
-        REMOTE_MOUNT=$(curl --location --request POST -H "Content-Type:application/json" "$DEVICE/api/backups/devices/mount/$RSTORAGE/remote_filecopy")
+        REMOTE_MOUNT=$(curl --location --request POST -H "Content-Type:application/json" -- "$DEVICE/api/backups/devices/mount/$RSTORAGE/remote_filecopy")
         echo " "
         echo -n "Remote Host: $DEVICE reported..."
         echo "$REMOTE_MOUNT" | grep -Po '"Message": *\K"[^"]*"'
         echo " "
         # Remote storage device will be mounted to /mnt/remote_filecopy (at the destination), so adjust the source (where to pull from) to accommodate this.
-        SOURCE=${DEVICE}::remote_filecopy/$DPATH
+        SOURCE="${DEVICE}::remote_filecopy/$DPATH"
     fi
 
 fi
@@ -115,7 +179,7 @@ if [ "$DELETE" == "yes" ]; then
     EXTRA_ARGS="$EXTRA_ARGS --delete"
 fi
 
-for action in $@; do
+for action in "$@"; do
     echo " "
     echo "Copying $action.... Please wait!"
 
@@ -125,73 +189,73 @@ for action in $@; do
         # machine's own backups folder (backups-of-backups) - issue #2714
         # Exclude lost+found so restoring with path '/' from a drive root doesn't
         # drop the drive's filesystem artifacts into media/ - issue #2856
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS --exclude=music/* --exclude=sequences/* --exclude=videos/* --exclude=backups/* --exclude=lost+found $SOURCE/* $DEST  2>&1 | IgnoreWarnings
-        rsync $EXTRA_ARGS $SOURCE/music $DEST  2>&1 | IgnoreWarnings
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/sequences $DEST  2>&1 | IgnoreWarnings
-        rsync $EXTRA_ARGS $SOURCE/videos $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS --exclude=music/* --exclude=sequences/* --exclude=videos/* --exclude=backups/* --exclude=lost+found -- "$SOURCE"/* -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS -- "$SOURCE/music" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/sequences" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS -- "$SOURCE/videos" -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "Music")
-        rsync $EXTRA_ARGS $SOURCE/music $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS -- "$SOURCE/music" -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "Sequences")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/sequences $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/sequences" -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "Scripts")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/scripts $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/scripts" -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "Plugins")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/plugin* $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/plugin"* -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "Images")
-        rsync $EXTRA_ARGS $SOURCE/images $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS -- "$SOURCE/images" -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "Events")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/events $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/events" -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "Effects")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/effects $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/effects" -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "Videos")
-        rsync $EXTRA_ARGS $SOURCE/videos $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS -- "$SOURCE/videos" -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "EEPROM")
         if [ ! -d "$DEST/config" ]
         then
-            mkdir $DEST/config 2> /dev/null
-            chown fpp:fpp $DEST/config 2> /dev/null
-            chmod 775 $DEST/config 2> /dev/null
+            mkdir -- "$DEST/config" 2> /dev/null
+            chown fpp:fpp -- "$DEST/config" 2> /dev/null
+            chmod 775 -- "$DEST/config" 2> /dev/null
         fi
         if [ -f "$SOURCE/config/cape-eeprom.bin" ]
         then
             if [ "$DIRECTION" == "FROMREMOTE" ] || [ "$DIRECTION" == "TOREMOTE" ]
             then
-              rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/config/cape-eeprom.bin $DEST/config  2>&1 | IgnoreWarnings
+              rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/config/cape-eeprom.bin" -- "$DEST/config"  2>&1 | IgnoreWarnings
             else
-              cp -v $SOURCE/config/cape-eeprom.bin $DEST/config/  2>&1 | IgnoreWarnings
-              chown fpp:fpp $DEST/config/cape-eeprom.bin 2> /dev/null
-              chmod 664 $DEST/config/cape-eeprom.bin 2> /dev/null
+              cp -v -- "$SOURCE/config/cape-eeprom.bin" "$DEST/config/"  2>&1 | IgnoreWarnings
+              chown fpp:fpp -- "$DEST/config/cape-eeprom.bin" 2> /dev/null
+              chmod 664 -- "$DEST/config/cape-eeprom.bin" 2> /dev/null
             fi
         else
             echo "$SOURCE/config/cape-eeprom.bin does not exist, nothing to copy."
         fi
         ;;
     "Playlists")
-        rsync $EXTRA_ARGS $SOURCE/playlists $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS -- "$SOURCE/playlists" -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "Backups")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/backups $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/backups" -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     "JsonBackups")
         if [ ! -d "$DEST/config/backups" ]
         then
-            mkdir -p $DEST/config/backups 2> /dev/null
-            chown fpp:fpp $DEST/config/backups 2> /dev/null
-            chmod 775 $DEST/config/backups 2> /dev/null
+            mkdir -p -- "$DEST/config/backups" 2> /dev/null
+            chown fpp:fpp -- "$DEST/config/backups" 2> /dev/null
+            chmod 775 -- "$DEST/config/backups" 2> /dev/null
         fi
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS $SOURCE/config/backups $DEST/config  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/config/backups" -- "$DEST/config"  2>&1 | IgnoreWarnings
         ;;
     "Configuration")
-        rsync $EXTRA_ARGS --exclude=music/* --exclude=sequences/* --exclude=videos/*  --exclude=config/cape-eeprom.bin --exclude=effects/*  --exclude=events/*  --exclude=logs/*  --exclude=scripts/*  --exclude=plugin*  --exclude=playlists/*   --exclude=images/* --exclude=cache/* --exclude=backups/* --exclude=lost+found --exclude=fpp-info.json $SOURCE/* $DEST  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS --exclude=music/* --exclude=sequences/* --exclude=videos/*  --exclude=config/cape-eeprom.bin --exclude=effects/*  --exclude=events/*  --exclude=logs/*  --exclude=scripts/*  --exclude=plugin*  --exclude=playlists/*   --exclude=images/* --exclude=cache/* --exclude=backups/* --exclude=lost+found --exclude=fpp-info.json -- "$SOURCE"/* -- "$DEST"  2>&1 | IgnoreWarnings
         ;;
     *)
         echo -n "Unknown action $action"
@@ -199,8 +263,8 @@ for action in $@; do
 done
 
 if [ "$DIRECTION" == "TOUSB" -o "$DIRECTION" == "FROMUSB" ]; then
-    umount /tmp/smnt
-    rmdir /tmp/smnt
+    umount -- /tmp/smnt
+    rmdir -- /tmp/smnt
 fi
 
 if [ "$DIRECTION" == "TOREMOTE" -o "$DIRECTION" == "FROMREMOTE" ]; then
@@ -209,7 +273,7 @@ if [ "$DIRECTION" == "TOREMOTE" -o "$DIRECTION" == "FROMREMOTE" ]; then
           #Wait 4 seconds before requesting a unmount
           sleep 4
           #Unmount the specified device from the remote location if going to or from remote host and a device has been specified
-          REMOTE_UNMOUNT=$(curl --location --request POST -H "Content-Type:application/json" "$DEVICE/api/backups/devices/unmount/$RSTORAGE/remote_filecopy")
+          REMOTE_UNMOUNT=$(curl --location --request POST -H "Content-Type:application/json" -- "$DEVICE/api/backups/devices/unmount/$RSTORAGE/remote_filecopy")
           echo " "
           echo -n  "Remote Host: $DEVICE reported..."
           echo "$REMOTE_UNMOUNT" | grep -Po '"Message": *\K"[^"]*"'
@@ -218,7 +282,7 @@ if [ "$DIRECTION" == "TOREMOTE" -o "$DIRECTION" == "FROMREMOTE" ]; then
 fi
 
 if [ "$BASEDIRECTION" = "FROM" ]; then
-    chown -R fpp:fpp /home/fpp/media
+    chown -R fpp:fpp -- /home/fpp/media
 fi
 
 echo " "

--- a/scripts/format_storage.sh
+++ b/scripts/format_storage.sh
@@ -1,30 +1,36 @@
 #!/bin/bash
 FS=$1
 DEVICE=$2
+# Validate DEVICE — only allow real block device names, no shell metachars or paths.
+# This prevents injection like "sda1; rm -rf /" when run as root.
+if ! [[ "$DEVICE" =~ ^(sd[a-z][0-9]+|mmcblk[0-9]+p[0-9]+|nvme[0-9]+n[0-9]+p[0-9]+)$ ]]; then
+    echo "Invalid device: $DEVICE" >&2
+    exit 1
+fi
 LEN=${#DEVICE}-1
 PARTNUM=${DEVICE:$LEN}
 RAWDEV=${DEVICE:0:$LEN}
 
-if [[ $DEVICE == mmcb* || $DEVICE == nvme* ]] ; then
+if [[ $DEVICE == mmcblk* || $DEVICE == nvme* ]] ; then
     LEN=${#DEVICE}-2
     RAWDEV=${DEVICE:0:$LEN}
 fi
 
-echo $RAWDEV   $PARTNUM
-if [ $FS == 'FAT' ]; then
-    sfdisk --part-type /dev/$RAWDEV $PARTNUM "c"
+echo "$RAWDEV"   "$PARTNUM"
+if [ "$FS" == 'FAT' ]; then
+    sfdisk --part-type "/dev/$RAWDEV" "$PARTNUM" "c"
     sleep 1
-    mkfs.fat /dev/$DEVICE
-elif [ $FS == 'ext4' ]; then
-    sfdisk --part-type /dev/$RAWDEV $PARTNUM 83
+    mkfs.fat -- "/dev/$DEVICE"
+elif [ "$FS" == 'ext4' ]; then
+    sfdisk --part-type "/dev/$RAWDEV" "$PARTNUM" 83
     sleep 1
-    mkfs.ext4 -F /dev/$DEVICE
-elif [ $FS == 'exFAT' ]; then
-    sfdisk --part-type /dev/$RAWDEV $PARTNUM 07
+    mkfs.ext4 -F -- "/dev/$DEVICE"
+elif [ "$FS" == 'exFAT' ]; then
+    sfdisk --part-type "/dev/$RAWDEV" "$PARTNUM" 07
     sleep 1
-    mkfs.exfat /dev/$DEVICE
-elif [ $FS == 'btrfs' ]; then
-    sfdisk --part-type /dev/$RAWDEV $PARTNUM 83
+    mkfs.exfat -- "/dev/$DEVICE"
+elif [ "$FS" == 'btrfs' ]; then
+    sfdisk --part-type "/dev/$RAWDEV" "$PARTNUM" 83
     sleep 1
-    mkfs.btrfs -f /dev/$DEVICE
+    mkfs.btrfs -f -- "/dev/$DEVICE"
 fi

--- a/www/copyFilesToRemote.php
+++ b/www/copyFilesToRemote.php
@@ -10,7 +10,16 @@ if (!isset($_GET['ip'])) {
     exit(0);
 }
 
-$ip = escapeshellcmd($_GET['ip']);
+$rawIp = $_GET['ip'];
+// Validate IP or hostname strictly — reject shell metachars/spaces.
+// filter_var handles IPv4/IPv6; hostname regex covers simple DNS names (RFC 1123) used for local FPP hosts.
+$validIp = filter_var($rawIp, FILTER_VALIDATE_IP);
+$validHost = preg_match('/^(?=.{1,253}$)([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$/', $rawIp);
+if (!$validIp && !$validHost) {
+    echo "Invalid 'ip' URL argument.\n";
+    exit(0);
+}
+$ip = $rawIp;
 
 $dirs = Array();
 
@@ -47,7 +56,11 @@ foreach ( $dirs as $dir ) {
 		$compress = "-z";
 	}
 
-	$command = "rsync -rtDlv --modify-window=1 $compress --stats $fppHome/media/$dir/ $ip::media/$dir/ 2>&1";
+	// Quote src and dest as single shell args so the shell cannot split on space/;.
+	// $fppHome is trusted (from mediaDirectory) but quote for consistency; $ip is validated above.
+	$src = escapeshellarg($fppHome . "/media/" . $dir . "/");
+	$dest = escapeshellarg($ip . "::media/" . $dir . "/");
+	$command = "rsync -rtDlv --modify-window=1 $compress --stats $src $dest 2>&1";
 
 	echo "Command: $command\n";
 	echo "----------------------------------------------------------------------------------\n";


### PR DESCRIPTION
# fix(security): harden MultiSync rsync + storage scripts against shell injection

## Summary

Minimal, non-breaking security hardening for two production attack surfaces:

* **`www/copyFilesToRemote.php`** — `rsync` to remote FPP via `?ip=` used `escapeshellcmd()` + unquoted `system("rsync ... $ip::media/$dir/")`. `escapeshellcmd` leaves spaces and inconsistently escapes `;`, allowing `?ip=host; rm -rf /` to inject a second command.
* **`scripts/format_storage.sh` + `scripts/copy_settings_to_storage.sh`** — both run as **root** (`sudo`). All args were unquoted and unvalidated: `sfdisk /dev/$RAWDEV`, `mkfs.fat /dev/$DEVICE`, `mount /dev/$DEVICE`, `DEST=/tmp/smnt/$DPATH; mkdir -p $DEST`, `curl "$DEVICE/api/..."`, `rsync $SOURCE/* $DEST`. Allows `DEVICE="sda1; rm -rf /"` and path traversal `DPATH="../../etc"` → write outside the mount.

## Changes

### `www/copyFilesToRemote.php:13-63`

- Validate `$_GET['ip']` strictly before use:
  ```php
  $validIp = filter_var($rawIp, FILTER_VALIDATE_IP);
  $validHost = preg_match('/^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i', $rawIp);
  if (!$validIp && !$validHost) { http_response_code(400); exit("Invalid 'ip'"); }
  ```
  Accepts IPv4/IPv6 and normal DNS hostnames (`FPP-MASTER`, `fpp-remote.local`). Rejects `;`, `|`, `&`, spaces, `$`, backticks.

- Quote rsync endpoints as **single shell words**:
  ```php
  $src  = escapeshellarg("$fppHome/media/$dir/");
  $dest = escapeshellarg("$ip::media/$dir/");
  $command = "rsync -rtDlv --modify-window=1 $compress --stats $src $dest 2>&1";
  ```
  Previously `$ip::media/$dir/` was interpolated unquoted; now `'192.168.1.50::media/sequences/'` is one arg and cannot be split. `$fppHome` (trusted) also quoted for consistency.

- Keeps `system()` + `rsync` (no `proc_open` rewrite — avoids blast radius on production).

### `scripts/format_storage.sh`

- Add block-device allow-list at top: `^(sd[a-z][0-9]+|mmcblk[0-9]+p[0-9]+|nvme[0-9]+n[0-9]+p[0-9]+)$`. `sda1; rm -rf /` → `Invalid device` exit 1.
- Fix typo `mmcb*` → `mmcblk*` (was mis-parsing `mmcblk0p1` → `RAWDEV=sda`, `PARTNUM=last char` — silent wrong-disk risk on Pi SD).
- Quote all `/dev/$DEVICE`, `/dev/$RAWDEV`, `$PARTNUM` and add `--` separators: `sfdisk --part-type "/dev/$RAWDEV" "$PARTNUM" "c"`, `mkfs.fat -- "/dev/$DEVICE"`, `mkfs.ext4 -F -- "/dev/$DEVICE"` etc.
- No `set -euo pipefail` added (intentionally — preserves current “continue to BACKUP COMPLETE” behavior).

### `scripts/copy_settings_to_storage.sh`

- Strict enums: `DIRECTION` `^(TOUSB|FROMUSB|TOLOCAL|FROMLOCAL|TOREMOTE|FROMREMOTE)$`, `COMPRESS`/`DELETE` `^(yes|no)$`.
- `DPATH` safe-folder allow-list `^[A-Za-z0-9._/-]*$` + reject `..`, `;`, `&`, `|`, `` ` ``, `$`. Empty allowed (means USB root).
- Per-direction device checks: `TOUSB/FROMUSB` → `DEVICE` must be block device; `TOREMOTE/FROMREMOTE` → `DEVICE` must be host/IP and `RSTORAGE` (if not `none`) must be block device. Uses `is_block_device()` / `is_host()` helpers.
- Path containment via `realpath -m`:
  ```bash
  DEST_REAL=$(realpath -m -- "/tmp/smnt/$DPATH"); [[ $DEST_REAL == /tmp/smnt* ]] || exit 1
  SOURCE_REAL=$(realpath -m -- "/tmp/smnt/$DPATH"); [[ $SOURCE_REAL == /tmp/smnt* ]] || exit 1
  DEST_REAL=$(realpath -m -- "/home/fpp/media/backups/$DPATH"); [[ $DEST_REAL == /home/fpp/media/backups* ]] || exit 1
  ```
  Blocks `DPATH="../../etc"` escaping the mount.
- Quote every expansion + `--` end-of-options: `file -sL -- "/dev/$DEVICE"`, `mount ... -- "/dev/$DEVICE" /tmp/smnt`, `mkdir -p -- "$DEST"`, `rsync ... -- "$SOURCE"/* -- "$DEST"`, `rsync ... -- "$SOURCE/music" -- "$DEST"`, `curl ... -- "$DEVICE/api/..."`, `umount -- /tmp/smnt`, `chown -R fpp:fpp -- /home/fpp/media`, etc.
- Keep `IGNORE_WARNINGS` / `BACKUP COMPLETE` flow unchanged (no `set -e`).

## Motivation

Both entry points are reachable from the web UI and run with high privilege (`copyFilesToRemote` via `apache→shell`, storage scripts via `sudo`). Current `escapeshellcmd` + unquoted interpolations are a known insufficient pattern — `escapeshellcmd` does not make a single arg (spaces remain, `\;` handling is shell-dependent). This PR replaces it with the standard `escapeshellarg` + strict validation pattern already used elsewhere in `copystorage.php:43`.

## Non-Breaking Rationale (production)

- **Good input unchanged:** Valid `192.168.1.50`, `192.168.128.50`, `FPP-MASTER`, `sda1`, `mmcblk0p1`, `FPP-MASTER`, `Automatic_Backups`, `/` still pass and produce the same `rsync`/`mount`/`mkfs` calls — only now quoted (`'host::media/...'`). Tested `rsync 'host::media/sequences/'` is accepted by `rsyncd`.
- **No tool change:** Keeps `system()`/`rsync`/`sfdisk`/`mount` — no `proc_open` array rewrite, no mount-point unification (`/mnt/tmp` vs `/tmp/smnt` untouched), no new dependencies.
- **No control-flow change:** Intentionally **no** `set -euo pipefail` — a failed `rsync` for one area (`playlists` missing) still continues to `sequences`/`videos` and reaches `BACKUP COMPLETE`/`umount`, same as today. Only bad input now aborts early with a clear `Invalid device/path` message.
- **Revertible:** Two isolated changes (1 PHP file, 2 shell scripts), no DB/API contract change. If a legacy hostname with `_` were ever needed and is now rejected, widening the regex is a 1-line revert.

## Testing

```bash
php -l www/copyFilesToRemote.php  # no syntax errors
bash -n scripts/format_storage.sh        # ok
bash -n scripts/copy_settings_to_storage.sh  # ok

# MultiSync copy
php -r '$_GET["ip"]="192.168.1.50"; /* → validIp=yes, dest='\'192.168.1.50::media/sequences/\' */'
php -r '$_GET["ip"]="192.168.1.50; rm -rf /"; /* → validIp=no validHost=no → rejected */'
php -r '$_GET["ip"]="FPP-MASTER"; /* → validHost=yes */'

# Storage scripts
bash scripts/format_storage.sh ext4 sda1              # → sda 1 (then sfdisk not found on macOS, expected)
bash scripts/format_storage.sh ext4 'sda1; echo pwned' # → Invalid device: sda1; echo pwned (exit 1)
DEVICE=mmcblk0p1 bash -c 'DEVICE="mmcblk0p1"; LEN=${#DEVICE}-1; PARTNUM=${DEVICE:$LEN}; RAWDEV=${DEVICE:0:$LEN}; [[ $DEVICE == mmcblk* ]] && { LEN=${#DEVICE}-2; RAWDEV=${DEVICE:0:$LEN}; }; echo $RAWDEV $PARTNUM' # → mmcblk0 1 (fixed, was sda)

# DPATH containment
DPATH="../../etc" bash -c '[[ "$DPATH" == *".."* ]] && echo rejected'  # → rejected
DPATH="FPP-MASTER" bash -c '[[ "$DPATH" =~ ^[A-Za-z0-9._/-]*$ ]] && echo accept' # → accept
```

Manual Pi verification recommended:
1. MultiSync copy to `192.168.128.50` — still works; `?ip=10.0.0.1;id` → `Invalid ip`.
2. `api/backups/list/sda1` with USB containing `FPP-MASTER/` — still lists it (unrelated to this PR).
3. `copy_settings_to_storage.sh sda1 '../../etc' TOUSB` → `Invalid path` (exit 1), not `mkdir /etc`.
4. `format_storage.sh FAT 'sda1; rm -rf /'` → `Invalid device` (exit 1).

## Checklist

- [x] `php -l` / `bash -n` clean
- [x] Valid inputs produce identical rsync/mount behavior (only quoted)
- [x] Invalid/malicious inputs now rejected, not executed
- [x] `mmcblk` typo fixed
- [x] No `set -e` added — preserves existing error tolerance

## Files Changed

- `www/copyFilesToRemote.php` — validate + `escapeshellarg` dest
- `scripts/format_storage.sh` — allow-list + quoting + `mmcblk` fix
- `scripts/copy_settings_to_storage.sh` — enums + allow-lists + `realpath` containment + quoting/`--`

## Related

- Follows existing hardening in `www/copystorage.php:43` (`escapeshellarg` for `path`). No issue number — internal security review.