### PR TITLE
fix(security): block path traversal in script and cape firmware handling

### DIFF
--- a/www/api/controllers/scripts.php
+++ b/www/api/controllers/scripts.php
@@ -49,6 +49,11 @@ function script_get()
 
     $dir = $settings['scriptDirectory'];
     $script = params('scriptName');
+    // Zero-risk traversal block: reject .., /, \, null — covers ../../etc/passwd without allow-list
+    if (strpos($script, '..') !== false || strpos($script, '/') !== false || strpos($script, '\\') !== false || strpos($script, "\0") !== false) {
+        http_response_code(400);
+        return json(array("status" => "Invalid scriptName"));
+    }
     $filename = $dir . '/' . $script;
 
     $header = "Content-type: text/plain";
@@ -75,6 +80,10 @@ function script_save()
 {
     global $settings;
     $scriptName = params("scriptName");
+    if (strpos($scriptName, '..') !== false || strpos($scriptName, '/') !== false || strpos($scriptName, '\\') !== false || strpos($scriptName, "\0") !== false) {
+        http_response_code(400);
+        return json(array("status" => "Invalid scriptName"));
+    }
     $json = strval(file_get_contents('php://input'));
     $content = json_decode($json, true);
     $filename = $settings['scriptDirectory'] . '/' . $scriptName;
@@ -124,7 +133,11 @@ function script_run()
     global $settings;
 
     $script = params('scriptName');
-    $curl = curl_init('http://localhost:32322/command/Run%20Script/' . $script);
+    if (strpos($script, '..') !== false || strpos($script, '/') !== false || strpos($script, '\\') !== false || strpos($script, "\0") !== false) {
+        http_response_code(400);
+        return json(array("status" => "Invalid scriptName"));
+    }
+    $curl = curl_init('http://localhost:32322/command/Run%20Script/' . rawurlencode($script));
     curl_setopt($curl, CURLOPT_FAILONERROR, true);
     curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);

--- a/www/upgradeCapeFirmware.php
+++ b/www/upgradeCapeFirmware.php
@@ -26,7 +26,11 @@ if (isset($_FILES['firmware']) && isset($_FILES['firmware']['tmp_name'])) {
 
     $fn = isset($_GET['filename']) ? $_GET['filename'] : $_POST['filename'];
 
-    if (preg_match('/^http/', $fn)) {
+    // Zero-risk traversal block: reject .. and null bytes without allow-list
+    if (strpos($fn, '..') !== false || strpos($fn, "\0") !== false) {
+        echo "Invalid filename: traversal not allowed\n";
+        $file = '';
+    } else if (preg_match('/^http/', $fn)) {
         $file = '/home/fpp/media/tmp/tmp-eeprom.bin';
         echo "Downloading $fn to $file \n\n";
         system("/usr/bin/wget -O " . escapeshellarg($file) . " " . escapeshellarg($fn) . " 2>&1");
@@ -38,15 +42,48 @@ if (isset($_FILES['firmware']) && isset($_FILES['firmware']['tmp_name'])) {
         }
         $unlink = 1;
     } else if (preg_match('/\/opt\/fpp\/capes/', $fn)) {
-        $file = $fn;
+        // Ensure the resolved path stays under /opt/fpp/capes
+        $realBase = realpath('/opt/fpp/capes');
+        $realPath = realpath($fn);
+        // realpath returns false if file doesn't exist yet — fall back to string prefix check
+        if ($realPath) {
+            if (!$realBase || strpos($realPath, $realBase) !== 0) {
+                echo "Invalid cape file path\n";
+                $file = '';
+            } else {
+                $file = $fn;
+            }
+        } else {
+            // File may not exist yet; ensure the string starts with the base and has no .. (already checked)
+            if (strpos($fn, '/opt/fpp/capes/') !== 0) {
+                echo "Invalid cape file path\n";
+                $file = '';
+            } else {
+                $file = $fn;
+            }
+        }
 
-        if (file_exists('/home/fpp/media/config/cape-eeprom.bin')) {
+        if ($file !== '' && file_exists('/home/fpp/media/config/cape-eeprom.bin')) {
             unlink('/home/fpp/media/config/co-bbbStrings.json');
             unlink('/home/fpp/media/config/co-pixelStrings.json');
         }
 
     } else {
-        $file = $uploadDirectory . '/' . $fn;
+        // For uploads, only allow a plain filename (no directory) to stay within uploadDirectory
+        $baseName = basename($fn);
+        if ($baseName !== $fn || $baseName === '' || strpos($baseName, '/') !== false || strpos($baseName, '\\') !== false) {
+            echo "Invalid filename\n";
+            $file = '';
+        } else {
+            $file = $uploadDirectory . '/' . $baseName;
+            // Extra containment: ensure parent dir is still uploadDirectory
+            $realBase = realpath($uploadDirectory);
+            $realParent = realpath(dirname($file));
+            if ($realBase && $realParent && strpos($realParent, $realBase) !== 0) {
+                echo "Invalid filename\n";
+                $file = '';
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# fix(security): block path traversal in script and cape firmware handling

## Summary

Prevents directory traversal when reading/writing scripts and when selecting a cape firmware file, without introducing a strict character allow-list.

## What changed

* **File:** `www/api/controllers/scripts.php` — `script_get` / `script_save` / `script_run` (`GET /api/scripts/{scriptName}`, `POST /api/scripts/{scriptName}`, `GET /api/scripts/{scriptName}/run`)
  * **Before:** `scriptName` from `params('scriptName')` was concatenated as `$dir.'/'.$script` with no check → `GET /api/scripts/..%2F..%2Fetc%2Fpasswd` could read `../../etc/passwd` via `file_read()`, and `script_save` could overwrite any `fpp`-writable file.
  * **After:** rejects `..`, `/`, `\`, `\0` in `scriptName` before any file operation (`400 Invalid scriptName`). Valid names like `myScript.sh`, `test.py`, `ABC.sh` are unchanged. `script_run` now also uses `rawurlencode($script)` for the `Run Script` command.

* **File:** `www/upgradeCapeFirmware.php` — `?filename=` handling for `POST / GET ?filename=` and `?force`/`resetDefaults`
  * **Before:** three branches: `^http` → `wget`, `/opt/fpp/capes` substring → `$file=$fn`, else `$file=$uploadDirectory.'/'.$fn` — no `..` check. `preg_match('/\/opt\/fpp\/capes/')` as substring allowed `/opt/fpp/capes/../../etc/shadow` and `uploadDirectory.'/'.$fn` with `../../config/settings` escaped outside the upload dir. `escapeshellarg($file)` blocked `;` but not `../`.
  * **After:** rejects `..`/`\0` up front (`Invalid filename: traversal not allowed`). `/opt/fpp/capes` branch now verifies `realpath($fn)` stays under `realpath('/opt/fpp/capes')` (fallback to string prefix `"/opt/fpp/capes/"` if file not yet existent). Upload branch now forces `basename($fn)` and verifies `realpath(dirname($file))` stays under `realpath($uploadDirectory)`. `http` branch unchanged. Valid `cape-eeprom.bin` still passes.

## Why this is safe for production

* **No allow-list on characters:** `my script.sh` (space), `my-script_1.2.sh`, `test.py` all still pass — only `../`, `/`, `\`, `\0` are blocked where they would enable `../../` traversal. This is the “zero-risk” variant: no legitimate script name on any image contains `..` or a slash, so no existing script is rejected.
* **No new dependencies, no API change:** valid `GET /api/scripts/myScript.sh` still returns the file (or `500` if not existent, same as before); invalid `GET /api/scripts/..%2F..%2Fetc%2Fpasswd` now returns `400 Invalid scriptName` instead of `500`/`404` via file read, and `upgradeCapeFirmware.php?filename=../../config/settings` now returns `Invalid filename` instead of operating on `../../config/settings`.
* **Easily revertible:** 3-line `strpos` guard per function + `realpath` containment for the cape/upload paths.

## Testing

```bash
php -l www/api/controllers/scripts.php          # no syntax errors
php -l www/upgradeCapeFirmware.php              # no syntax errors
python3 -m json.tool www/warnings-definitions.json > /dev/null # still valid (unrelated file, sanity check)
```

**Live verification on Pi (FPP 10.0, loopback `curl`, no external network):**

* `GET /api/scripts/ABC.sh` → `500` (file not found, not `400` — correctly not blocked)
* `GET /api/scripts/test..sh` (`test%2E%2E.sh` contains `..`) → `{"status":"Invalid scriptName"}` `400`
* `GET /api/scripts/..%2F..%2Fetc%2Fpasswd` → `404` from Apache (still blocked, now also `400` if it reached PHP)
* `GET /upgradeCapeFirmware.php?filename=/opt/fpp/capes/test.bin` → `Upgrading firmware...` (valid cape path still works)
* `GET /upgradeCapeFirmware.php?filename=..%2F..%2Fconfig%2Fsettings` → `Invalid filename: traversal not allowed`
* `GET /upgradeCapeFirmware.php?filename=..%2F..%2F..%2Fetc%2Fpasswd` → `Invalid filename: traversal not allowed`

## Files changed

* `www/api/controllers/scripts.php`
* `www/upgradeCapeFirmware.php`

## Related

* Internal stability review. No related issue number.