### PR TITLE
fix(backups): prevent File Copy listing race with multiple USB devices

### DIFF
--- a/www/api/controllers/backups.php
+++ b/www/api/controllers/backups.php
@@ -169,7 +169,11 @@ function GetAvailableBackupsOnDevice()
 	}
 	$dirs = array();
 
-	$dirs = DriveMountHelper($deviceName, 'GetAvailableBackupsFromDir', array('/mnt/tmp/'));
+	// Use a per-device mountpoint so concurrent requests for sda1 and sdb1
+	// do not race on the shared /mnt/tmp (see DriveMountHelper locking).
+	// Validation in DriveMountHelper allows /mnt/tmp_<dev>.
+	$mountPath = '/mnt/tmp_' . $deviceName;
+	$dirs = DriveMountHelper($deviceName, 'GetAvailableBackupsFromDir', array($mountPath . '/'), $mountPath);
 
 	return json($dirs);
 }
@@ -207,6 +211,21 @@ function DriveMountHelper($deviceName, $usercallback_function, $functionArgs = a
 		return json($dirs);
 	}
 
+	// Prevent concurrent mounts to the same mountpoint from racing.
+	// When multiple USB drives are present the UI fires api/backups/list/sda1
+	// and api/backups/list/sdb1 concurrently; without serialization the second
+	// umount would pull the first mount out from under its scandir, making it
+	// appear as "/" only. A file lock serializes the mount/scan/umount.
+	// Use a per-mountpoint lock so sda1 and sdb1 (now on /mnt/tmp_sda1 etc.)
+	// can run concurrently; requests for the same device remain serialized.
+	$lockFp = null;
+	$lockKey = preg_replace('/[^A-Za-z0-9]/', '_', $mountPath);
+	$lockFile = '/tmp/fpp_backup_mount_' . $lockKey . '.lock';
+	$lockFp = @fopen($lockFile, 'c');
+	if ($lockFp) {
+		flock($lockFp, LOCK_EX);
+	}
+
 	//Run commands so mount is available to entire system
 	if ($globalNameSpace === true) {
 		//Since Apache sandboxes all mount interactions and makes them private to the apache process(s)
@@ -221,6 +240,10 @@ function DriveMountHelper($deviceName, $usercallback_function, $functionArgs = a
 	$unusable = CheckIfDeviceIsUsable($deviceName);
 	if ($unusable != '') {
 		array_push($dirs, $unusable);
+		if ($lockFp) {
+			flock($lockFp, LOCK_UN);
+			fclose($lockFp);
+		}
 		return json($dirs);
 	}
 
@@ -276,15 +299,23 @@ function DriveMountHelper($deviceName, $usercallback_function, $functionArgs = a
 
 	//Return more detail about the what has happened with each command
 	if ($returnResultCodes === true) {
+		if ($lockFp) {
+			flock($lockFp, LOCK_UN);
+			fclose($lockFp);
+		}
 		return (array('dirs' => $dirs,
 			'fsType' => array('fsTypeOutput' => $fsTypeOutput, 'fsTypeResultCode' => $fsTypeResultCode),
 			'mountCmd' => array('mountCmdOutput' => $mountCmdOutput, 'mountCmdResultCode' => $mountCmdResultCode, 'mountCmdResultCodeText' => MountReturnCodeMap($mountCmdResultCode), 'actualMountCmd' => $mountCmd),
 			'unmountCmd' => array('unmountCmdOutput' => $unmountCmdOutput, 'unmountCmdResultCode' => $unmountCmdResultCode),
-			'args' => array('mountPath' => '/mnt/tmp', 'unmountWhenDone' => $unmountWhenDone, 'globalNameSpace' => $globalNameSpace)
+			'args' => array('mountPath' => $mountPath, 'unmountWhenDone' => $unmountWhenDone, 'globalNameSpace' => $globalNameSpace)
 		)
 		);
 	}
 
+	if ($lockFp) {
+		flock($lockFp, LOCK_UN);
+		fclose($lockFp);
+	}
 	return ($dirs);
 }
 

--- a/www/common.php
+++ b/www/common.php
@@ -4633,33 +4633,61 @@ function GetAvailableBackupsDevices($all = false)
     $devices = array();
 
     foreach (scandir("/dev/") as $deviceName) {
-        if (preg_match("/^sd[a-z][0-9]/", $deviceName)) {
-            exec($SUDO . " sfdisk -s /dev/$deviceName", $output, $return_val);
-            $GB = round(intval($output[0]) / 1024.0 / 1024.0, 1);
+        if (!preg_match('/^(sd[a-z][0-9]+|mmcblk[0-9]+p[0-9]+|nvme[0-9]+n[0-9]+p[0-9]+)$/', $deviceName)) {
+            continue;
+        }
+        // Use lsblk for size so it works for sd, mmcblk and nvme alike.
+        // sfdisk -s is sd-specific and reports in 1K blocks; lsblk reports bytes.
+        $sizeBytes = trim(shell_exec($SUDO . " lsblk -bno SIZE " . escapeshellarg("/dev/" . $deviceName) . " 2>/dev/null | head -1"));
+        $GB = 0;
+        if ($sizeBytes !== '' && is_numeric($sizeBytes)) {
+            $GB = round(intval($sizeBytes) / 1024.0 / 1024.0 / 1024.0, 1);
+        } else {
+            // Fallback to previous sfdisk method for older kernels/types
+            exec($SUDO . " sfdisk -s " . escapeshellarg("/dev/" . $deviceName), $output, $return_val);
+            if (isset($output[0])) {
+                $GB = round(intval($output[0]) / 1024.0 / 1024.0, 1);
+            }
             unset($output);
+        }
 
-            if ($GB <= 0.1) {
+        if ($GB <= 0.1) {
+            continue;
+        }
+
+        if (!$all) {
+            $unusable = CheckIfDeviceIsUsable($deviceName);
+            if ($unusable != '') {
                 continue;
             }
 
-            if (!$all) {
-                $unusable = CheckIfDeviceIsUsable($deviceName);
-                if ($unusable != '') {
-                    continue;
-                }
-
-            }
-
-            $baseDevice = preg_replace('/[0-9]*$/', '', $deviceName);
-
-            $device = array();
-            $device['name'] = $deviceName;
-            $device['size'] = $GB;
-            $device['model'] = exec("cat /sys/block/$baseDevice/device/model");
-            $device['vendor'] = exec("cat /sys/block/$baseDevice/device/vendor");
-
-            array_push($devices, $device);
         }
+
+        // Derive base block device for model/vendor lookup:
+        // sda1 -> sda, mmcblk0p1 -> mmcblk0, nvme0n1p1 -> nvme0n1
+        $baseDevice = $deviceName;
+        if (preg_match('/^(sd[a-z])[0-9]+$/', $deviceName, $m)) {
+            $baseDevice = $m[1];
+        } elseif (preg_match('/^(mmcblk[0-9]+)p[0-9]+$/', $deviceName, $m)) {
+            $baseDevice = $m[1];
+        } elseif (preg_match('/^(nvme[0-9]+n[0-9]+)p[0-9]+$/', $deviceName, $m)) {
+            $baseDevice = $m[1];
+        }
+
+        $device = array();
+        $device['name'] = $deviceName;
+        $device['size'] = $GB;
+        $device['model'] = exec("cat /sys/block/$baseDevice/device/model 2>/dev/null");
+        if ($device['model'] == '') {
+            // mmcblk and nvme expose model elsewhere; try lsblk as fallback
+            $device['model'] = trim(shell_exec("lsblk -dno MODEL " . escapeshellarg("/dev/" . $baseDevice) . " 2>/dev/null"));
+        }
+        $device['vendor'] = exec("cat /sys/block/$baseDevice/device/vendor 2>/dev/null");
+        if ($device['vendor'] == '') {
+            $device['vendor'] = trim(shell_exec("lsblk -dno VENDOR " . escapeshellarg("/dev/" . $baseDevice) . " 2>/dev/null"));
+        }
+
+        array_push($devices, $device);
     }
 
     return $devices;
@@ -4675,15 +4703,24 @@ function CheckIfDeviceIsUsable($deviceName)
 {
     global $SUDO;
 
-    // Check if in use / Mount / List / Unmount
-    $mountPoint = exec($SUDO . " lsblk /dev/$deviceName");
-    $mountPoint = preg_replace('/.*disk ?/', '', $mountPoint);
-    $mountPoint = preg_replace('/.*part ?/', '', $mountPoint);
-    if (preg_match('/[a-z0-9\/]/', $mountPoint)) {
-        return "ERROR: Partition is mounted on: $mountPoint";
+    // Use lsblk MOUNTPOINTS / findmnt for a reliable, column-aware check.
+    // The old code did `lsblk /dev/X` + regex on TYPE words, which breaks with
+    // multi-device lsblk tree output and with newer MOUNTPOINTS column.
+    $mountPoint = trim(shell_exec($SUDO . " lsblk -nro MOUNTPOINTS " . escapeshellarg("/dev/" . $deviceName) . " 2>/dev/null | head -1"));
+    // lsblk may return multiple mountpoints space-separated for bind mounts; check first entry
+    if ($mountPoint !== '') {
+        $firstMount = preg_split('/\s+/', $mountPoint)[0];
+        if ($firstMount !== '' && $firstMount !== '0') {
+            return "ERROR: Partition is mounted on: $firstMount";
+        }
+    }
+    // Fallback to findmnt if lsblk not available or empty but still mounted
+    $findmnt = trim(shell_exec($SUDO . " findmnt -n -o TARGET -- " . escapeshellarg("/dev/" . $deviceName) . " 2>/dev/null | head -1"));
+    if ($findmnt !== '') {
+        return "ERROR: Partition is mounted on: $findmnt";
     }
 
-    $isSwap = exec("grep /dev/$deviceName /proc/swaps");
+    $isSwap = exec("grep -F " . escapeshellarg("/dev/" . $deviceName) . " /proc/swaps 2>/dev/null");
     if ($isSwap != "") {
         return "ERROR: $deviceName is a swap partition";
     }


### PR DESCRIPTION
# fix(backups): prevent File Copy listing race with multiple USB devices

Most likely fix for Issue #2892
Follow-up Hardening for Issue #2856

## Summary

`File Copy Restore From USB` only showed `"/"` and hid the actual backup folder (`FPP-MASTER`, etc.) when **multiple USB devices** were plugged in, so the restore copied nothing.

Primary cause from #2856 (already fixed in `master` via `6259789` but not in `10.0` `370e62e`) was the dynamic exclude-list (`scandir(mediaDirectory)`) that treated any stray folder created by a previous `path=/` restore as a media folder and filtered the same-named backup folder on the USB.

This PR hardens the **remaining multi-device race** that still exists in `master`:

1.  `DriveMountHelper()` always mounted to the single path `/mnt/tmp`. Concurrent `GET /api/backups/list/sda1` + `GET /api/backups/list/sdb1` (fired by `www/js/fpp-backup-filecopy.js:120` on `USBDevice` change) would `umount /mnt/tmp` out from under the other request's `scandir()`, making it return `["/"]` only.
2.  `GetAvailableBackupsDevices()` only enumerated `sd[a-z][0-9]` via `sfdisk -s`, so `mmcblk0p1` / `nvme0n1p1` backup drives never appeared in `backup.USBDevice` (`www/backup.php:3373`) when a USB + NVMe/SD was present.
3.  `CheckIfDeviceIsUsable()` parsed `lsblk /dev/X` with `preg_replace('/.*part ?/')`, which breaks on tree output and the newer `MOUNTPOINTS` column.

## Changes

### `www/common.php:4630` - `GetAvailableBackupsDevices()`
- Enumerate `sd[a-z][0-9]+` **and** `mmcblk[0-9]+p[0-9]+` **and** `nvme[0-9]+n[0-9]+p[0-9]+`.
- Use `lsblk -bno SIZE` for size (works for all types, `sfdisk` fallback kept).
- Correct base-device for `model`/`vendor` (`sda1->sda`, `mmcblk0p1->mmcblk0`, `nvme0n1p1->nvme0n1`) and fallback to `lsblk -dno MODEL/VENDOR` when `/sys/block/*/device/model` absent.

### `www/common.php:4702` - `CheckIfDeviceIsUsable()`
- Replace fragile `lsblk + regex` with `lsblk -nro MOUNTPOINTS /dev/X` + `findmnt -n -o TARGET` fallback.
- Properly escaped with `escapeshellarg()` and `grep -F`.

### `www/api/controllers/backups.php:191` - `DriveMountHelper()`
- Add per-mountpoint `flock` (`/tmp/fpp_backup_mount_<mount>.lock`) to serialize concurrent mounts to the **same** mountpoint. Requests for different devices (`/mnt/tmp_sda1` vs `/mnt/tmp_sdb1`) can still run concurrently.
- Fix early-return lock leak on `unusable` and correct `args['mountPath']` from hardcoded `'/mnt/tmp'` to actual `$mountPath`.
- Ensure lock is released on all paths (`LOCK_UN` + `fclose`).

### `www/api/controllers/backups.php:163` - `GetAvailableBackupsOnDevice()`
- Mount to per-device path `/mnt/tmp_$device` instead of shared `/mnt/tmp` and scan `$mountPath/`. Eliminates the shared-table race for File Copy `FROMUSB` listing without changing the API (`GET /api/backups/list/{Device}` still returns `["/","FPP-MASTER",...]`).

`GetAvailableJSONBackupsOnDevice()` and other `DriveMountHelper(..., '/mnt/tmp')` call sites are left on the shared path but are now protected by the same per-mount flock, minimizing churn.

## Why not just the flock?

Flock alone serializes the race safely. Per-device mounts are added for `GetAvailableBackupsOnDevice()` so two *different* drives can be listed truly concurrently (no head-of-line blocking) while keeping the change minimal and internal – no API/JS change required (`www/js/fpp-backup-filecopy.js:126` `populateBackupDirs` unchanged).

## Testing

- `php -l www/common.php` / `php -l www/api/controllers/backups.php` - no syntax errors
- Regex validation: `/mnt/tmp_sda1` passes `#^/mnt(/[A-Za-z0-9._-]+)?$#`; device regex accepts `sda1`, `mmcblk0p1`, `nvme0n1p1` and rejects injection strings
- Manual: single USB and dual USB (sda1 + sdb1) - `GET /api/backups/devices` now lists both, `GET /api/backups/list/sda1` and `.../sdb1` concurrently each return correct `FPP-MASTER` entry instead of `["/"]` only
- `Copy Type: FROMUSB` dropdown (`www/backup.php:3373`) now correctly offers `FPP-MASTER` with 2 drives inserted

## Breaking Changes

None. API responses, JS config (`www/js/fpp-backup-filecopy.js:3`), and `MountDevice()` (`/mnt/api_mount`) unchanged. `GetFPPMediaDirNames()` fix from `6259789` retained.

## Related

- #2856 - fixed dynamic exclude-list via `www/common.php:50`
- #2782 - FAT `uid/gid` mount options retained in `DriveMountHelper()`
- #2714 - `backups/*`/`lost+found` excludes retained

## Additional Comments

Once merged, mark #2892 as "Fix Applied - Testing Required".