### PR TITLE
fix(fppd): improve crash handler stability when reading executable path

### DIFF
--- a/src/fppd.cpp
+++ b/src/fppd.cpp
@@ -166,7 +166,12 @@ static bool dumpstack_gdb(const char** reason = nullptr) {
     char thread_buf[30];
     snprintf(thread_buf, sizeof(thread_buf), "(LWP %ld)", syscall(__NR_gettid));
     char name_buf[512];
-    name_buf[readlink("/proc/self/exe", name_buf, 511)] = 0;
+    ssize_t nLink = readlink("/proc/self/exe", name_buf, sizeof(name_buf) - 1);
+    if (nLink > 0 && nLink < (ssize_t)sizeof(name_buf)) {
+        name_buf[nLink] = '\0';
+    } else {
+        name_buf[0] = '\0';
+    }
 
     constexpr static int kTimeoutSec = 30;
 


### PR DESCRIPTION
# fix(fppd): improve crash handler stability when reading executable path

## Summary

Small robustness fix in the crash handler that generates debug information after a crash. If the system cannot read the path to the running program, the handler previously wrote outside its buffer and could crash itself. This change makes it safely handle that rare case.

## What changed

* **File:** `src/fppd.cpp` — crash stack collection (`dumpstack_gdb`)
* **Before:** directly used the result of reading `/proc/self/exe` as an array index without checking for failure.
* **After:** checks the result first; on success uses the path, on failure uses an empty string and continues to the fallback path (raw addresses + module map + log ring).

The fallback path already exists for when `gdb` is unavailable — this just ensures we reach it instead of crashing inside the handler.

## Why this is safe for production

* **Normal operation unchanged:** when the path is readable (the common case) the behavior is identical — same `gdb` invocation with the same executable path.
* **Only the failure case changes:** previously a rare failure caused a second crash inside the crash handler (leaving no report and requiring a hard power cycle); now it produces a clean report with raw frames and module map.
* **No new dependencies, no API change, no config change.**
* **Easily revertible:** single 4-line check in one file.

## Testing

* Code compiles with existing flags (no new includes).
* Verified normal path: `readlink` returns length > 0 → buffer is null-terminated and passed to `gdb` as before.
* Verified failure path: `readlink` returns -1 → buffer is set to empty string, handler proceeds to raw backtrace without writing out of bounds.
* Compared to existing correct handling in `src/settings.cpp` which already checks `readlink` return value.

## Files changed

* `src/fppd.cpp`

## Related

* Internal stability review. No related issue number.