### PR TITLE
BBShiftString: gate the receiver enable pin on any Falcon receiver, not just V5

### DIFF
--- a/src/non-gpl/BBShiftString/BBShiftString.cpp
+++ b/src/non-gpl/BBShiftString/BBShiftString.cpp
@@ -520,6 +520,7 @@ int BBShiftStringOutput::Init(Json::Value config) {
         hasV5SR = false;
     }
     m_hasBidirSR = hasV5SR;
+    m_hasFalconSR = hasFalconSR;
 
     int curRecPort = -1;
     for (int x = 0; x < m_strings.size(); x++) {
@@ -676,9 +677,10 @@ int BBShiftStringOutput::Init(Json::Value config) {
     m_pru1.formattedData = (uint8_t*)calloc(1, m_pru1.frameSize);
 #endif
 
-    if (supportsV5Listeners && hasV5SR) {
+    if (supportsV5Listeners && hasFalconSR) {
         // if the cape supports v5 listeners, the enable pin needs to be
-        // configured or data won't be sent on port1 of each receiver
+        // configured or data won't be sent on port1 of each receiver.
+        // Gated on hasFalconSR, not hasV5SR: a V4 receiver needs the same pin.
         PinCapabilities::getPinByName(PRU1_ENABLE_PIN).configPin("pru1out", true, "BBShiftString-Enable");
     }
     if (hasFalconSR) {
@@ -923,7 +925,7 @@ int BBShiftStringOutput::Close(void) {
     for (auto& a : m_usedPins) {
         PinCapabilities::getPinByName(a.first).releasePin();
     }
-    if (supportsV5Listeners && m_hasBidirSR) {
+    if (supportsV5Listeners && m_hasFalconSR) {
         PinCapabilities::getPinByName(PRU1_ENABLE_PIN).releasePin();
     }
     return ChannelOutput::Close();

--- a/src/non-gpl/BBShiftString/BBShiftString.h
+++ b/src/non-gpl/BBShiftString/BBShiftString.h
@@ -248,6 +248,10 @@ private:
     // any configured Falcon V5 (bidirectional) receivers after the
     // capability checks; V4 (send-only) chains do not set this
     bool m_hasBidirSR = false;
+    // any configured Falcon receiver, V4 or V5. The cape enable pin gates data
+    // to the receiver regardless of protocol version, so it must be configured
+    // and released on this rather than on m_hasBidirSR.
+    bool m_hasFalconSR = false;
 
     void prepData(FrameData& d, unsigned char* channelData);
     void sendData(FrameData& d);


### PR DESCRIPTION
**TL;DR** — On a cape with V5 listener support the PRU1 enable pin is gated on `hasV5SR`. With a Falcon V4 receiver that flag is false, the pad is never configured, and port 1 of every receiver stays dark. Gate it on `hasFalconSR` instead — already computed two lines away, and already used for the V5 setup right below it.

**Fix** — one member, three lines. `Close()` mirrors the same condition.

**Tested** — two vendors, same cable and string throughout, K32-Max:

| receiver | `differentialType` | before | after |
| --- | --- | --- | --- |
| Falcon SRx1 V5 | Falcon V4 (16) | silent wire, no detection | clean |
| Genius 4-Output LR | Falcon V4 (16) | silent wire, no detection | full 4-min sequence, steady 40.0 fps, 0 resyncs, 0 log errors |

**Unchanged** — `willListen` and `addListeners()` keep using `m_hasBidirSR`; those are genuinely V5-only.

**Known gap** — v1/v2 receivers set neither flag and stay dark. Same root cause, out of scope here.

Refs #2854
