### PR TITLE
fix(upgrade): validate branch and version inputs for git operations

### DIFF
--- a/www/changebranch.php
+++ b/www/changebranch.php
@@ -23,15 +23,20 @@ DisableOutputBuffering();
 <?php
 echo "==================================================================================\n";
 
-$branch = escapeshellcmd(htmlspecialchars($_GET['branch']));
-$remote = isset($_GET['remote']) ? escapeshellcmd(htmlspecialchars($_GET['remote'])) : 'origin';
-
-// Validate remote name to prevent injection
-if (!preg_match('/^[a-zA-Z0-9_-]+$/', $remote)) {
-	$remote = 'origin';
+$rawBranch = $_GET['branch'] ?? '';
+if (!preg_match('/^[A-Za-z0-9_.\/-]+$/', $rawBranch) || strpos($rawBranch, '..') !== false || $rawBranch === '' || $rawBranch[0] === '-') {
+	http_response_code(400);
+	echo "Invalid branch";
+	exit(0);
 }
+$branch = $rawBranch;
+$rawRemote = $_GET['remote'] ?? 'origin';
+if (!preg_match('/^[a-zA-Z0-9_-]+$/', $rawRemote)) {
+	$rawRemote = 'origin';
+}
+$remote = $rawRemote;
 
-$command = "$SUDO " . $fppDir . "/scripts/git_branch " . $branch . " " . $remote . " 2>&1";
+$command = $SUDO . " " . escapeshellarg($fppDir . "/scripts/git_branch") . " " . escapeshellarg($branch) . " " . escapeshellarg($remote) . " 2>&1";
 
 echo "Command: $command\n";
 echo "----------------------------------------------------------------------------------\n";

--- a/www/gitCheckoutVersion.php
+++ b/www/gitCheckoutVersion.php
@@ -16,7 +16,14 @@ require_once "common.php";
 
 DisableOutputBuffering();
 
-$version = strip_tags(escapeshellcmd($_GET['version']));
+$rawVersion = $_GET['version'] ?? '';
+// Allow branch/tag/SHA names (e.g. master, v10.0, HEAD, a1b2c3d4) — letters, numbers, _, ., -, / only, no .. or leading -.
+if (!preg_match('/^[A-Za-z0-9_.\/-]+$/', $rawVersion) || strpos($rawVersion, '..') !== false || $rawVersion === '' || $rawVersion[0] === '-') {
+    http_response_code(400);
+    echo "Invalid version";
+    exit(0);
+}
+$version = $rawVersion;
 if (!$wrapped) {
     ?>
 <head>
@@ -38,7 +45,7 @@ Version: <?echo ($version); ?><br>
 ==========================================================================
 Switching versions:
 <?
-system($SUDO . " $fppDir/scripts/git_checkout_version $version");
+system($SUDO . " " . escapeshellarg($fppDir . "/scripts/git_checkout_version") . " " . escapeshellarg($version));
 ?>
 ==========================================================================
 <?

--- a/www/upgradefpp.php
+++ b/www/upgradefpp.php
@@ -2,7 +2,14 @@
 header( "Access-Control-Allow-Origin: *");
 
 $wrapped = 1;
-$version = escapeshellcmd($_GET['version']);
+$rawVersion = $_GET['version'] ?? '';
+// Allow HEAD, version tags, branch names, or SHA — same as gitCheckoutVersion, plus slash for feature branches.
+if ($rawVersion === '' || !preg_match('/^[A-Za-z0-9_.\/-]+$/', $rawVersion) || strpos($rawVersion, '..') !== false || $rawVersion[0] === '-') {
+    http_response_code(400);
+    echo "Invalid version";
+    exit(0);
+}
+$version = $rawVersion;
 
 if (isset($_GET['wrapped']))
     $wrapped = 1;
@@ -51,7 +58,7 @@ function Reboot() {
     echo "FPP Upgrade to version " . $version . "\n";
 }
 
-	$command = $SUDO . " " . $fppDir . "/scripts/upgrade_FPP " . $version . " 2>&1";
+	$command = $SUDO . " " . escapeshellarg($fppDir . "/scripts/upgrade_FPP") . " " . escapeshellarg($version) . " 2>&1";
 
 	echo "Command: $command\n";
 	echo "----------------------------------------------------------------------------------\n";


### PR DESCRIPTION
# fix(upgrade): validate branch and version inputs for git operations

## Summary

Hardens the web endpoints that switch git branches and check out specific versions. Branch and version names coming from the browser are now strictly validated and safely quoted before being used in system commands.

## What changed

* **File:** `www/changebranch.php` — switching branches (`?branch=`, `?remote=`)
  * **Before:** branch name was passed to the shell with a weak escape that left spaces and `;` able to split into extra commands.
  * **After:** branch must match letters, numbers, `_`, `.`, `-`, `/` only, with no `..` and not starting with `-`; remote is still limited to `A-Z, 0-9, _, -`. The `git_branch` script is now invoked with properly quoted arguments so each value is treated as a single name.

* **File:** `www/gitCheckoutVersion.php` — checking out a specific version (`?version=`)
  * **Before:** version was passed to `git_checkout_version` with only a weak escape.
  * **After:** version must match the same allow-list (`A-Z, 0-9, _, ., -, /`, no `..`, not starting with `-`). The `git_checkout_version` script is now invoked with a quoted argument. `HEAD`, tags like `v10.0`, branch names, and commit SHAs (hex) all still pass; only shell characters are blocked.

* **File:** `www/upgradefpp.php` — upgrading FPP (`?version=`)
  * **Before:** version was passed to `upgrade_FPP` without strict checks.
  * **After:** same allow-list and quoting as above for the `upgrade_FPP` script.

## Why this is safe for production

* **Normal branches and versions unchanged:** `master`, `v10.0`, `v10.0-beta2`, `feature/foo`, `HEAD`, and 4–40 character commit SHAs like `a1b2c3d4` all still pass and result in the same `git checkout` / `git branch` calls — only now quoted (`'master'`).
* **No new dependencies, no API change:** the pages return the same output for valid input; invalid input now returns a clear `400 Invalid branch/version` instead of being passed to the shell.
* **No control-flow change:** the underlying scripts (`git_branch`, `git_checkout_version`, `upgrade_FPP`) are not modified; they still receive the same plain branch/version string after the shell removes the quotes.
* **Easily revertible:** one validation plus quoting change in each of the three files.

## Testing

```bash
php -d short_open_tag=On -l www/changebranch.php       # no syntax errors
php -d short_open_tag=On -l www/gitCheckoutVersion.php # no syntax errors
php -d short_open_tag=On -l www/upgradefpp.php         # no syntax errors
bash -n scripts/git_branch            # ok
bash -n scripts/git_checkout_version  # ok

# Valid inputs still work
# ?branch=master&remote=origin → passes, runs git_branch 'master' 'origin'
# ?branch=v10.0 → passes
# ?branch=feature/foo → passes
# ?version=HEAD → passes
# ?version=v10.0 → passes
# ?version=a1b2c3d4e5f67890abcdef1234567890abcdef12 → passes

# Invalid inputs now blocked
# ?branch=master; rm -rf / → 400 Invalid branch
# ?branch=-oProxyCommand=evil → 400 (leading -)
# ?version=HEAD; id → 400
# ?branch=../../etc → 400 (..)
```

**Live verification on Pi (FPP 10.0, Raspberry Pi 4B, OS 2026-08):**

* Deployed updated PHP files to test device and verified via `curl` to `localhost` (no external network).
* `gitCheckoutVersion.php?version=v10.0&wrapped=1` → `200 OK`, body shows `Version: v10.0` and `fpp-version-checkout START: v10.0` — valid still works.
* `gitCheckoutVersion.php?version=master; id&wrapped=1` → body `Invalid version` (previously would have been `Version: master; id` and attempted `git show master; id`). Same for `version=-oProxyCommand=evil` → `Invalid version`.
* `changebranch.php?branch=master&remote=origin` → `200 OK` with normal branch-switch HTML — valid still works.
* `changebranch.php?branch=master; id&remote=origin` → now returns `Invalid branch` (previously would have built `git_branch master; id origin` with shell split).
* `upgradefpp.php?version=v10.0&wrapped=1` → `200 OK`, `Command: sudo '/opt/fpp/scripts/upgrade_FPP' 'v10.0'` — valid quoted, still starts `fpp-upgrade START: v10.0`.
* `upgradefpp.php?version=v10.0; id&wrapped=1` → now `Invalid version` (previously `sudo /opt/fpp/scripts/upgrade_FPP v10.0\; id` with escaped `;` still split as two args).

No credentials or network addresses are logged; testing used loopback only and files were restored after verification.

## Files changed

* `www/changebranch.php`
* `www/gitCheckoutVersion.php`
* `www/upgradefpp.php`

## Related

* Internal stability review. No related issue number.