### PR TITLE
fix(crashes): prevent crashes when reading empty values and blank settings lines

### DIFF
--- a/src/common_mini.cpp
+++ b/src/common_mini.cpp
@@ -583,7 +583,7 @@ bool ParseTimeString(const std::string& str, int& hour, int& minute, int& second
 }
 
 inline std::string dequote(const std::string& s) {
-    if ((s[0] == '\'' || s[0] == '"') && s[0] == s[s.length() - 1] && s.length() > 2) {
+    if (s.length() > 2 && (s[0] == '\'' || s[0] == '"') && s[0] == s[s.length() - 1]) {
         return s.substr(1, s.length() - 2);
     }
     return s;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -423,9 +423,6 @@ int SettingsConfig::LoadSettings(const std::string& base, bool logChanges) {
             char* saveptr = nullptr;
             char* token = strtok_r(line, "=", &saveptr);
             if (!token) {
-                if (line) {
-                    free(line);
-                }
                 continue;
             }
 


### PR DESCRIPTION
# fix(crashes): prevent crashes when reading empty values and blank settings lines

## Summary

Improves stability when reading settings and quoted values

Two small stability fixes for reading configuration:

* Quoted values (like `"hello"`) are now safely handled even when the value is empty.
* Loading the settings file now safely skips blank lines instead of corrupting memory.

Both are rare cases — an empty field or a stray blank line in `/media/settings` — but when hit they could crash the player or corrupt memory over time, especially since settings are reloaded on every save.

## What changed

* **File:** `src/common_mini.cpp` — helper that removes surrounding quotes
  * **Before:** checked the first character before checking if the string was long enough.
  * **After:** checks length first, then checks the first/last character. Empty strings now correctly return as-is instead of reading past the end.

* **File:** `src/settings.cpp` — loader for `/media/settings`
  * **Before:** when a line had no `=` (blank line), it freed the internal read buffer and then asked for the next line with the same freed buffer.
  * **After:** simply skips the blank line and lets the read buffer be reused. The buffer is still freed once at the end, as intended. This matches the correct handling already used in the similar loader for plugin settings.

## Why this is safe for production

* **Normal settings unchanged:** lines like `HostName = "FPP-MASTER"` still parse identically.
* **Only the edge case changes:** empty values and blank lines previously crashed or corrupted memory; now they are safely skipped/returned as-is.
* **No new dependencies, no API change, no config change.**
* **Easily revertible:** one reordered check and removal of three lines.

## Testing

* Verified empty string, single-character, and normally quoted strings return correctly.
* Verified a settings file containing blank lines, lines with no `=`, and comment lines is now skipped without error and without leaking memory.
* Confirmed the read buffer is still freed exactly once at the end of loading.

## Files changed

* `src/common_mini.cpp`
* `src/settings.cpp`

## Related

* Internal stability review. No related issue number.