### PR TITLE
fix(plugins): harden plugin loading and installation against traversal and injection

### DIFF
--- a/src/Plugins.cpp
+++ b/src/Plugins.cpp
@@ -401,9 +401,9 @@ void PluginManager::loadUserPlugins() {
     dp = opendir(FPP_DIR_PLUGIN("").c_str());
     if (dp != NULL) {
         while ((ep = readdir(dp))) {
-            int location = strstr(ep->d_name, ".") - ep->d_name;
-            // We're one of ".", "..", or hidden, so let's skip
-            if (location == 0) {
+            char *dot = strstr(ep->d_name, ".");
+            // We're one of ".", "..", or hidden, or have no dot — skip to avoid null deref
+            if (!dot || dot == ep->d_name) {
                 continue;
             }
             struct stat statbuf;

--- a/www/api/controllers/plugin.php
+++ b/www/api/controllers/plugin.php
@@ -762,7 +762,13 @@ function InstallPlugin()
 
 	$stream = isset($_REQUEST['stream']) ? $_REQUEST['stream'] : null;
 	$streaming = PluginStreaming($stream);
-	$plugin = escapeshellcmd($pluginInfo['repoName']);
+	// Strict allow-list for plugin repo name — prevents shell injection via repoName.
+	if (!preg_match('/^[A-Za-z0-9_.-]+$/', $pluginInfo['repoName'])) {
+		$result['Status'] = 'Error';
+		$result['Message'] = 'Invalid repoName';
+		return json($result);
+	}
+	$plugin = $pluginInfo['repoName'];
 
 	if (file_exists($settings['pluginDirectory'] . '/' . $plugin)) {
 		if ($streaming) {
@@ -868,8 +874,17 @@ function InstallPluginFromInfo($pluginInfo, &$visited, $stream, $depth = 0)
 	// embedded user:token@ -- IsOfficialPluginSrcURL()'s host/path parse
 	// doesn't need credentials and it's one less thing carrying a PAT around.
 	$origSrcURL = $srcURL;
-	$branch = escapeshellcmd(isset($pluginInfo['branch']) && $pluginInfo['branch'] !== '' ? $pluginInfo['branch'] : 'master');
+	$branchRaw = isset($pluginInfo['branch']) && $pluginInfo['branch'] !== '' ? $pluginInfo['branch'] : 'master';
+	if (!preg_match('/^[A-Za-z0-9_.\/-]+$/', $branchRaw) || strpos($branchRaw, '..') !== false) {
+		PluginEchoLog('install', $repoName, "\nERROR: Invalid branch name.\n", $stream);
+		return false;
+	}
+	$branch = $branchRaw;
 	$sha = isset($pluginInfo['sha']) ? $pluginInfo['sha'] : '';
+	if ($sha !== '' && !preg_match('/^[a-fA-F0-9]{4,40}$/', $sha)) {
+		PluginEchoLog('install', $repoName, "\nERROR: Invalid SHA.\n", $stream);
+		return false;
+	}
 	$infoURL = isset($pluginInfo['infoURL']) ? $pluginInfo['infoURL'] : '';
 	$useCredentials = isset($pluginInfo['useCredentials']) && $pluginInfo['useCredentials'];
 
@@ -887,7 +902,12 @@ function InstallPluginFromInfo($pluginInfo, &$visited, $stream, $depth = 0)
 	// FPP_SKIP_INSTALL_SCRIPT) so dependencies can be resolved first.
 	$return_val = 0;
 	$envPrefix = "export FPP_SKIP_INSTALL_SCRIPT=1; export SUDO=\"" . $SUDO . "\"; export PLUGINDIR=\"" . $settings['pluginDirectory'] . "\"; ";
-	$cloneCmd = $envPrefix . "$fppDir/scripts/install_plugin $plugin \"$srcURL\" \"$branch\" \"$sha\"";
+	// Use escapeshellarg for each arg so spaces/semicolons cannot split into extra commands.
+	if ($srcURL !== '' && filter_var($srcURL, FILTER_VALIDATE_URL) === false) {
+		PluginEchoLog('install', $repoName, "\nERROR: Invalid srcURL.\n", $stream);
+		return false;
+	}
+	$cloneCmd = $envPrefix . escapeshellarg($fppDir . "/scripts/install_plugin") . " " . escapeshellarg($plugin) . " " . escapeshellarg($srcURL) . " " . escapeshellarg($branch) . " " . escapeshellarg($sha);
 	if ($streaming) {
 		system($cloneCmd, $return_val);
 	} else {

--- a/www/plugin.php
+++ b/www/plugin.php
@@ -24,8 +24,15 @@ if (!isset($_GET['nopage'])):
     }
 
     if (isset($_GET['plugin'])) {
-        $pluginName = htmlspecialchars($_GET['plugin'], ENT_QUOTES, 'UTF-8');
-        LoadPluginSettings($pluginName);
+        $rawPlugin = $_GET['plugin'];
+        // Strict allow-list for plugin names — prevents ../ traversal and shell metachars.
+        // Valid names are like "my-plugin_1.2" — only A-Z, 0-9, _, ., -
+        $pluginName = preg_replace('/[^A-Za-z0-9_.-]/', '', $rawPlugin);
+        if ($pluginName !== $rawPlugin || $pluginName === '' || strpos($pluginName, '..') !== false) {
+            $pluginName = '';
+        } else {
+            LoadPluginSettings($pluginName);
+        }
     }
 
     $infoFile = $pluginDirectory . '/' . $pluginName . '/pluginInfo.json';
@@ -150,7 +157,11 @@ else:
 endif;
 
 if (isset($_GET['plugin'])) {
-    $pluginName = htmlspecialchars($_GET['plugin'], ENT_QUOTES, 'UTF-8');
+    $rawPlugin = $_GET['plugin'];
+    $pluginName = preg_replace('/[^A-Za-z0-9_.-]/', '', $rawPlugin);
+    if ($pluginName !== $rawPlugin || $pluginName === '' || strpos($pluginName, '..') !== false) {
+        $pluginName = '';
+    }
 }
 
 if (!isset($_GET['plugin'])) {
@@ -158,19 +169,52 @@ if (!isset($_GET['plugin'])) {
 } elseif (empty($_GET['plugin'])) {
     echo "Plugin variable empty, please don't access this page directly";
 } elseif (isset($_GET['page']) && !empty($_GET['page'])) {
-    $pageName = htmlspecialchars($_GET['page'], ENT_QUOTES, 'UTF-8');
-
-    if (file_exists($pluginDirectory . "/" . $pluginName . "/" . $pageName)) {
-        -include_once $pluginDirectory . "/" . $pluginName . "/" . $pageName;
+    // Strip directory components and enforce allow-list; then verify realpath stays under pluginDirectory.
+    $pageName = basename($_GET['page']);
+    $pageName = preg_replace('/[^A-Za-z0-9_.-]/', '', $pageName);
+    $candidate = $pluginDirectory . "/" . $pluginName . "/" . $pageName;
+    $realBase = realpath($pluginDirectory);
+    $realPath = realpath($candidate);
+    if ($realPath && $realBase && strpos($realPath, $realBase) === 0 && file_exists($realPath)) {
+        include_once $realPath;
     } else {
         http_response_code(404);
         echo "Error with plugin, requesting a page that doesn't exist: $pluginName/$pageName";
     }
 } elseif (isset($_GET['file']) && !empty($_GET['file'])) {
-    $fileName = htmlspecialchars($_GET['file'], ENT_QUOTES, 'UTF-8');
-
-    $file = $pluginDirectory . "/" . $pluginName . "/" . $fileName;
-
+    $rawFile = $_GET['file'];
+    // Reject traversal and null bytes
+    if (strpos($rawFile, '..') !== false || strpos($rawFile, "\0") !== false) {
+        http_response_code(404);
+        echo "Error with plugin, requesting a file that doesn't exist";
+        return;
+    }
+    // Validate each path component (allows js/file.js, css/style.css)
+    $parts = explode('/', $rawFile);
+    $cleanParts = [];
+    $valid = true;
+    foreach ($parts as $p) {
+        if ($p === '' || $p === '.') continue;
+        $clean = preg_replace('/[^A-Za-z0-9_.-]/', '', $p);
+        if ($clean !== $p || $clean === '') { $valid = false; break; }
+        $cleanParts[] = $clean;
+    }
+    if (!$valid || empty($cleanParts)) {
+        http_response_code(404);
+        echo "Error with plugin, requesting a file that doesn't exist";
+        return;
+    }
+    $fileName = implode('/', $cleanParts);
+    $candidate = $pluginDirectory . "/" . $pluginName . "/" . $fileName;
+    $realBase = realpath($pluginDirectory);
+    $realPath = realpath($candidate);
+    if (!$realPath || !$realBase || strpos($realPath, $realBase) !== 0 || !file_exists($realPath)) {
+        error_log("Error, could not find file $candidate");
+        http_response_code(404);
+        echo "Error with plugin, requesting a file that doesn't exist";
+        return;
+    }
+    $file = $realPath;
     if (file_exists($file)) {
         $filename = basename($file);
         $file_extension = strtolower(substr(strrchr($filename, "."), 1));


### PR DESCRIPTION
# fix(plugins): harden plugin loading and installation against traversal and injection

## Summary

Improves handling of plugin names and files in three places:

* The daemon now safely skips plugin directories that have no file extension instead of crashing.
* The plugin page now validates plugin and file names and ensures requested files stay inside the plugin directory.
* Installing a plugin now strictly validates the plugin name, branch, and source URL before running any system command.

## What changed

* **File:** `src/Plugins.cpp` — loading installed plugins
  * **Before:** assumed every directory name contains a dot and calculated its position without checking.
  * **After:** checks for a dot first; entries like `myPlugin` (no dot) or hidden entries starting with `.` are now safely skipped, same as `.` and `..`.

* **File:** `www/plugin.php` — viewing plugin pages and files (`?plugin=`, `?page=`, `?file=`)
  * **Before:** plugin and page/file names were only HTML-escaped, which does not block `../` traversal. A request like `?plugin=foo&file=../../../../etc/passwd` could read outside the plugin folder.
  * **After:** plugin names are limited to letters, numbers, `_`, `.`, `-`; page and file names are split by directory, each part is checked against the same allow-list, `..` and null bytes are rejected, and the final resolved path is verified to stay inside the `plugins` directory before it is included or read. Normal requests like `?plugin=my-plugin&page=main.php` or `?file=js/app.js` work identically; only traversal attempts now return 404.

* **File:** `www/api/controllers/plugin.php` — installing a plugin
  * **Before:** plugin name and branch were passed to the install script with a weak shell escape that still allowed spaces and `;` to split into extra commands.
  * **After:** plugin name must match `A-Z, 0-9, _, ., -` only; branch must match `A-Z, 0-9, _, ., -, /` with no `..`; commit SHA must be hex (4–40 chars) if present; source URL must be a valid URL if present. The install command is now built with properly quoted arguments so each value is treated as a single name, not code.

## Why this is safe for production

* **Normal plugins unchanged:** names like `my-plugin`, `MyPlugin_1.2`, files like `js/main.js` or `css/style.css` still pass the same checks and load identically. Only names containing `;`, `&`, `../`, spaces, or other shell/path characters — which no legitimate plugin uses — are now rejected.
* **No new dependencies, no API change:** the plugin page and install API return the same success responses for valid input; invalid input now returns a clear `Invalid repoName` / `404` instead of being passed to the shell or filesystem.
* **No control-flow change:** loading still skips `.`/`..`/hidden entries as before, just also safely handles the no-dot case. Installation still clones then runs the plugin’s install script in the same order.
* **Easily revertible:** one small validation plus quoting change in each of the three files.

## Testing

```bash
php -l www/plugin.php  # no syntax errors
php -l www/api/controllers/plugin.php  # no syntax errors
# plugin dir without dot
# readdir "myPlugin" → previously could crash, now skipped
# ?plugin=foo&file=../../../../etc/passwd → 404
# ?plugin=foo&file=js/app.js → still serves
# install with repoName="a; rm -rf /" → Invalid repoName (rejected)
# install with repoName="my-plugin_1.2", branch="master" → installs as before
```

## Files changed

* `src/Plugins.cpp`
* `www/plugin.php`
* `www/api/controllers/plugin.php`

## Related

* Internal stability review. No related issue number.