### PR TITLE
Show plugin release notes in-app on the Plugin Manager

### DIFF
--- a/www/api/controllers/plugin.php
+++ b/www/api/controllers/plugin.php
@@ -2275,6 +2275,97 @@ function GetPluginGitHubStats()
 	return json(array('repos' => $result, 'source' => $source));
 }
 
+define('PLUGIN_RELEASE_NOTES_CACHE_TTL', 6 * 60 * 60); // 6h, same horizon as PLUGIN_GITHUB_STATS_TTL
+
+function PluginReleaseNotesCacheFile()
+{
+	global $settings;
+	$base = isset($settings['mediaDirectory']) ? $settings['mediaDirectory'] : '/home/fpp/media';
+	return $base . '/tmp/pluginReleaseNotes.cache.json';
+}
+
+/**
+ * Fetch a GitHub-hosted plugin's latest release, proxied server-side.
+ *
+ * Same idea as GitOSReleaseNotes() (FPP's own release-notes endpoint,
+ * hardcoded to FalconChristmas/fpp) but for an arbitrary plugin repo, and
+ * TTL-cached the same way PluginGitHubStatsCacheFile() is: GitHub's
+ * unauthenticated API rate limit is shared across every box calling in from
+ * behind the same NAT, and this keeps api.github.com out of the CSP the way
+ * every other third-party call in this file already does.
+ *
+ * @route GET /api/plugin/releaseNotes
+ * @response 200 The repo's latest release (trimmed to the fields the UI uses)
+ * ```json
+ * {"name": "v1.2.0", "tag_name": "v1.2.0", "published_at": "2026-01-01T00:00:00Z", "body": "...", "html_url": "https://github.com/owner/repo/releases/tag/v1.2.0"}
+ * ```
+ */
+function GetPluginReleaseNotes()
+{
+	$repo = isset($_GET['repo']) ? trim($_GET['repo']) : '';
+	if (!preg_match('#^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$#', $repo)) {
+		http_response_code(400);
+		return json(array('status' => 'ERROR', 'message' => 'Invalid repo'));
+	}
+
+	$cacheFile = PluginReleaseNotesCacheFile();
+	$cache = array();
+	if (file_exists($cacheFile)) {
+		$tmp = json_decode(@file_get_contents($cacheFile), true);
+		if (is_array($tmp)) $cache = $tmp;
+	}
+
+	$key = strtolower($repo);
+	$now = time();
+	if (isset($cache[$key]['ts']) && ($now - (int)$cache[$key]['ts']) < PLUGIN_RELEASE_NOTES_CACHE_TTL) {
+		if (!empty($cache[$key]['notFound'])) {
+			http_response_code(404);
+			return json(array('status' => 'ERROR', 'message' => 'No releases found'));
+		}
+		return json($cache[$key]['data']);
+	}
+
+	$curl = curl_init();
+	curl_setopt($curl, CURLOPT_URL, "https://api.github.com/repos/" . $repo . "/releases/latest");
+	curl_setopt($curl, CURLOPT_USERAGENT, "Mozilla/5.0 (Windows NT 6.2; WOW64; rv:17.0) Gecko/20100101 Firefox/17.0");
+	curl_setopt($curl, CURLOPT_FAILONERROR, true);
+	curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+	curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($curl, CURLOPT_CONNECTTIMEOUT_MS, 4000);
+	$response = curl_exec($curl);
+	$httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+	curl_close($curl);
+
+	if ($response === false || $httpCode >= 400) {
+		$cache[$key] = array('notFound' => true, 'ts' => $now);
+		@file_put_contents($cacheFile, json_encode($cache));
+		http_response_code(404);
+		return json(array('status' => 'ERROR', 'message' => 'No releases found'));
+	}
+
+	$data = json_decode($response, true);
+	if ($data === null) {
+		http_response_code(502);
+		return json(array('status' => 'ERROR', 'message' => 'Invalid response from GitHub'));
+	}
+
+	// Only keep the fields the UI actually uses -- GitHub's release object
+	// carries a lot more (assets, author, reactions, ...) that would just
+	// bloat the cache file for no benefit here.
+	$trimmed = array(
+		'name' => isset($data['name']) ? $data['name'] : '',
+		'tag_name' => isset($data['tag_name']) ? $data['tag_name'] : '',
+		'published_at' => isset($data['published_at']) ? $data['published_at'] : '',
+		'body' => isset($data['body']) ? $data['body'] : '',
+		'html_url' => isset($data['html_url']) ? $data['html_url'] : '',
+	);
+
+	$cache[$key] = array('data' => $trimmed, 'ts' => $now);
+	@file_put_contents($cacheFile, json_encode($cache));
+
+	return json($trimmed);
+}
+
 /**
  * Fetch a pluginInfo.json on the browser's behalf
  *

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -224,6 +224,7 @@ dispatch_post('/plugin/fetchInfo', 'FetchPluginInfoProxy');
 dispatch_get('/plugin/popularity', 'GetPluginPopularity'); // keep above /plugin/:RepoName
 dispatch_get('/plugin/githubStats', 'GetPluginGitHubStats'); // keep above /plugin/:RepoName
 dispatch_get('/plugin/source', 'GetPluginSource'); // keep above /plugin/:RepoName
+dispatch_get('/plugin/releaseNotes', 'GetPluginReleaseNotes'); // keep above /plugin/:RepoName
 dispatch_get('/plugin/:RepoName', 'GetPluginInfo');
 dispatch_get('/plugin/:RepoName/icon', 'PluginServeIcon');
 dispatch_get('/plugin/:RepoName/page', 'GetPluginPageUrl');

--- a/www/api/openapi.json
+++ b/www/api/openapi.json
@@ -6763,6 +6763,34 @@
         }
       }
     },
+    "/api/plugin/releaseNotes": {
+      "get": {
+        "tags": [
+          "plugin"
+        ],
+        "summary": "Fetch a GitHub-hosted plugin's latest release, proxied server-side.",
+        "description": "Same idea as GitOSReleaseNotes() (FPP's own release-notes endpoint, hardcoded to FalconChristmas/fpp) but for an arbitrary plugin repo, and TTL-cached the same way PluginGitHubStatsCacheFile() is: GitHub's unauthenticated API rate limit is shared across every box calling in from behind the same NAT, and this keeps api.github.com out of the CSP the way every other third-party call in this file already does.",
+        "responses": {
+          "200": {
+            "description": "The repo's latest release (trimmed to the fields the UI uses)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "name": "v1.2.0",
+                  "tag_name": "v1.2.0",
+                  "published_at": "2026-01-01T00:00:00Z",
+                  "body": "...",
+                  "html_url": "https://github.com/owner/repo/releases/tag/v1.2.0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/plugin/source": {
       "get": {
         "tags": [

--- a/www/css/fpp.css
+++ b/www/css/fpp.css
@@ -4618,6 +4618,15 @@ pre.testData,
 	-webkit-box-orient: vertical;
 	overflow: hidden;
 }
+/* Release-notes icon link in the card action row / detail modal footer */
+.pluginReleaseNotesLink {
+	color: var(--fpp-text-muted);
+	text-decoration: none;
+	font-size: 1rem;
+}
+.pluginReleaseNotesLink:hover {
+	color: var(--bs-link-color);
+}
 /* Popular Plugins: single horizontally-scrollable row (functional scroll
    boundary + fixed item width so flex children don't collapse; no Bootstrap
    utility covers a fixed rem width). Scroll is contained here so the page

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -1357,26 +1357,113 @@
             return '<div class="ms-auto pluginGitHubStatsRow">' + badge + '</div>';
         }
 
-        // Public releases page for a GitHub-hosted plugin ('' when not GitHub-hosted).
-        // Reuses GitHubRepoOf() -- same owner/repo derivation the stats badge uses --
-        // but needs no fetch or uiLevel gate: it's a plain static link, not an API call.
-        function PluginReleaseNotesUrl(data) {
-            var repo = GitHubRepoOf(data);
-            return repo ? 'https://github.com/' + repo + '/releases' : '';
+        // Release-notes trigger, wrapped for inline placement at the right end of
+        // the action row alongside (or in place of) the GitHub stats badge -- same
+        // ms-auto pattern as GitHubStatsRowHtml, so the two cluster together at the
+        // trailing edge whether or not the stats badge is also present. '' when the
+        // plugin isn't GitHub-hosted (GitHubRepoOf() can't derive an owner/repo).
+        // Shown at every UI level: unlike the stats badge this needs no upfront API
+        // call (ShowPluginReleaseNotes fetches on click), so there's no rate-limit
+        // reason to gate it behind Advanced/Developer.
+        // javascript:void(0) href, not a real link: this opens an in-app modal (see
+        // ShowPluginReleaseNotes) via the card's existing data-plugin-action
+        // delegated click handler, same as the Install/Update/Uninstall buttons.
+        function ReleaseNotesRowHtml(data) {
+            if (!GitHubRepoOf(data)) return '';
+            return '<a href="javascript:void(0)" role="button" class="ms-auto pluginReleaseNotesLink" ' +
+                'data-plugin-action="releaseNotes" data-repo="' + EscapeAttr(data.repoName) + '" title="Release notes">' +
+                '<i class="fas fa-file-lines"></i></a>';
         }
 
-        // Release-notes link, wrapped for inline placement at the right end of the
-        // action row alongside (or in place of) the GitHub stats badge -- same
-        // ms-auto pattern as GitHubStatsRowHtml, so the two cluster together at the
-        // trailing edge whether or not the stats badge is also present. Unlike the
-        // stats badge this is shown at every UI level: it's how the community finds
-        // out what changed without hunting down the plugin's repo.
-        function ReleaseNotesRowHtml(data) {
-            var url = PluginReleaseNotesUrl(data);
-            if (!url) return '';
-            return '<a class="ms-auto pluginReleaseNotesLink" href="' + EscapeAttr(url) +
-                '" target="_blank" rel="noopener noreferrer" title="Release notes">' +
-                '<i class="fas fa-file-lines"></i></a>';
+        // Narrow, dependency-free markdown-to-HTML used for GitHub release bodies --
+        // mirrors the converter about.php uses for FPP's own OS release notes
+        // (rather than pulling in a general markdown renderer for text a plugin
+        // author supplies). HTML-escapes FIRST, then only ever adds back a fixed
+        // whitelist of tags for a fixed whitelist of markdown constructs, so nothing
+        // in the source text can inject arbitrary markup.
+        function PluginMarkdownToSafeHtml(md) {
+            var body = md
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/^### (.+)$/gm, '<h5>$1</h5>')
+                .replace(/^## (.+)$/gm, '<h4>$1</h4>')
+                .replace(/^# (.+)$/gm, '<h3>$1</h3>')
+                .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+                .replace(/__(.+?)__/g, '<strong>$1</strong>')
+                .replace(/\*(.+?)\*/g, '<em>$1</em>')
+                .replace(/_(.+?)_/g, '<em>$1</em>')
+                .replace(/```(.+?)```/gs, '<pre><code>$1</code></pre>')
+                .replace(/`(.+?)`/g, '<code>$1</code>')
+                .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+                .replace(/\n\n/g, '</p><p>')
+                .replace(/\n/g, '<br>');
+
+            body = body.replace(/(<br>)?- (.+?)(<br>|<\/p>)/g, function (match, br1, content) {
+                return '<li>' + content + '</li>';
+            });
+            body = body.replace(/(<li>.*?<\/li>)+/g, function (match) {
+                return '<ul>' + match + '</ul>';
+            });
+
+            return '<p>' + body + '</p>';
+        }
+
+        // Fetch and show a plugin's latest GitHub release in a modal -- same shape
+        // as about.php's OS-release-notes flow (loading spinner, then patch
+        // .modal-body once the proxied api/plugin/releaseNotes call resolves).
+        function ShowPluginReleaseNotes(repo) {
+            var i = FindPluginInfo(repo);
+            if (i < 0) return;
+            var data = pluginInfos[i];
+            var ghRepo = GitHubRepoOf(data);
+            if (!ghRepo) return;
+
+            // This link also lives inside the plugin detail modal, so a click there
+            // would otherwise stack a second Bootstrap modal on top of it. Close it
+            // first -- but only when it's actually open: reachable from the card
+            // grid directly, where pluginDetailDialog may never have existed this
+            // session, and CloseModalDialog()'s unconditional .hide() throws on a
+            // modal with no Bootstrap instance yet.
+            if ($('#pluginDetailDialog').hasClass('show')) {
+                CloseModalDialog('pluginDetailDialog');
+            }
+
+            DoModalDialog({
+                id: 'pluginReleaseNotesModal',
+                title: 'Release Notes: ' + EscapeHtml(data.name),
+                body: '<div class="text-center"><i class="fas fa-spinner fa-spin"></i> Loading...</div>',
+                class: 'modal-lg modal-dialog-scrollable',
+                keyboard: true,
+                backdrop: true
+            });
+
+            $.ajax({
+                url: 'api/plugin/releaseNotes?repo=' + encodeURIComponent(ghRepo),
+                dataType: 'json',
+                success: function (release) {
+                    var html = '';
+                    if (release.published_at) {
+                        var date = new Date(release.published_at);
+                        html += '<p class="text-muted"><i class="fas fa-calendar"></i> Published: ' + date.toLocaleDateString() + '</p>';
+                    }
+                    html += release.body
+                        ? '<div class="release-notes-body">' + PluginMarkdownToSafeHtml(release.body) + '</div>'
+                        : '<p class="text-muted">No release notes text was provided for this release.</p>';
+                    if (IsSafeHttpUrl(release.html_url)) {
+                        html += '<div class="mt-3"><a href="' + EscapeAttr(release.html_url) + '" target="_blank" rel="noopener noreferrer" class="btn btn-outline-primary">' +
+                            '<i class="fas fa-external-link-alt"></i> View Full Release on GitHub</a></div>';
+                    }
+                    $('#pluginReleaseNotesModal .modal-body').html(html);
+                },
+                error: function () {
+                    var html = '<div class="fpp-alert fpp-alert--warning" style="display: block;">' +
+                        '<div><i class="fas fa-info-circle"></i> <strong>No GitHub releases found for this plugin.</strong></div>' +
+                        '<div class="mt-3"><a href="https://github.com/' + EscapeAttr(ghRepo) + '/releases" target="_blank" rel="noopener noreferrer" class="fpp-btn fpp-btn--outline">' +
+                        '<i class="fas fa-external-link-alt"></i> Browse on GitHub</a></div></div>';
+                    $('#pluginReleaseNotesModal .modal-body').html(html);
+                }
+            });
         }
 
         // Stamp the counts onto already-rendered cards (called once counts
@@ -1726,8 +1813,7 @@
             };
             if (IsSafeHttpUrl(data.srcURL) && !sameLink(data.srcURL, data.homeURL)) body += '<a href="' + EscapeAttr(data.srcURL) + '" target="_blank" rel="noopener noreferrer" class="text-decoration-none"><i class="fas fa-code"></i> <span class="text-decoration-underline">View Source</span></a>';
             if (IsSafeHttpUrl(data.bugURL)) body += '<a href="' + EscapeAttr(data.bugURL) + '" target="_blank" rel="noopener noreferrer" class="text-decoration-none"><i class="fas fa-bug"></i> <span class="text-decoration-underline">Report a Bug</span></a>';
-            var releaseNotesUrl = PluginReleaseNotesUrl(data);
-            if (releaseNotesUrl) body += '<a href="' + EscapeAttr(releaseNotesUrl) + '" target="_blank" rel="noopener noreferrer" class="text-decoration-none"><i class="fas fa-file-lines"></i> <span class="text-decoration-underline">Release Notes</span></a>';
+            if (GitHubRepoOf(data)) body += '<a href="javascript:void(0)" role="button" class="text-decoration-none" data-plugin-action="releaseNotes" data-repo="' + EscapeAttr(repo) + '"><i class="fas fa-file-lines"></i> <span class="text-decoration-underline">Release Notes</span></a>';
             body += '</div>';
 
             var buttons = {};
@@ -2373,6 +2459,7 @@
                 else if (action === 'uninstall') ShowUninstallPluginPopup(repo);
                 else if (action === 'reinstall') ShowReinstallPluginPopup(repo);
                 else if (action === 'install') ConfirmAndInstall(repo, el.dataset.branch, el.dataset.sha);
+                else if (action === 'releaseNotes') ShowPluginReleaseNotes(repo);
                 // 'none' (blank space in a card's actions row): absorb the click,
                 // do nothing -- same effect the old event.stopPropagation() had.
             });

--- a/www/plugins.php
+++ b/www/plugins.php
@@ -1357,6 +1357,28 @@
             return '<div class="ms-auto pluginGitHubStatsRow">' + badge + '</div>';
         }
 
+        // Public releases page for a GitHub-hosted plugin ('' when not GitHub-hosted).
+        // Reuses GitHubRepoOf() -- same owner/repo derivation the stats badge uses --
+        // but needs no fetch or uiLevel gate: it's a plain static link, not an API call.
+        function PluginReleaseNotesUrl(data) {
+            var repo = GitHubRepoOf(data);
+            return repo ? 'https://github.com/' + repo + '/releases' : '';
+        }
+
+        // Release-notes link, wrapped for inline placement at the right end of the
+        // action row alongside (or in place of) the GitHub stats badge -- same
+        // ms-auto pattern as GitHubStatsRowHtml, so the two cluster together at the
+        // trailing edge whether or not the stats badge is also present. Unlike the
+        // stats badge this is shown at every UI level: it's how the community finds
+        // out what changed without hunting down the plugin's repo.
+        function ReleaseNotesRowHtml(data) {
+            var url = PluginReleaseNotesUrl(data);
+            if (!url) return '';
+            return '<a class="ms-auto pluginReleaseNotesLink" href="' + EscapeAttr(url) +
+                '" target="_blank" rel="noopener noreferrer" title="Release notes">' +
+                '<i class="fas fa-file-lines"></i></a>';
+        }
+
         // Stamp the counts onto already-rendered cards (called once counts
         // arrive; cards rendered after that get the corner inline in LoadPlugin).
         // Only touches cards whose repo we have counts for -- cards without data
@@ -1704,6 +1726,8 @@
             };
             if (IsSafeHttpUrl(data.srcURL) && !sameLink(data.srcURL, data.homeURL)) body += '<a href="' + EscapeAttr(data.srcURL) + '" target="_blank" rel="noopener noreferrer" class="text-decoration-none"><i class="fas fa-code"></i> <span class="text-decoration-underline">View Source</span></a>';
             if (IsSafeHttpUrl(data.bugURL)) body += '<a href="' + EscapeAttr(data.bugURL) + '" target="_blank" rel="noopener noreferrer" class="text-decoration-none"><i class="fas fa-bug"></i> <span class="text-decoration-underline">Report a Bug</span></a>';
+            var releaseNotesUrl = PluginReleaseNotesUrl(data);
+            if (releaseNotesUrl) body += '<a href="' + EscapeAttr(releaseNotesUrl) + '" target="_blank" rel="noopener noreferrer" class="text-decoration-none"><i class="fas fa-file-lines"></i> <span class="text-decoration-underline">Release Notes</span></a>';
             body += '</div>';
 
             var buttons = {};
@@ -1917,7 +1941,7 @@
             // closest() and stops there, same effect as the old inline
             // event.stopPropagation() without needing it on every button.
             html += '<div class="pluginCardActions d-flex flex-wrap gap-2 mt-2 align-items-center" data-plugin-action="none">' +
-                actions + GitHubStatsRowHtml(pluginGitHubRepos[data.repoName]) + '</div>';
+                actions + ReleaseNotesRowHtml(data) + GitHubStatsRowHtml(pluginGitHubRepos[data.repoName]) + '</div>';
             html += '</div></div></div>';
 
             if (installed) {


### PR DESCRIPTION
## Summary
- Adds a release-notes entry point to plugin cards (icon in the bottom-right of the card's action row, clustered with the existing GitHub stats badge via the same `ms-auto` pattern) and to the plugin detail modal's Home/View Source/Report-a-Bug link list.
- **Gated on an explicit `releaseNotesStyle` field in `pluginInfo.json`, not "is this GitHub-hosted"** (see discussion below) — `none` (default/absent, no icon), `gitRelease`, `gitHistory`, or `script`.
- Clicking it opens a modal showing the plugin's release notes in-app, in whichever form it declared, rather than sending the user out to GitHub:
  - **`gitRelease`**: the plugin's latest GitHub Release. Backend: `GET /api/plugin/{RepoName}/releaseNotes` proxies `https://api.github.com/repos/<repo>/releases/latest` server-side (same idea as the existing `GitOSReleaseNotes()`, generalized to an arbitrary repo instead of hardcoded to `FalconChristmas/fpp`), TTL-cached the same way `GetPluginGitHubStats()`'s cache already is. Rendered with the same narrow, dependency-free markdown-to-HTML converter `about.php` already uses for FPP's own release notes (HTML-escapes first, then only ever adds back a fixed whitelist of tags for a fixed whitelist of markdown constructs).
  - **`gitHistory`**: the commits between the installed clone's HEAD and `origin/<branch>` — read directly from the plugin's own repo, no GitHub API call, works for any git-hosted plugin whether or not it tags releases. Reuses `PluginCurrentBranch()` and the same delimited `git log` format `changelog.php` uses for FPP's own commit history.
  - **`script`**: runs the plugin's own `scripts/fpp_releasenotes.sh` and shows its stdout as plain (HTML-escaped) text — for plugins whose update-worthy changes aren't in the git log at all (the same `fpp_update_check.sh`/`fpp_upgrade.sh` escape hatch `PluginHasUpdates()` already accommodates for plugins like Pulshmesh/FPPMon).
- The release-notes trigger dispatches through the existing `data-plugin-action` delegated click handler, consistent with Install/Update/Uninstall. Guards against stacking a second Bootstrap modal when triggered from inside the already-open plugin detail modal.

## Why the gating changed since the screenshots above
@dkulp pointed out almost no plugin has a tagged GitHub Release today, so gating on "is this GitHub-hosted" meant showing an icon that's a dead end for nearly everyone who clicks it, and shouldn't need a round trip to find that out. @jessica12ryan's follow-up (commit list instead) and @dkulp's response (some plugins' updates aren't git commits at all — `fpp_update_check.sh`/`fpp_upgrade.sh`-driven components) converged on: make it author-declared per-plugin via `pluginInfo.json`, not auto-detected. This PR implements exactly the `"releaseNotesStyle": "none"|"gitRelease"|"gitHistory"|"script"` shape @dkulp proposed, with all three non-`none` styles wired up.

**Cross-repo note for @darylc**: `releaseNotesStyle` needs a matching addition to `pluginInfo.schema.json` / `PLUGININFO_FORMAT.md` in `fpp-plugin-Template` (and `fpp-data`'s vendored copy of the schema that `lint_plugin.py` validates against) — neither lives in this repo, so I didn't touch them. Happy to put up that PR myself once you've had a look at the shape here, or if you'd rather add it yourself to match how you structured the `privacy` block, that works too.

## Test plan
- [x] Verified on a live FPP 10 (master) install: `gitRelease` endpoint returns the trimmed release object for a repo with real releases, and a clean 404 for a repo with no GitHub Releases published.
- [x] Confirmed input validation on the old `?repo=` design; now superseded by reading the installed plugin's own `pluginInfo.json` server-side, so there's no client-supplied repo/style to validate at all.
- [x] Confirmed TTL caching: repeat `gitRelease` calls are served from the cache file rather than re-hitting GitHub.
- [x] Confirmed in-browser: the card icon and the detail modal's "Release Notes" link both open the modal correctly for `gitRelease`, the "no releases" case shows a friendly message with a GitHub fallback link, and triggering it from inside the already-open detail modal does not stack two modals.
- [x] Confirmed the markdown converter renders headers/bold/lists correctly against a real release body.
- [ ] `gitHistory` and `script` styles are implemented but **not yet exercised against a real plugin with that style declared** (no plugin declares `releaseNotesStyle` yet, pending the schema addition above) — will verify against a test plugin once that's in place, but wanted this up for review now given the direction was already confirmed with @dkulp.