### PR TITLE
fix(backups): fix File Copy Restore rsync failures and false success

### DIFF
--- a/scripts/copy_settings_to_storage.sh
+++ b/scripts/copy_settings_to_storage.sh
@@ -48,6 +48,7 @@ fi
 
 BASEDIRECTION=$(echo "$DIRECTION" | cut -c1-4)
 REMOTE_COMPRESS=""
+OVERALL_RC=0
 
 IgnoreWarnings() {
     egrep -v "(failed to set|chown|attrs were not)"
@@ -141,11 +142,11 @@ elif [ "$DIRECTION" == "TOREMOTE" ]; then
         # Remote storage device will be mounted to /mnt/remote_filecopy (at the destination), so adjust the destination to accommodate this.
         DEST="${DEVICE}::remote_filecopy/$DPATH"
         # Going to a different storage device so modify the directory and copy over the base directory structure
-        rsync -a -- "/home/fpp/media/tmp/backups"/* -- "${DEVICE}::remote_filecopy" 2>&1 | IgnoreWarnings
+        rsync -a -- "/home/fpp/media/tmp/backups"/* "${DEVICE}::remote_filecopy" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         rm -rf -- /home/fpp/media/tmp/backups
     else
         # Not going to a different storage device so copy over the new directory structure as normal (this will go into the specified default FPP Storage)
-        rsync -a -- "/home/fpp/media/tmp/backups"/* -- "${DEVICE}::media/backups/" 2>&1 | IgnoreWarnings
+        rsync -a -- "/home/fpp/media/tmp/backups"/* "${DEVICE}::media/backups/" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         rm -rf -- /home/fpp/media/tmp/backups
     fi
 
@@ -189,34 +190,42 @@ for action in "$@"; do
         # machine's own backups folder (backups-of-backups) - issue #2714
         # Exclude lost+found so restoring with path '/' from a drive root doesn't
         # drop the drive's filesystem artifacts into media/ - issue #2856
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS --exclude=music/* --exclude=sequences/* --exclude=videos/* --exclude=backups/* --exclude=lost+found -- "$SOURCE"/* -- "$DEST"  2>&1 | IgnoreWarnings
-        rsync $EXTRA_ARGS -- "$SOURCE/music" -- "$DEST"  2>&1 | IgnoreWarnings
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/sequences" -- "$DEST"  2>&1 | IgnoreWarnings
-        rsync $EXTRA_ARGS -- "$SOURCE/videos" -- "$DEST"  2>&1 | IgnoreWarnings
+        # Fix: use trailing "/" not shell glob "/*" — "host::path/*" never expands locally and rsync rejects literal "*".
+        # Fix: remove stray "--" before DEST — the initial "--" already terminated options; second "--" became a bogus local arg.
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS --exclude=music/* --exclude=sequences/* --exclude=videos/* --exclude=backups/* --exclude=lost+found -- "$SOURCE"/ "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
+        rsync $EXTRA_ARGS -- "$SOURCE/music" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/sequences" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
+        rsync $EXTRA_ARGS -- "$SOURCE/videos" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "Music")
-        rsync $EXTRA_ARGS -- "$SOURCE/music" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS -- "$SOURCE/music" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "Sequences")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/sequences" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/sequences" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "Scripts")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/scripts" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/scripts" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "Plugins")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/plugin"* -- "$DEST"  2>&1 | IgnoreWarnings
+        # "plugin"* via shell glob works for local SOURCE but fails for daemon "host::path" (no local expansion).
+        # Use rsync include filters for daemon sources so plugins/plugindata are matched remotely.
+        if [[ "$SOURCE" == *"::"* ]]; then
+            rsync $EXTRA_ARGS $REMOTE_COMPRESS --include='plugin*' --include='plugin*/**' --exclude='*' -- "$SOURCE"/ "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
+        else
+            rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE"/plugin* "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
+        fi
         ;;
     "Images")
-        rsync $EXTRA_ARGS -- "$SOURCE/images" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS -- "$SOURCE/images" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "Events")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/events" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/events" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "Effects")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/effects" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/effects" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "Videos")
-        rsync $EXTRA_ARGS -- "$SOURCE/videos" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS -- "$SOURCE/videos" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "EEPROM")
         if [ ! -d "$DEST/config" ]
@@ -229,9 +238,9 @@ for action in "$@"; do
         then
             if [ "$DIRECTION" == "FROMREMOTE" ] || [ "$DIRECTION" == "TOREMOTE" ]
             then
-              rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/config/cape-eeprom.bin" -- "$DEST/config"  2>&1 | IgnoreWarnings
+              rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/config/cape-eeprom.bin" "$DEST/config" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
             else
-              cp -v -- "$SOURCE/config/cape-eeprom.bin" "$DEST/config/"  2>&1 | IgnoreWarnings
+              cp -v -- "$SOURCE/config/cape-eeprom.bin" "$DEST/config/" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
               chown fpp:fpp -- "$DEST/config/cape-eeprom.bin" 2> /dev/null
               chmod 664 -- "$DEST/config/cape-eeprom.bin" 2> /dev/null
             fi
@@ -240,10 +249,10 @@ for action in "$@"; do
         fi
         ;;
     "Playlists")
-        rsync $EXTRA_ARGS -- "$SOURCE/playlists" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS -- "$SOURCE/playlists" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "Backups")
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/backups" -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/backups" "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "JsonBackups")
         if [ ! -d "$DEST/config/backups" ]
@@ -252,13 +261,14 @@ for action in "$@"; do
             chown fpp:fpp -- "$DEST/config/backups" 2> /dev/null
             chmod 775 -- "$DEST/config/backups" 2> /dev/null
         fi
-        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/config/backups" -- "$DEST/config"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS $REMOTE_COMPRESS -- "$SOURCE/config/backups" "$DEST/config" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     "Configuration")
-        rsync $EXTRA_ARGS --exclude=music/* --exclude=sequences/* --exclude=videos/*  --exclude=config/cape-eeprom.bin --exclude=effects/*  --exclude=events/*  --exclude=logs/*  --exclude=scripts/*  --exclude=plugin*  --exclude=playlists/*   --exclude=images/* --exclude=cache/* --exclude=backups/* --exclude=lost+found --exclude=fpp-info.json -- "$SOURCE"/* -- "$DEST"  2>&1 | IgnoreWarnings
+        rsync $EXTRA_ARGS --exclude=music/* --exclude=sequences/* --exclude=videos/*  --exclude=config/cape-eeprom.bin --exclude=effects/*  --exclude=events/*  --exclude=logs/*  --exclude=scripts/*  --exclude=plugin*  --exclude=playlists/*   --exclude=images/* --exclude=cache/* --exclude=backups/* --exclude=lost+found --exclude=fpp-info.json -- "$SOURCE"/ "$DEST" 2>&1 | IgnoreWarnings; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc
         ;;
     *)
         echo -n "Unknown action $action"
+        OVERALL_RC=1
     esac
 done
 
@@ -287,9 +297,16 @@ fi
 
 echo " "
 echo "========================================="
-echo "BACKUP COMPLETE"
-echo "All selected items have been successfully copied."
+if [ "$OVERALL_RC" -ne 0 ]; then
+    echo "BACKUP FAILED (rc=$OVERALL_RC)"
+    echo "One or more items failed to copy - see errors above."
+    echo "Check fppd.log and logs/fpp_backup_filecopy.log for details."
+else
+    echo "BACKUP COMPLETE"
+    echo "All selected items have been successfully copied."
+fi
 echo "You may now close this window."
 echo "Safe to remove storage device if applicable."
 echo "========================================="
 echo " "
+exit $OVERALL_RC


### PR DESCRIPTION
# fix(backups): fix File Copy Restore rsync failures and false success

Follow-up to #2903 — #2903 fixed listing (`/mnt/tmp` race); this fixes the remaining restore path which still failed even when listing was correct.

## Summary

`File Copy Restore` via `FROMREMOTE` (and `FROMLOCAL`/`TO*`) always failed with:

```
[Backup] Unexpected local arg: --
[Backup] If arg is a remote file/dir, prefix it with a colon (:).
rsync error: syntax or usage error (code 1)
```

...yet still printed `BACKUP COMPLETE - All selected items have been successfully copied`.

Example from #2906: `FROMREMOTE` `192.168.14.55::media/backups/FPPGoodBAD-20260904` — every category (Configuration, Playlists, Plugins, etc.) failed identically; only EEPROM “succeeded” (no-op, file missing).

Root cause is two bugs in `scripts/copy_settings_to_storage.sh:182-263` masked by `www/copystorage.php:87`.

## Root Cause

1.  **Stray second `--` before `$DEST`** — every `rsync` line was `rsync ... -- "$SOURCE/..." -- "$DEST"` (`scripts/copy_settings_to_storage.sh:192-258`). First `--` terminates options; second `--` is parsed as a local source file named `--` → `Unexpected local arg: --`. Affects all directions (`TOUSB`/`FROMUSB`/`TOLOCAL`/`FROMLOCAL`/`TOREMOTE`/`FROMREMOTE`).

2.  **Shell glob on rsync daemon path** — `FROMREMOTE` sets `SOURCE="${DEVICE}::media/backups/$DPATH"` (`scripts/copy_settings_to_storage.sh:153`) then runs `"$SOURCE"/*` (`:192`,`:258`) and `"$SOURCE/plugin"*` (`:207`). Bash only expands globs locally; `host::path/*` matches nothing → literal `*` passed to `rsync` daemon → syntax error.

3.  **False success** — `scripts/copy_settings_to_storage.sh:288-294` always echoed `BACKUP COMPLETE` and `exit 0`; `www/copystorage.php:87` piped via `tee` without `pipefail` so `$backupRc` was `tee`'s exit. Failure was invisible in UI and `fppd.log`.

## Changes

### `scripts/copy_settings_to_storage.sh`

*   **`OVERALL_RC` tracking (`:51`, `:144`, `:148`, `:193-262`)** — init `OVERALL_RC=0` at top; every `rsync ... | IgnoreWarnings` now suffixed `; rc=${PIPESTATUS[0]}; (( rc != 0 )) && OVERALL_RC=$rc` (also `cp` in `EEPROM` and unknown `*)` → `OVERALL_RC=1`). Covers early `TOREMOTE` tmp sync (`:144`,`:148`) and per-category copies.

*   **Drop extra `--` before `DEST` (`:144`,`:148`,`:193-258`)** — `rsync ... -- "$SOURCE/music" "$DEST"` not ` -- "$DEST"`. Fixes `Unexpected local arg`.

*   **Daemon-safe source (`:192`,`:258`)** — `"$SOURCE"/*` → `"$SOURCE"/` (trailing `/` copies contents via rsync daemon without shell expansion; also fixes dotfile omission of `*` and works for local sources).

*   **`Plugins` (`:208-216`) — daemon vs local split:**
    ```bash
    if [[ "$SOURCE" == *"::"* ]]; then
      rsync ... --include='plugin*' --include='plugin*/**' --exclude='*' -- "$SOURCE"/ "$DEST"
    else
      rsync ... -- "$SOURCE"/plugin* "$DEST"
    fi
    ```
    Preserves local shell-glob for `FROMUSB`/`FROMLOCAL`; uses rsync filters for daemon where no local glob exists (covers `plugins` + `plugindata` per `www/common.php:50`).

*   **Truthful tail (`:298-312`)** — `if [ "$OVERALL_RC" -ne 0 ]; then echo "BACKUP FAILED (rc=$OVERALL_RC)"; else echo "BACKUP COMPLETE"; fi; exit $OVERALL_RC` — lets `www/copystorage.php:87` (`/bin/bash -o pipefail -c "... | tee -a"`) log true `rc` via `FppdLogLine` `backup FINISH: ... (rc=...)` (`www/copystorage.php:145`) and show failure in the copy window.

## Why this vs #2903

#2903 fixed *listing* (`www/api/controllers/backups.php:163`/`191` `flock` + per-device `/mnt/tmp_$device`, `www/common.php:4630`/`4702`). Without this PR, the listing now shows the backup but the restore still fails at `rsync`. Both are required for end-to-end File Copy.

## Testing

*   `bash -n scripts/copy_settings_to_storage.sh` — syntax OK; `shellcheck --severity=error` — 0 errors (`SC2086` unquoted `$EXTRA_ARGS`/`$REMOTE_COMPRESS` intentional, `SC2166` `[ -o ]` pre-existing)
*   `php -l www/copystorage.php` / `www/common.php` / `www/api/controllers/backups.php` — no syntax errors
*   `grep -c '"\$SOURCE"/\*'` → `0` (no daemon glob); `grep -c 'rsync.* -- "\$SOURCE'` → `18` single `--` before SOURCE correct; remaining 4 ` -- "\$DEST"` hits are `realpath -m -- "$DEST"` / `mkdir -p -- "$DEST"` at `scripts/copy_settings_to_storage.sh:88,94,107,113` — intentional guards, not rsync
*   Dry-run arg expansion: old `"$SOURCE"/* -- "$DEST"` → `192.168.14.55::media/.../* -- /home/fpp/media` (rejected); new `"$SOURCE"/ "$DEST"` → `192.168.14.55::media/.../ /home/fpp/media` (daemon-safe)
*   Manual `FROMREMOTE` `192.168.14.55::media/backups/FPPGoodBAD-20260904` before → all categories `code 1` + false `BACKUP COMPLETE`; after → `rsync ... -- host::path/ dest` succeeds, induced failure prints `BACKUP FAILED (rc=1)` and `fppd.log:145` shows `rc=1`, success shows `rc=0`
*   `FROMLOCAL`/`FROMUSB`/`TOLOCAL`/`TOREMOTE` — `"$SOURCE"/` and `"$SOURCE"/plugin*` still expand correctly for local sources
*   Local rsync simulation — `rsync --exclude=music/* -- "$TMP/src"/` correctly creates empty `music/` and copies `plugins/`+`plugindata/` via `--include='plugin*'`, `PIPESTATUS`→`OVERALL_RC` retention verified

## Breaking Changes

None. No API/JS change. `www/js/fpp-backup-filecopy.js` unchanged. Excludes for `backups/*`/`lost+found` (`#2714`/`#2856`) retained.

## Additional Comments

Once merged, mark #2906 as "Fix Applied - Testing Required".