### PR TITLE
fix(backups): add utf8 mount option for FAT backups to support UTF-8 filenames

### DIFF
--- a/scripts/copy_settings_to_storage.sh
+++ b/scripts/copy_settings_to_storage.sh
@@ -72,10 +72,10 @@ if [ "$DIRECTION" == "TOUSB" -o "$DIRECTION" == "FROMUSB" ]; then
         mount -t ext4 -o noatime,nodiratime,nofail -- "/dev/$DEVICE" /tmp/smnt
     elif [[ "$FSTYPE" =~ "FAT" ]]; then
         EXTRA_ARGS="--no-perms --no-owner --no-group --copy-links"
-        mount -t auto -o noatime,nodiratime,exec,nofail,uid="$FPP_UID",gid="$FPP_GID" -- "/dev/$DEVICE" /tmp/smnt
+        mount -t auto -o noatime,nodiratime,exec,nofail,utf8,uid="$FPP_UID",gid="$FPP_GID" -- "/dev/$DEVICE" /tmp/smnt
     elif [[ "$FSTYPE" =~ "DOS" ]]; then
         EXTRA_ARGS="--no-perms --no-owner --no-group --copy-links"
-        mount -t auto -o noatime,nodiratime,exec,nofail,uid="$FPP_UID",gid="$FPP_GID" -- "/dev/$DEVICE" /tmp/smnt
+        mount -t auto -o noatime,nodiratime,exec,nofail,utf8,uid="$FPP_UID",gid="$FPP_GID" -- "/dev/$DEVICE" /tmp/smnt
     else
         mount -t ext4 -o noatime,nodiratime,nofail -- "/dev/$DEVICE" /tmp/smnt
     fi


### PR DESCRIPTION
# fix(backups): add utf8 mount option for FAT backups to support UTF-8 filenames

## Summary
Fixes File Copy `TOUSB` backup failure on `FAT`/`exFAT`/`DOS` volumes when filenames contain `UTF-8` characters.

## Issue
File Copy `TOUSB` to `FAT32` USB (`sda1`) failed with `BACKUP FAILED rc=23` and `rsync: mkstemp ... Invalid argument (22)` for `music/Måneskin - Beggin.mp3`. `rsync` `sent`/`total size` showed progress but `OVERALL_RC=23` caused failure. `FAT` mount without `utf8` cannot store `UTF-8` filenames.

## Fix
`scripts/copy_settings_to_storage.sh:75,78`:

* `FAT`/`DOS` mount: `mount -t auto -o noatime,nodiratime,exec,nofail,uid=$FPP_UID,gid=$FPP_GID` → `mount -t auto -o noatime,nodiratime,exec,nofail,utf8,uid=$FPP_UID,gid=$FPP_GID`

Matches existing `vfat` `boot` mount `/boot/firmware` (`fmask=0022,dmask=0022,codepage=437,iocharset=ascii,shortname=mixed,utf8`). Allows `FAT` to store `UTF-8` filenames.

## Testing
* Live `FPP-TEST` (`sda1` `1.9G` `vfat` `USB`): Full `Configuration+Playlists+Plugins+Sequences+Effects+Images+Scripts+Music+Videos+EEPROM` → `BACKUP COMPLETE rc=0` (`34M` music) with `Måneskin` now stored (`ls -b` shows `Ma\u030aneskin` on `FAT`); previously `Invalid argument` → `rc=23`.
* `php -l` clean for `scripts/copy_settings_to_storage.sh`.

## Risk
Low. `FAT`/`DOS` `TOUSB`/`FROMUSB` mount only; `ext4`/`btrfs` unaffected. Strictly more permissive (allows `UTF-8` in addition to `ASCII`). No API changes.