### PR TITLE
Fix stale PipeWire output-group hardware targets

### DIFF
--- a/www/api/controllers/pipewire.php
+++ b/www/api/controllers/pipewire.php
@@ -4479,7 +4479,8 @@ function GeneratePipeWireGroupsConfig($groups, $returnCardMap = false)
 
     // Resolve card IDs to PipeWire node names.
     // Priority order:
-    //   1. Previously-stored nodeTarget in member JSON (survives PipeWire being down)
+    //   0. Existing FPP adapter named for this card's stable ALSA ID
+    //   1. Previously-stored nodeTarget in member JSON (validated for FPP adapters)
     //   2. Direct cardId→nodeName via sinkCardIdMap (no card-number dependency)
     //   3. cardId→cardNum→nodeName via sinkCardNumMap (legacy fallback)
     //   4. Create FPP ALSA adapter if card exists but has no PipeWire sink
@@ -4541,6 +4542,21 @@ function GeneratePipeWireGroupsConfig($groups, $returnCardMap = false)
                     $unresolvedCards[] = $cardId . " (Opus RTP instance not found or disabled)";
                 }
                 continue;
+            }
+
+            // FPP adapter names encode the stable ALSA card ID. Prefer the
+            // matching live adapter over a cached target from another card.
+            $fppTarget = 'fpp_alsa_' . preg_replace('/[^a-zA-Z0-9_]/', '_', strtolower($cardId));
+            if (isset($existingSinks[$fppTarget])) {
+                $cardNodeMap[$cardId] = $fppTarget;
+                continue;
+            }
+            // Also reject mismatched FPP targets when the intended adapter is
+            // absent, so neither cached-target fallback can select another card.
+            if (isset($member['nodeTarget'])
+                && strpos($member['nodeTarget'], 'fpp_alsa_') === 0
+                && $member['nodeTarget'] !== $fppTarget) {
+                unset($member['nodeTarget']);
             }
 
             // Priority 1: Previously-stored nodeTarget from last successful Apply

--- a/www/pipewire-audio.php
+++ b/www/pipewire-audio.php
@@ -1364,6 +1364,9 @@
 
         function UpdateMemberCard(groupIndex, memberIndex, cardId) {
             var member = audioGroups.groups[groupIndex].members[memberIndex];
+            if (member.cardId !== cardId) {
+                delete member.nodeTarget;
+            }
             member.cardId = cardId;
 
             // Find card info and auto-set channels to the card's capability


### PR DESCRIPTION
Changing an Advanced PipeWire output-group member's sound card can leave its cached `nodeTarget` pointing to the previous card. If that sink still exists, `GeneratePipeWireGroupsConfig()` accepts it and caches the wrong destination for other members using the selected card. In the reported configuration, both Sound Blaster and onboard Headphones members targeted `fpp_alsa_headphones`.

This patch clears `nodeTarget` when the selected card changes. During configuration generation, it prefers the live FPP ALSA adapter named for the selected stable card ID and rejects cached FPP adapter names belonging to a different card. The existing Apply operation then persists the corrected targets, repairing already-affected configurations.

Related to #2894.

### Scope

Only `www/pipewire-audio.php` and `www/api/controllers/pipewire.php` change. AES67/Opus handling remains unchanged; non-FPP cached targets retain the existing fallback behavior when no matching live FPP adapter exists.

### Validation

Tested on FPP 10.0 (`370e62ed7e8c8318da6ee5b01312b8b75082d952`), Raspberry Pi 4, with Sound Blaster Play! 3 (`S3`) and onboard `Headphones`:

- Both modified PHP files passed PHP lint. A standalone resolver harness passed eight fixtures; the original resolver failed the stale-target case. A JavaScript harness confirmed that changing cards clears the target while reselecting the same card preserves it.
- Normal Save & Apply repaired the saved hardware targets and generated the expected live PipeWire connections.
- Physical listening confirmed Main Show on both devices and Triggered Audio only on onboard headphones, including simultaneous playback with no triggered audio on Sound Blaster.
- Patch removal/reapplication and a full Pi reboot were tested. Correct saved targets and live hardware connections survived reboot.

The patch is based on current `master`; hardware runtime testing was on 10.0. USB hotplug and other hardware combinations have not been tested. The standalone test harnesses were used during investigation and are not added to this small production-code patch.

### Reproduction / verification

With two active FPP ALSA outputs, reproduce an affected member whose `cardId` selects one card but whose cached `nodeTarget` names the other. Before this fix, Apply can route that member to the wrong physical device and reuse the same incorrect mapping in another group. After applying this fix, Save & Apply should resolve each member to the adapter for its selected card. Changing a card in the UI should also discard its previous cached target.

### AI assistance

OpenAI Codex investigated the source and wrote the patch and this PR description. I performed the physical listening tests on my FPP installation and confirmed the routing results reported above.

