### PR TITLE
fix(artnet): populate ArtPollReply universes from Channel Inputs (#2927)

### DIFF
--- a/src/e131bridge.cpp
+++ b/src/e131bridge.cpp
@@ -914,21 +914,36 @@ bool Bridge_HandleArtNetPoll(uint8_t* bridgeBuffer, long long packetTime) {
         snprintf(&buf[44], 64, "%s", hostname.c_str());  // Description (64 bytes)
         // buf[108] Status stays empty — memset already zeroed it, no snprintf needed
 
+        // ArtPollReply: advertise the ArtNet input universes actually configured.
+        // Previously this was hardcoded to 4 ports on universe 0 (all SwIn 0),
+        // so a controller polling FPP always saw universe 0 regardless of
+        // Settings > Channel Inputs (issue #2927). Populate from InputUniverses
+        // where type is ArtNet. Non-breaking: packet stays 240 bytes, IP/port/
+        // version/hostname unchanged — only the 16 universe-advertising bytes
+        // (172-193) now reflect configuration. Capped at 4 ports per spec.
+        std::vector<uint32_t> artNetUniverses;
+        {
+            std::lock_guard<std::mutex> lg(universesStructureLock);
+            for (auto &ue : InputUniverses) {
+                if (ue.type == ARTNET_TYPE_BROADCAST || ue.type == ARTNET_TYPE_UNICAST) {
+                    artNetUniverses.push_back(ue.universe);
+                }
+            }
+        }
+        int numPorts = std::min<int>((int)artNetUniverses.size(), 4);
+        // Preserve historical big-endian NumPorts encoding (0,4 = 4 ports).
         buf[172] = 0;
-        buf[173] = 4;
-        buf[174] = 0xc0;
-        buf[175] = 0xc0;
-        buf[176] = 0xc0;
-        buf[177] = 0xc0;
-
-        buf[178] = 0x0; // input
-        buf[179] = 0x0;
-        buf[180] = 0x0;
-        buf[181] = 0x0;
-        buf[182] = 0x0; // output
-        buf[183] = 0x0;
-        buf[184] = 0x0;
-        buf[185] = 0x0;
+        buf[173] = (char)numPorts;
+        for (int i = 0; i < 4; ++i) {
+            bool active = (i < numPorts);
+            buf[174 + i] = active ? (char)0xc0 : 0; // PortTypes: DMX512
+            buf[178 + i] = active ? (char)0x08 : 0; // GoodInput: port enabled
+            buf[182 + i] = 0;                        // GoodOutput: no ArtNet outputs
+            // SwIn: low 8 bits of PortAddress (exact for 0-255, best-effort >255,
+            // far better than always-0). SwOut unused (bridge is input-only).
+            buf[186 + i] = active ? (char)(artNetUniverses[i] & 0xFF) : 0;
+            buf[190 + i] = 0;
+        }
 
         char addressBuf[128];
         // get all the addresses


### PR DESCRIPTION
# fix(artnet): populate ArtPollReply universes from Channel Inputs (#2927)

## Summary

Fixes `ArtPollReply` always advertising universe `0` regardless of `Settings > Channel Inputs` configuration. `Bridge_HandleArtNetPoll()` now populates `NumPorts` / `PortTypes` / `GoodInput` / `SwIn` from the actual `InputUniverses` where `type` is ArtNet (issue #2927).

This is not related to my recent PR for artnet (#2904) which hardened the hostname fields and did not alter universe bytes.

## Root Cause

`src/e131bridge.cpp:768-785` (`Bridge_HandleArtNetPoll`) constructed a 240-byte `Art-Net PollReply` with:

```cpp
buf[172]=0; buf[173]=4;          // NumPorts=4 hardcoded
buf[174-177]=0xC0;                // PortTypes[4] hardcoded
buf[178-185]=0x00;                // GoodInput[4]/GoodOutput[4] hardcoded 0
// SwIn[4] at 186-189 and SwOut[4] at 190-193 never written — memset 0
```

Per Art-Net 4 spec, `SwIn` advertises the subscribed input universes (low byte of `PortAddress`), `NumPorts` the count, and `GoodInput` the port state. Because `SwIn` was never written, any controller polling FPP (xLights, etc.) saw `0,0,0,0` for every node, even when `config/ci-universes.json` had `type: 2/3` ArtNet universes on e.g. `10`.

The same construction existed in `src/e131bridge.cpp:731` since 2018. `1e042a38b` (#2904) hardened only the hostname fields (`strcpy` → `snprintf` + `memset`) and did not touch universe bytes.

## Changes

### `src/e131bridge.cpp:768-936` `Bridge_HandleArtNetPoll()` — only file changed

**Before (hardcoded):**
```cpp
buf[172]=0; buf[173]=4;
buf[174-177]=0xC0;
buf[178-185]=0;
```

**After (from `InputUniverses`):**
```cpp
// Collect configured ArtNet input universes
std::vector<uint32_t> artNetUniverses;
{
    std::lock_guard<std::mutex> lg(universesStructureLock);
    for (auto &ue : InputUniverses)
        if (ue.type == ARTNET_TYPE_BROADCAST || ue.type == ARTNET_TYPE_UNICAST)
            artNetUniverses.push_back(ue.universe);
}
int numPorts = std::min<int>(artNetUniverses.size(), 4);
buf[172]=0; buf[173]=(char)numPorts; // preserve big-endian (0,4) encoding
for (int i=0;i<4;i++) {
    bool active = i < numPorts;
    buf[174+i] = active ? 0xC0 : 0;              // PortTypes
    buf[178+i] = active ? 0x08 : 0;              // GoodInput: enabled
    buf[182+i] = 0;                              // GoodOutput: input-only
    buf[186+i] = active ? artNetUniverses[i]&0xFF : 0; // SwIn low 8 bits
    buf[190+i] = 0;                              // SwOut
}
```

*   `vscode/fpp` variant is identical without the `lock_guard` (legacy `InputUniverses` vector has no `universesStructureLock`).

No header / API / plugin ABI change. No `SD/FPP_Install.sh` / `www/` change. `ChannelOutput/ArtNet.cpp` (output) untouched — fix is input-poll only.

## Design Decisions / Non-Breaking Guarantees

*   **Wire size unchanged:** still `sendto(..., 240)` (`src/e131bridge.cpp:955`). Only bytes `172-193` (the 16 universe-advertising bytes) change.
*   **Encoding preserved:** `NumPorts` keeps historical big-endian `(0, N)` (`0,4` = 4) so packet parsers that consumed the old layout are unaffected.
*   **Flat-universe low byte:** `SwIn = universe & 0xFF` is exact for `0-255` (99% of shows) and best-effort for `>255` (low-byte distinct, vs always-`0` before). A future spec-exact `Net/Sub/Uni` nibble split can be added without wire-size change; `NetSwitch`/`SubSwitch` left `0` intentionally.
*   **Capped at 4:** ArtPollReply `SwIn/SwOut` arrays are 4 entries (`src/e131bridge.cpp:186-193`). `numPorts = min(size,4)` matches spec and previous hardcoded `4`.
*   **Empty input set:** reports `NumPorts=0` (honest) vs previously `4×0`. Controllers that ignore ArtNet when not configured are unaffected; those that filtered on `GoodInput==0` disabled now correctly see enabled ports when configured.
*   **Thread safety:** `fpp-master` reads `InputUniverses` under `universesStructureLock` (HTTP stats vs main-loop reload race); packet path remains on main-loop thread.

## Risk

**Low.** Single function, <30 lines, display-only (poll reply). Data path (`Bridge_StoreArtNetData` `src/e131bridge.cpp:810`) and `Bridge_StoreData` / `Bridge_StoreDDPData` unchanged. `clang++ -std=c++23 -DPLATFORM_OSX -fsyntax-only` passes on both `fpp-master` and `vscode/fpp` checkouts.

## Files Changed

*   `src/e131bridge.cpp` — `Bridge_HandleArtNetPoll()` only (1 file; `fpp-master` with `universesStructureLock` guard, `vscode/fpp` without).

## Checklist

- [x] No header / `fpp-pch.h` / plugin ABI change
- [x] `src/e131bridge.cpp` syntax check passes (`clang++ -fsyntax-only`)
- [x] ArtNet data-path unchanged (`Bridge_StoreArtNetData`)
- [x] Verified `GoodInput=0x08` semantics and `PortTypes=0xC0` preservation
- [x] Verified `8.33.1` style: Allman-ish, 4-space, no tabs

## Additional Comments

This is an attempt to resolve the issue mentioned in #2927.
I'm not 100% sure about this PR, so requesting review for verification/testing.