### PR TITLE
fix(email): Exim4 smarthost implicit-TLS on port 465 (#2922)

### DIFF
--- a/SD/FPP_Install.sh
+++ b/SD/FPP_Install.sh
@@ -2003,6 +2003,9 @@ EOF
     # remove exim4 panic log so exim4 doesn't throw an alert about a non-zero log
     # file due to some odd error thrown during inital setup
     rm -f /var/log/exim4/paniclog
+    # FPP manages implicit-TLS for port 465 via /etc/exim4/conf.d/main/99_fpp_smarthost.
+    # The default smarthost here is ::587 (STARTTLS), so ensure no stale smtps macro ships in the image.
+    rm -f /etc/exim4/conf.d/main/99_fpp_smarthost
     #update config and restart exim
     update-exim4.conf
 

--- a/www/common.php
+++ b/www/common.php
@@ -3136,6 +3136,21 @@ function ApplyEmailConfig()
         return;
     }
 
+    // Debian Trixie split-config: transport 30_exim4-config_remote_smtp_smarthost
+    // honors .ifdef REMOTE_SMTP_SMARTHOST_PROTOCOL but ::465 no longer auto-defines it.
+    // FPP must set protocol = smtps for implicit-TLS on 465, and ensure 587/25 use plain smtp.
+    // Use dedicated conf.d/main/99_fpp_smarthost so we never clobber user's 00_local_macros.
+    $emailportInt = (int) $emailport;
+    $fppMacroStaged = $exim4Directory . '/99_fpp_smarthost';
+    $fppMacroLive = '/etc/exim4/conf.d/main/99_fpp_smarthost';
+    if ($emailportInt === 465) {
+        file_put_contents($fppMacroStaged, "REMOTE_SMTP_SMARTHOST_PROTOCOL=smtps\n");
+        exec("sudo mkdir -p /etc/exim4/conf.d/main && sudo cp " . escapeshellarg($fppMacroStaged) . " " . escapeshellarg($fppMacroLive));
+    } else {
+        @unlink($fppMacroStaged);
+        exec("sudo rm -f " . escapeshellarg($fppMacroLive));
+    }
+
     $exim4Conf = sprintf(
         "dc_eximconfig_configtype='smarthost'\n" .
         "dc_other_hostnames='%s'\n" .


### PR DESCRIPTION
# fix(email): Exim4 smarthost implicit-TLS on port 465 (#2922)

## Summary
Fixes silently failing email delivery on port 465 (implicit TLS) after Trixie upgrade. `ApplyEmailConfig()` now explicitly sets `REMOTE_SMTP_SMARTHOST_PROTOCOL=smtps` via dedicated `conf.d/main/99_fpp_smarthost` when `emailport=465`; ports `587`/`25` remain unchanged. Non-breaking: `587`/`25` config is byte-identical to master, no API/schema changes, no plugin ABI impact.

This is an attempt to resolve issue #2922.

## Root Cause
Debian Trixie split-config (`dc_use_split_config='true'` - `www/common.php:3149` / `SD/FPP_Install.sh:1996`) transport `30_exim4-config_remote_smtp_smarthost` honors:
```
.ifdef REMOTE_SMTP_SMARTHOST_PROTOCOL
  protocol = REMOTE_SMTP_SMARTHOST_PROTOCOL
```
but `dc_smarthost='host::465'` no longer auto-defines the macro. `www/common.php:3147` wrote `::465` and relied on auto-detection, so Exim fell back to `protocol = smtp` (plaintext + STARTTLS) on a port that requires TLS immediately. Yahoo dropped (`Remote host closed connection in response to initial connection`), Gmail returned auth error — both while `POST /api/email/test` (`www/api/controllers/email.php:40` `mail(1)` queue) reported success.

## Changes
### 1. `www/common.php:3082` `ApplyEmailConfig()` (primary fix)
- Added port-aware macro handling before `update-exim4.conf`:
  ```php
  $emailportInt = (int)$emailport;
  $fppMacroStaged = $exim4Directory.'/99_fpp_smarthost';
  $fppMacroLive   = '/etc/exim4/conf.d/main/99_fpp_smarthost';
  if ($emailportInt===465) { file_put_contents(... "smtps") + sudo mkdir -p/cp } else { @unlink + sudo rm -f }
  ```
- Uses dedicated `99_fpp_smarthost` (never `00_local_macros`) so user custom macros survive. `escapeshellarg` + existing `sudo` pattern. Runs before `sudo update-exim4.conf` at `www/common.php:3195`.

### 2. `SD/FPP_Install.sh:2006` `finalize_image_pre_build()`
- Bare `rm -f /etc/exim4/conf.d/main/99_fpp_smarthost` before bare `update-exim4.conf` (runs as root in chroot via `SD/build-image-pi.sh:513`, matches existing `rm -f /var/log/exim4/paniclog` pattern). Default `smtp.gmail.com::587` ships clean.

No change to `www/api/controllers/email.php:40` queue semantics, `www/settings.json:1433` schema, or plugin headers. Healing of already-broken `465` hosts requires one manual `Settings > Email > Configure Email` click.

## Testing
### Pi 4B — before/after (FPP-TEST)
**Before (reproduced #2922):**
```
cat /etc/exim4/conf.d/main/99_fpp_smarthost: No such file or directory
```
**After `emailport=465` + `ApplyEmailConfig()` (Configure Email):**
```
cat /etc/exim4/conf.d/main/99_fpp_smarthost: REMOTE_SMTP_SMARTHOST_PROTOCOL=smtps
grep -A2 protocol /var/lib/exim4/config.autogenerated: protocol = REMOTE_SMTP_SMARTHOST_PROTOCOL (inside .ifdef, expands to smtps)
cat /etc/exim4/update-exim4.conf.conf: dc_smarthost='smtp.abcdefg.com::465'
systemctl status exim4: active (running) 22:24:48, fpp-defer.conf
tail /var/log/exim4/mainlog: only daemon started/queue run, no "Remote host closed connection"
exim -bp: (empty)
```
**Round-trip:** `465` -> `587` via `Configure Email` correctly removes file; `config.autogenerated` reverts to `smtp` (STARTTLS). `587` is non-breaking.

### Local syntax
```
php -l www/common.php -> OK
bash -n SD/FPP_Install.sh -> OK
```

## Risk
Low. 2 files, <15 lines, `465` branch only. `587`/`25`/`unset`/MacOS/Docker/no-exim all no-ops. Dedicated `99_` file avoids clobbering `00_local_macros`.

## Additional Comments
Once merged, please mark issue #2922 as "Fix Applied - Testing Required".