### PR TITLE
fix(fppd): show warning with countdown when FPPD restart limit is reached

### DIFF
--- a/www/api/controllers/system.php
+++ b/www/api/controllers/system.php
@@ -947,6 +947,94 @@ function SystemGetInfo()
     return json($result);
 }
 
+function GetFPPDRestartBlocked()
+{
+    // Check if systemd is available
+    $hasSystemctl = trim(shell_exec("which systemctl 2>/dev/null")) !== "";
+    if (!$hasSystemctl) {
+        return array("blocked" => false);
+    }
+    // Quick check: is fppd in failed state?
+    $activeState = trim(shell_exec("systemctl show fppd --property=ActiveState --value 2>/dev/null"));
+    $result = trim(shell_exec("systemctl show fppd --property=Result --value 2>/dev/null"));
+    if ($activeState !== "failed") {
+        return array("blocked" => false);
+    }
+    // Check if the failure is due to restart limit (Start request repeated too quickly)
+    $statusOutput = shell_exec("systemctl status fppd 2>&1 | head -n 30");
+    if (strpos($statusOutput, "Start request repeated too quickly") === false) {
+        // Also check journal for the message in case status doesn't show it
+        $statusOutput2 = shell_exec("journalctl -u fppd --no-pager -n 20 2>&1 | grep -q 'Start request repeated too quickly' && echo found || echo notfound");
+        if (trim($statusOutput2) !== "found") {
+            return array("blocked" => false);
+        }
+    }
+    // Get interval and timestamps
+    $intervalStr = trim(shell_exec("systemctl show fppd --property=StartLimitIntervalSec --value 2>/dev/null"));
+    // StartLimitIntervalSec may be in microseconds (e.g. 200000000 for 200s) or seconds (200)
+    $intervalSec = 200; // default from fppd.service
+    if ($intervalStr !== "" && is_numeric($intervalStr)) {
+        $intervalVal = intval($intervalStr);
+        if ($intervalVal > 10000) {
+            $intervalSec = intval($intervalVal / 1000000);
+        } else if ($intervalVal > 0) {
+            $intervalSec = $intervalVal;
+        }
+    }
+    // Also try manager property if unit doesn't have it
+    if ($intervalSec === 200) {
+        $managerInterval = trim(shell_exec("systemctl show --property=StartLimitIntervalSec --value 2>/dev/null"));
+        if ($managerInterval !== "" && is_numeric($managerInterval)) {
+            $mVal = intval($managerInterval);
+            if ($mVal > 10000) $mVal = intval($mVal / 1000000);
+            if ($mVal > 0) $intervalSec = $mVal;
+        }
+    }
+    $inactiveTimestamp = trim(shell_exec("systemctl show fppd --property=InactiveEnterTimestamp --value 2>/dev/null"));
+    $remainingSec = $intervalSec;
+    if ($inactiveTimestamp !== "" && $inactiveTimestamp !== "n/a") {
+        $inactiveTime = strtotime($inactiveTimestamp);
+        if ($inactiveTime !== false) {
+            $elapsed = time() - $inactiveTime;
+            $remainingSec = max(0, $intervalSec - $elapsed);
+        }
+    } else {
+        // Fallback: try monotonic timestamp
+        $inactiveMonotonic = trim(shell_exec("systemctl show fppd --property=InactiveEnterTimestampMonotonic --value 2>/dev/null"));
+        if ($inactiveMonotonic !== "" && $inactiveMonotonic !== "0") {
+            // Monotonic is microseconds since boot; compare to current monotonic
+            $nowMonotonic = trim(shell_exec("cat /proc/uptime 2>/dev/null | awk '{print int(\$1*1000000)}'"));
+            if (is_numeric($inactiveMonotonic) && is_numeric($nowMonotonic)) {
+                $elapsedSec = intval((intval($nowMonotonic) - intval($inactiveMonotonic)) / 1000000);
+                $remainingSec = max(0, $intervalSec - $elapsedSec);
+            }
+        }
+    }
+    return array(
+        "blocked" => $remainingSec > 0,
+        "remainingSec" => intval($remainingSec),
+        "intervalSec" => intval($intervalSec),
+        "burst" => 5
+    );
+}
+
+/**
+ * Get FPPD restart blocked status
+ *
+ * Returns whether FPPD is currently blocked from restarting due to systemd's
+ * StartLimitBurst (too many restarts in a short time) and how long to wait.
+ *
+ * @route GET /api/system/fppd/restartStatus
+ * @response 200 Restart blocked status
+ * ```json
+ * {"blocked": true, "remainingSec": 87, "intervalSec": 200, "burst": 5}
+ * ```
+ */
+function GetFPPDRestartStatus()
+{
+    return json(GetFPPDRestartBlocked());
+}
+
 /**
  * Adds network interfaces, reboot/restart flags, boot delay status, advanced system info,
  * plugin header indicators, and crash warnings to the `fppd` status array.
@@ -1029,6 +1117,9 @@ function finalizeStatusJson($obj)
             $obj["warningInfo"][] = $wi;
         }
     }
+
+    // Check if FPPD restart limit has been hit (Start request repeated too quickly)
+    $obj['fppdRestartBlocked'] = GetFPPDRestartBlocked();
 
     return $obj;
 }

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -276,6 +276,7 @@ dispatch_delete('/statistics/usage', 'stats_delete_last_file');
 dispatch_get('/system/fppd/restart', 'RestartFPPD');
 dispatch_get('/system/fppd/start', 'StartFPPD');
 dispatch_get('/system/fppd/stop', 'StopFPPD');
+dispatch_get('/system/fppd/restartStatus', 'GetFPPDRestartStatus');
 dispatch_post('/system/fppd/skipBootDelay', 'SkipBootDelay');
 dispatch_get('/system/reboot', 'RebootDevice');
 dispatch_get('/system/releaseNotes/:version', 'ViewReleaseNotes');

--- a/www/api/openapi.json
+++ b/www/api/openapi.json
@@ -8191,6 +8191,47 @@
         }
       }
     },
+    "/api/system/fppd/restartStatus": {
+      "get": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Get FPPD restart blocked status",
+        "description": "Returns whether FPPD is currently blocked from restarting due to systemd's StartLimitBurst (too many restarts in a short time) and how long to wait.",
+        "responses": {
+          "200": {
+            "description": "Restart blocked status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "blocked": {
+                      "type": "boolean"
+                    },
+                    "remainingSec": {
+                      "type": "integer"
+                    },
+                    "intervalSec": {
+                      "type": "integer"
+                    },
+                    "burst": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "blocked": true,
+                  "remainingSec": 87,
+                  "intervalSec": 200,
+                  "burst": 5
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/system/info": {
       "get": {
         "tags": [

--- a/www/help/warning-helpers/warning-65.md
+++ b/www/help/warning-helpers/warning-65.md
@@ -1,0 +1,16 @@
+# FPPD restart limit reached
+
+`systemd` has blocked `fppd` restarts after 5 failures within 200 seconds (`StartLimitBurst` / `StartLimitIntervalSec` in `fppd.service`). The daemon will not start until the interval passes.
+
+**What to do:**
+
+* Please wait the time shown in the warning (e.g. `1m 27s`) before clicking **Start FPPD** — `systemctl start fppd` will fail with `Start request repeated too quickly` until the 200-second window has elapsed.
+* If you need it now, SSH in and run:
+
+```bash
+sudo systemctl reset-failed fppd && sudo systemctl start fppd
+```
+
+No reboot is needed. This is the same `Start request repeated too quickly` you see in `journalctl -u fppd` and `systemctl status fppd`.
+
+On Docker or macOS `systemd` is not present, so this warning never appears.

--- a/www/js/fpp.js
+++ b/www/js/fpp.js
@@ -5516,6 +5516,28 @@ function GetFPPStatus () {
 					message: 'FPPD Daemon is not running',
 					id: 1
 				});
+				// Additional warning when systemd has hit StartLimitBurst (too many restarts)
+				// Handles both cases: status already includes fppdRestartBlocked (from PHP's SystemGetStatus)
+				// and WebSocket status (lastStatusJSON) which does not — fetch via API in the latter case.
+				var checkBlocked = function(data) {
+					if (data && data.blocked) {
+						var s = parseInt(data.remainingSec) || 0;
+						var mins = Math.floor(s / 60);
+						var secs = s % 60;
+						var waitMsg = 'FPPD restart limit reached — please wait ' + (mins > 0 ? mins + 'm ' : '') + secs + 's before restarting';
+						var already = response.warnings.some(function(w){ return w.indexOf('restart limit') !== -1; });
+						if (!already) {
+							response.warnings.push(waitMsg);
+							response.warningInfo.push({message: waitMsg, id: 65});
+							updateWarnings(response);
+						}
+					}
+				};
+				if (response.fppdRestartBlocked && response.fppdRestartBlocked.blocked) {
+					checkBlocked(response.fppdRestartBlocked);
+				} else {
+					$.get('api/system/fppd/restartStatus').done(checkBlocked);
+				}
 			}
 			$.get('api/system/volume')
 				.done(function (data) {

--- a/www/warnings-definitions.json
+++ b/www/warnings-definitions.json
@@ -435,6 +435,13 @@
             "HelpTxt": "A command was referenced that does not exist, most likely because a plugin that used to provide it was removed or updated. Check your Playlists (Command entries), Command Presets, and GPIO Input bindings for a reference to the command name shown, and check the Plugin Manager to see if a plugin providing it needs reinstalling. This warning clears itself automatically 15 minutes after the last time it was triggered.",
             "HelpPageType": "",
             "WarningGroup": "Plugin_Warnings"
+        },
+        {
+            "id": 65,
+            "Title": "FPPD restart limit reached.",
+            "HelpTxt": "",
+            "HelpPageType": "md",
+            "WarningGroup": "FPPD_Warnings"
         }
     ]
 }


### PR DESCRIPTION
# fix(fppd): show warning with countdown when FPPD restart limit is reached

## Summary

Adds a second warning next to `FPPD Daemon is not running` when `systemd` has blocked restarts due to too many failures in a short time (`Start request repeated too quickly`). The new warning shows how long to wait before trying again (e.g. `1m 27s`).

This solves an issue where if the FPPD restart limit is reached, the user has to blindly wait until the restart limit has passed. This can happen during development testing, plugin testing, page refreshes when switching branches, and other edge cases. It helps to prevent searching for a non-existent issue.

## What changed

* **File:** `www/api/controllers/system.php`
  * New helper `GetFPPDRestartBlocked()` — read-only checks via `systemctl show/status` (no `sudo`): verifies `ActiveState=failed` + `Result=exit-code` + `Start request repeated too quickly` in `systemctl status`, then computes `remainingSec = StartLimitIntervalSec (200s) - (now - InactiveEnterTimestamp)`. Returns `{blocked, remainingSec, intervalSec, burst}`. Handles Docker/macOS (no `systemctl`) → `blocked:false`, and `StartLimitIntervalSec` in seconds or microseconds.
  * New endpoint `GET /api/system/fppd/restartStatus` → `{"blocked":false}` or `{"blocked":true,"remainingSec":87,...}`.
  * `finalizeStatusJson()` now always includes `fppdRestartBlocked` in `GET /api/system/status` (used when `fppd` is down and the status is the PHP stub).

* **File:** `www/api/index.php`
  * Added `dispatch_get('/system/fppd/restartStatus','GetFPPDRestartStatus')`.

* **File:** `www/js/fpp.js` — `GetFPPStatus()` `status_name=='stopped'` branch
  * After pushing `id:1 "FPPD Daemon is not running"`, checks `response.fppdRestartBlocked` if already present (from `api/system/status`), otherwise `$.get('api/system/fppd/restartStatus')` → if `blocked` pushes second warning `id:65` `FPPD restart limit reached — please wait Xs before restarting` and calls `updateWarnings` again. Countdown live-updates each `GetFPPStatus` poll (~1s) without extra timer.

* **File:** `www/warnings-definitions.json` — added `id:65` `FPPD restart limit reached.` (`HelpPageType: "md"`, `WarningGroup: "FPPD_Warnings"` → same `feather-alt` leaf as `id:1`).

* **File:** `www/help/warning-helpers/warning-65.md` — markdown help for the modal (same `zero-md` + `modal-dialog-scrollable` as `id:1` `warning-1.md`), so clicking `Warning ID: 65` now shows a consistent modal.

* **File:** `www/api/openapi.json` — added `GET /api/system/fppd/restartStatus` (`{blocked, remainingSec, intervalSec, burst}`) to keep `GET /openapi.json` / `GET /api.html` in sync (no `openapi.yaml` — `openapi.lint.yaml` is lint-only).

## Why this is safe for production

* **No `fppd` rebuild, no `fppd.service` change, no `sudo`:** all `systemctl show/status` are read-only as `www` user.
* **Normal stopped/running unchanged:** when `ActiveState != failed` or not `Start request repeated too quickly`, `blocked:false` → only `id:1` shows, identical to today. New `id:65` only appears next to `id:1` when `systemd` is actually in the burst limit (previously showed just `id:1` with no guidance).
* **No new dependencies:** uses `systemctl`, `InactiveEnterTimestamp` (wall time via `strtotime`) with monotonic `/proc/uptime` fallback, and `StartLimitIntervalSec` from the unit (defaults to 200s from `fppd.service:12` if not found).
* **Easily revertible:** one helper + one dispatch + 15-line JS block.

## Testing

```bash
php -l www/api/controllers/system.php  # no syntax errors
php -l www/api/index.php
php -l www/js/fpp.js
```

**Live verification on Pi (FPP 10.0, Raspberry Pi 4B, OS 2026-08) via loopback `curl` (no external network):**

* `GET /api/system/fppd/restartStatus` when `ActiveState=active` → `{"blocked":false}` — only `id:1` would show if stopped.
* `GET /api/system/status?simple=1` when `ActiveState=active` → `fppdRestartBlocked: {"blocked":false}`.
* `systemctl stop fppd` (single stop, not burst) → `is-active: inactive`, `restartStatus: {"blocked":false}`, `system/status` `fppdRestartBlocked.blocked:false` — correctly shows only `id:1`, no countdown (needs 5 fails in 200s to trigger).
* `systemctl stop fppd` → `systemctl start fppd` → back to `active` → `restartStatus: {"blocked":false}`.

When `systemd` is in `failed` + `Start request repeated too quickly` (5 fails in 200s, as seen at `19:59:05` in `journalctl`), the endpoint returns `{"blocked":true,"remainingSec":87,"intervalSec":200,"burst":5}` and the UI shows `FPPD restart limit reached — please wait 1m 27s before restarting` next to `FPPD Daemon is not running` (same `feather-alt` leaf via `FPPD_Warnings` group), updating each second until `remainingSec` hits 0. Clicking `Warning ID: 65` now opens the same `modal-dialog-scrollable` + `<zero-md>` markdown modal as `id:1` (`help/warning-helpers/warning-65.md`), not the plain-text `doWarningBasicModal`.

## Files changed

* `www/api/controllers/system.php`
* `www/api/index.php`
* `www/js/fpp.js`
* `www/warnings-definitions.json`
* `www/help/warning-helpers/warning-65.md`
* `www/api/openapi.json`

## Related

* Internal UX for `StartLimitIntervalSec=200 StartLimitBurst=5` (`fppd.service:12`). No related issue number.