### PR TITLE
feat(developer): Add GitHub fork branch switching when exists on GitHub credentials

### DIFF
--- a/scripts/git_branch
+++ b/scripts/git_branch
@@ -26,6 +26,17 @@ $SUDO git config --system --add safe.directory '*' 2>/dev/null || true
 
 echo "$0 running to switch branches to $1 from remote $REMOTE"
 
+# For fork remotes that were just added, refs may not exist yet - fetch first so
+# the show-ref check succeeds. Background git_fetch also uses runGitLocked, so
+# this fetch must be locked the same way.
+if [ "$REMOTE" != "origin" ] && [ "$REMOTE" != "newfeatures" ]; then
+	if [ "x${FPPDIR}" = "x/opt/fpp" ]; then
+		runGitLocked "cd ${FPPDIR} && git fetch $REMOTE 2>&1 | head -20" || true
+	else
+		runGitLocked "cd ${FPPDIR} && sudo -u ${FPPUSER} git fetch $REMOTE 2>&1 | head -20" || true
+	fi
+fi
+
 CNT=`cd ${FPPDIR} && git show-ref | grep "refs/remotes/$REMOTE" | grep -i $1 | wc -l`
 if [ $CNT -eq 0 ]; then
 	echo "Invalid Branch Name: $1 for remote: $REMOTE"

--- a/www/api/controllers/git.php
+++ b/www/api/controllers/git.php
@@ -406,4 +406,206 @@ function GitBranches()
 
     return json($rows);
 }
+
+/**
+ * Get fork branches
+ *
+ * Returns branches from the authenticated user's fork of FPP (github.com/<user>/fpp)
+ * if that fork exists. Used by the Developer settings page to offer a "switch to
+ * fork branch" dropdown. The fork is probed via the GitHub API using the saved
+ * gitHubUser / gitHubPAT credentials; an unreachable GitHub or a missing repo
+ * returns hasFork false rather than an error.
+ *
+ * @route GET /api/git/forkBranches
+ * @response 200 Fork branch list
+ * ```json
+ * {
+ *   "hasFork": true,
+ *   "user": "myuser",
+ *   "branches": ["master", "my-feature"]
+ * }
+ * ```
+ */
+function GitForkBranches()
+{
+    global $settings, $fppDir;
+
+    $user = isset($settings['gitHubUser']) ? trim($settings['gitHubUser']) : '';
+    $pat = isset($settings['gitHubPAT']) ? trim($settings['gitHubPAT']) : '';
+
+    // Reject header-injection payloads in PAT (would otherwise allow CRLF injection
+    // into the Authorization header). Username is already constrained by regex below.
+    if (preg_match('/[\r\n]/', $pat)) {
+        return json(array('hasFork' => false, 'user' => $user, 'branches' => array()));
+    }
+
+    // GitHub usernames: 1-39 chars, alphanumeric and hyphens, cannot begin/end with hyphen
+    $validUser = (preg_match('/^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/', $user) === 1);
+    if (!$validUser || $user === '' || $pat === '') {
+        return json(array('hasFork' => false, 'user' => $user, 'branches' => array()));
+    }
+
+    // Helper to perform a GitHub API GET with optional PAT auth
+    $doCurl = function ($url) use ($pat) {
+        $ch = curl_init($url);
+        $headers = array('User-Agent: FPP', 'Accept: application/vnd.github.v3+json');
+        if ($pat !== '') {
+            // GitHub accepts both "token <PAT>" and "Bearer <PAT>"; use token for classic PATs
+            $headers[] = 'Authorization: token ' . $pat;
+        }
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_FAILONERROR, false);
+        $body = curl_exec($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $err = curl_error($ch);
+        curl_close($ch);
+        return array('body' => $body, 'code' => $code, 'err' => $err);
+    };
+
+    // 1. Check if repo exists and is a fork (or at least exists)
+    $repoUrl = 'https://api.github.com/repos/' . rawurlencode($user) . '/fpp';
+    $repoResp = $doCurl($repoUrl);
+    if ($repoResp['body'] === false || $repoResp['code'] == 0) {
+        // Network unreachable - fallback to local git remote check (useful for offline tests
+        // or environments where github is blocked). If a remote named after the user exists
+        // locally, treat it as a fork and list its branches via git branch -r.
+        global $fppDir;
+        $fppDirEsc = escapeshellarg($fppDir);
+        exec("git -C $fppDirEsc remote get-url " . escapeshellarg($user) . " 2>&1", $chkOut, $chkRet);
+        if ($chkRet == 0) {
+            $branches = array();
+            exec("git -C $fppDirEsc branch -r 2>&1", $allLines);
+            foreach ($allLines as $line) {
+                $line = trim($line);
+                if (str_starts_with($line, "$user/") && strpos($line, '->') === false) {
+                    $branch = substr($line, strlen($user) + 1);
+                    if (
+                        preg_match("*v[01]\.[0-9x]*", $branch)
+                        || preg_match("*v2\.[0-9x]*", $branch)
+                        || preg_match("*v3\.[0-9x]*", $branch)
+                        || preg_match("*v4\.[0-9x]*", $branch)
+                        || preg_match("*v5\.[0-9x]*", $branch)
+                        || preg_match("*v6\.[0-9x]*", $branch)
+                        || str_starts_with($branch, "dependabot/")
+                        || str_starts_with($branch, "HEAD ")
+                    ) {
+                        continue;
+                    }
+                    $branches[] = $branch;
+                }
+            }
+            sort($branches);
+            return json(array('hasFork' => true, 'user' => $user, 'branches' => $branches));
+        }
+        return json(array('hasFork' => false, 'user' => $user, 'branches' => array()));
+    }
+    if ($repoResp['code'] == 404) {
+        // Also check local fallback - a locally-configured fork remote should still count
+        global $fppDir;
+        $fppDirEsc = escapeshellarg($fppDir);
+        exec("git -C $fppDirEsc remote get-url " . escapeshellarg($user) . " 2>&1", $chkOut, $chkRet);
+        if ($chkRet == 0) {
+            $branches = array();
+            exec("git -C $fppDirEsc branch -r 2>&1", $allLines);
+            foreach ($allLines as $line) {
+                $line = trim($line);
+                if (str_starts_with($line, "$user/") && strpos($line, '->') === false) {
+                    $branch = substr($line, strlen($user) + 1);
+                    if (
+                        preg_match("*v[01]\.[0-9x]*", $branch)
+                        || preg_match("*v2\.[0-9x]*", $branch)
+                        || preg_match("*v3\.[0-9x]*", $branch)
+                        || preg_match("*v4\.[0-9x]*", $branch)
+                        || preg_match("*v5\.[0-9x]*", $branch)
+                        || preg_match("*v6\.[0-9x]*", $branch)
+                        || str_starts_with($branch, "dependabot/")
+                        || str_starts_with($branch, "HEAD ")
+                    ) {
+                        continue;
+                    }
+                    $branches[] = $branch;
+                }
+            }
+            sort($branches);
+            if (!empty($branches)) {
+                return json(array('hasFork' => true, 'user' => $user, 'branches' => $branches));
+            }
+        }
+        return json(array('hasFork' => false, 'user' => $user, 'branches' => array()));
+    }
+    if ($repoResp['code'] < 200 || $repoResp['code'] >= 300) {
+        return json(array('hasFork' => false, 'user' => $user, 'branches' => array()));
+    }
+    $repoData = json_decode($repoResp['body'], true);
+    if (!is_array($repoData) || !isset($repoData['full_name'])) {
+        return json(array('hasFork' => false, 'user' => $user, 'branches' => array()));
+    }
+    // Optionally ensure it's a fork of FalconChristmas/fpp - but allow any repo named fpp
+    // If repoData indicates not a fork but still exists, treat as fork (user may have created manually)
+    // Uncomment strict check if needed:
+    // if (empty($repoData['fork'])) { return json(array('hasFork'=>false,...)); }
+
+    // 2. Fetch branches
+    $branchesUrl = 'https://api.github.com/repos/' . rawurlencode($user) . '/fpp/branches?per_page=100';
+    $brResp = $doCurl($branchesUrl);
+    if ($brResp['code'] < 200 || $brResp['code'] >= 300 || $brResp['body'] === false) {
+        // Repo exists but GitHub branch listing failed (network/rate-limit). Fall back to
+        // local git remote branches if the remote is already configured locally.
+        global $fppDir;
+        $fppDirEsc = escapeshellarg($fppDir);
+        $branches = array();
+        exec("git -C $fppDirEsc branch -r 2>&1", $allLines);
+        foreach ($allLines as $line) {
+            $line = trim($line);
+            if (str_starts_with($line, "$user/") && strpos($line, '->') === false) {
+                $branch = substr($line, strlen($user) + 1);
+                if (
+                    preg_match("*v[01]\.[0-9x]*", $branch)
+                    || preg_match("*v2\.[0-9x]*", $branch)
+                    || preg_match("*v3\.[0-9x]*", $branch)
+                    || preg_match("*v4\.[0-9x]*", $branch)
+                    || preg_match("*v5\.[0-9x]*", $branch)
+                    || preg_match("*v6\.[0-9x]*", $branch)
+                    || str_starts_with($branch, "dependabot/")
+                    || str_starts_with($branch, "HEAD ")
+                ) {
+                    continue;
+                }
+                $branches[] = $branch;
+            }
+        }
+        sort($branches);
+        return json(array('hasFork' => true, 'user' => $user, 'branches' => $branches));
+    }
+    $brData = json_decode($brResp['body'], true);
+    if (!is_array($brData)) {
+        return json(array('hasFork' => true, 'user' => $user, 'branches' => array()));
+    }
+
+    $branches = array();
+    foreach ($brData as $b) {
+        if (!isset($b['name'])) continue;
+        $branch = $b['name'];
+        // Apply same filtering as GitBranches for consistency (hide obsolete version branches etc)
+        if (
+            preg_match("*v[01]\.[0-9x]*", $branch)
+            || preg_match("*v2\.[0-9x]*", $branch)
+            || preg_match("*v3\.[0-9x]*", $branch)
+            || preg_match("*v4\.[0-9x]*", $branch)
+            || preg_match("*v5\.[0-9x]*", $branch)
+            || preg_match("*v6\.[0-9x]*", $branch)
+            || str_starts_with($branch, "dependabot/")
+            || str_starts_with($branch, "HEAD ")
+        ) {
+            continue;
+        }
+        $branches[] = $branch;
+    }
+    sort($branches);
+    return json(array('hasFork' => true, 'user' => $user, 'branches' => $branches));
+}
 ?>

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -84,6 +84,7 @@ dispatch_get('/git/releases/sizes', 'GitOSReleaseSizes');
 dispatch_get('/git/reset', 'GitReset');
 dispatch_get('/git/status', 'GitStatus');
 dispatch_get('/git/branches', 'GitBranches');
+dispatch_get('/git/forkBranches', 'GitForkBranches');
 
 dispatch_get('/media', 'GetMedia');
 dispatch_get('/media/:MediaName/duration', 'GetMediaDuration');

--- a/www/api/openapi.json
+++ b/www/api/openapi.json
@@ -3329,6 +3329,49 @@
         }
       }
     },
+    "/api/git/forkBranches": {
+      "get": {
+        "tags": [
+          "git"
+        ],
+        "summary": "Get fork branches",
+        "description": "Returns branches from the authenticated user's fork of FPP (github.com/<user>/fpp) if that fork exists. Probed via GitHub API using saved gitHubUser/gitHubPAT; returns hasFork false when no credentials, no fork, or GitHub unreachable. Falls back to local git remote <user> when offline. Used by Developer settings to offer a fork-branch switcher defaulting to Use Official Branches.",
+        "responses": {
+          "200": {
+            "description": "Fork branch list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "hasFork": {
+                      "type": "boolean"
+                    },
+                    "user": {
+                      "type": "string"
+                    },
+                    "branches": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "hasFork": true,
+                  "user": "jessica12ryan",
+                  "branches": [
+                    "master",
+                    "fixoverflow"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/git/originLog": {
       "get": {
         "tags": [

--- a/www/changebranch.php
+++ b/www/changebranch.php
@@ -36,6 +36,57 @@ if (!preg_match('/^[a-zA-Z0-9_-]+$/', $rawRemote)) {
 }
 $remote = $rawRemote;
 
+// If remote is a GitHub fork (matches saved gitHubUser), ensure the git remote exists
+$gitDir = escapeshellarg(dirname(dirname(__FILE__)) . "/.git");
+$isForkRemote = false;
+$forkUser = isset($settings['gitHubUser']) ? trim($settings['gitHubUser']) : '';
+$forkPat = isset($settings['gitHubPAT']) ? trim($settings['gitHubPAT']) : '';
+if ($remote !== 'origin' && $remote !== 'newfeatures') {
+	if ($forkUser !== '' && strtolower($remote) === strtolower($forkUser)) {
+		// normalize remote to the canonical saved username casing for git remote operations
+		$remote = $forkUser;
+		$isForkRemote = true;
+		// Check if remote already exists
+		exec("$SUDO git --git-dir=$gitDir remote get-url " . escapeshellarg($remote) . " 2>&1", $chkOut, $chkRet);
+		if ($chkRet != 0) {
+			if ($forkPat !== '') {
+				$remoteUrl = "https://" . rawurlencode($forkUser) . ":" . rawurlencode($forkPat) . "@github.com/" . rawurlencode($forkUser) . "/fpp.git";
+			} else {
+				$remoteUrl = "https://github.com/" . rawurlencode($forkUser) . "/fpp.git";
+			}
+			exec("$SUDO git --git-dir=$gitDir remote add " . escapeshellarg($remote) . " " . escapeshellarg($remoteUrl) . " 2>&1", $addOut, $addRet);
+		} else {
+			// Update URL to include PAT if present (keeps private fork fetches authenticated)
+			if ($forkPat !== '') {
+				$remoteUrl = "https://" . rawurlencode($forkUser) . ":" . rawurlencode($forkPat) . "@github.com/" . rawurlencode($forkUser) . "/fpp.git";
+				exec("$SUDO git --git-dir=$gitDir remote set-url " . escapeshellarg($remote) . " " . escapeshellarg($remoteUrl) . " 2>&1", $updOut, $updRet);
+			}
+		}
+	}
+}
+
+// Fetch the fork remote so that git_branch's show-ref validation succeeds.
+// Newly-added remotes have no refs yet; without this the script aborts with
+// "Invalid Branch Name" even though the branch exists on GitHub.
+if ($isForkRemote) {
+	$fetchOut = array();
+	$fetchRet = 0;
+	// Use same lock as git_branch / git_fetch to avoid FETCH_HEAD races
+	$mediaDirForLock = isset($settings['mediaDirectory']) ? $settings['mediaDirectory'] : (isset($mediaDirectory) ? $mediaDirectory : "/tmp");
+	$gitLock = escapeshellarg($mediaDirForLock . "/tmp/fpp-git-repo.lock");
+	$fetchInner = "git --git-dir=$gitDir fetch " . escapeshellarg($remote) . " 2>&1";
+	if (is_executable("/usr/bin/flock")) {
+		exec("$SUDO flock -w 60 -x $gitLock bash -c " . escapeshellarg($fetchInner), $fetchOut, $fetchRet);
+	} else {
+		exec("$SUDO bash -c " . escapeshellarg($fetchInner), $fetchOut, $fetchRet);
+	}
+	foreach ($fetchOut as $line) {
+		echo htmlspecialchars($line) . "\n";
+	}
+	flush(); ob_flush();
+	// Let git_branch report a proper error if fetch failed; don't abort here.
+}
+
 $command = $SUDO . " " . escapeshellarg($fppDir . "/scripts/git_branch") . " " . escapeshellarg($branch) . " " . escapeshellarg($remote) . " 2>&1";
 
 echo "Command: $command\n";

--- a/www/settings-developer.php
+++ b/www/settings-developer.php
@@ -192,8 +192,15 @@ function PrintGitBranchOptions()
                     data.branches.forEach(function (branch) {
                         $sel.append($('<option>').attr('value', branch).text(branch));
                     });
-                    $('#gitHubForkUserLabel').text(data.user);
                     $('#gitHubForkRepoLabel').text(data.user + '/fpp');
+                    var tipText = "Switch to a branch from your fork (" + data.user + ") or use official branches.";
+                    $('#gitHubForkBranch_tip').attr('data-bs-title', tipText);
+                    var tipEl = document.getElementById('gitHubForkBranch_tip');
+                    if (tipEl && window.bootstrap && bootstrap.Tooltip) {
+                        var inst = bootstrap.Tooltip.getInstance(tipEl);
+                        if (inst) inst.dispose();
+                        new bootstrap.Tooltip(tipEl);
+                    }
                     // Stay on the branch that was switched to instead of jumping back to Use Official Branches
                     if (currentGitBranch && currentGitRemote && data.user && currentGitRemote.toLowerCase() === data.user.toLowerCase() && data.branches.indexOf(currentGitBranch) !== -1) {
                         $sel.val(currentGitBranch);
@@ -204,8 +211,15 @@ function PrintGitBranchOptions()
                     var $sel = $('#gitHubForkBranch');
                     $sel.empty();
                     $sel.append($('<option>').attr('value', '').prop('selected', true).text('Use Official Branches'));
-                    $('#gitHubForkUserLabel').text(data.user);
                     $('#gitHubForkRepoLabel').text(data.user + '/fpp');
+                    var tipText2 = "Switch to a branch from your fork (" + data.user + ") or use official branches.";
+                    $('#gitHubForkBranch_tip').attr('data-bs-title', tipText2);
+                    var tipEl2 = document.getElementById('gitHubForkBranch_tip');
+                    if (tipEl2 && window.bootstrap && bootstrap.Tooltip) {
+                        var inst2 = bootstrap.Tooltip.getInstance(tipEl2);
+                        if (inst2) inst2.dispose();
+                        new bootstrap.Tooltip(tipEl2);
+                    }
                     if (currentGitBranch && currentGitRemote && data.user && currentGitRemote.toLowerCase() === data.user.toLowerCase()) {
                         // Current branch is on this fork but has no listed branches (filtered) - keep default
                     }
@@ -282,7 +296,7 @@ function PrintGitBranchOptions()
                 <option value="" selected>Use Official Branches</option>
             </select>
             <a href="#" class="btn btn-sm btn-outline-secondary ms-2" title="Reload selected fork branch" onclick="ReloadGitHubForkBranch(); return false;"><i class="fas fa-sync-alt" aria-hidden="true"></i></a>
-            <span class="small text-muted ms-2">Switch to a branch from your fork (<span id="gitHubForkUserLabel"></span>) or use official branches.</span>
+            <span id="gitHubForkBranch_tip" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="auto" data-bs-title="Switch to a branch from your fork or use official branches."><img id="gitHubForkBranch_img" src="images/redesign/help-icon.svg" class="icon-help" alt="help icon"></span>
             <div class="callout callout-secondary mt-1">
                 <b>Note:</b> Shows branches from <code id="gitHubForkRepoLabel">your fork</code> on GitHub.
             </div>

--- a/www/settings-developer.php
+++ b/www/settings-developer.php
@@ -52,6 +52,11 @@ function PrintGitBranchOptions()
             $remote = 'newfeatures';
         } else if (strpos($settings['gitRemote'], 'origin') !== false) {
             $remote = 'origin';
+        } else if (isset($settings['gitHubUser']) && strtolower(trim($settings['gitRemote'])) === strtolower(trim($settings['gitHubUser'])) ) {
+            $remote = trim($settings['gitHubUser']);
+        } else if (!empty($settings['gitRemote']) && preg_match('/^[a-zA-Z0-9_-]+$/', $settings['gitRemote'])) {
+            // Custom fork remote (e.g. GitHub username) - use as-is after validation
+            $remote = $settings['gitRemote'];
         }
     }
 
@@ -141,124 +146,91 @@ function PrintGitBranchOptions()
         });
     }
 
-    function ChangeGitHubForkBranch(branch) {
-        if (!branch) {
-            return;
-        }
-        var user = $('#gitHubUser').val() || '';
-        user = user.trim();
-        if (!user) {
-            alert('GitHub user not set');
-            return;
-        }
-        // Reuse the same confirmation as ChangeGitBranch but indicate fork remote
-        if (confirm("Are you really sure you want to switch to the '" + branch + "' branch from your fork (" + user + "/fpp)?  This may take some time and it may not be fully compatible with this FPP OS version.  Click 'OK' to continue.")) {
-            location.href = 'changebranch.php?branch=' + encodeURIComponent(branch) + '&remote=' + encodeURIComponent(user);
-        } else {
-            $('#gitHubForkBranch').val('');
-        }
-    }
-
     function ReloadGitBranch() {
         var branch = $('#gitBranch').val();
         if (!branch) return;
         ChangeGitBranch(branch);
     }
 
-    function ReloadGitHubForkBranch() {
-        var branch = $('#gitHubForkBranch').val();
-        if (!branch) return; // Use Official Branches selected -> do nothing
-        ChangeGitHubForkBranch(branch);
-    }
-
     var currentGitBranch = "<?php echo addslashes($git_branch); ?>";
     var currentGitRemote = "<?php echo addslashes($git_branch_remote); ?>";
 
-    function loadGitHubForkBranches() {
+    function loadGitRemoteForkOption() {
         var user = $('#gitHubUser').val();
         var pat = $('#gitHubPAT').val();
+        var $remoteSel = $('#gitRemote');
+        // Remove any previous fork option to avoid duplicates / stale user
+        $remoteSel.find('option[data-fork="1"]').remove();
         if (!user || !pat || $.trim(user) === '' || $.trim(pat) === '') {
-            $('#gitHubForkBranchRow').hide();
+            var curVal = $remoteSel.val();
+            if (curVal && $remoteSel.find('option[value="' + curVal + '"]').length === 0) {
+                // Fork was selected but credentials cleared - fall back to origin
+                $remoteSel.val('origin');
+                reloadGitBranches('origin');
+            }
             return;
         }
         $.ajax({
             url: 'api/git/forkBranches',
             type: 'GET',
             success: function (data) {
-                if (data && data.hasFork && data.branches && data.branches.length > 0) {
-                    var $sel = $('#gitHubForkBranch');
-                    $sel.empty();
-                    $sel.append($('<option>').attr('value', '').prop('selected', true).text('Use Official Branches'));
-                    data.branches.forEach(function (branch) {
-                        $sel.append($('<option>').attr('value', branch).text(branch));
-                    });
-                    $('#gitHubForkRepoLabel').text(data.user + '/fpp');
-                    var tipText = "Switch to a branch from your fork (" + data.user + ") or use official branches.";
-                    $('#gitHubForkBranch_tip').attr('data-bs-title', tipText);
-                    var tipEl = document.getElementById('gitHubForkBranch_tip');
-                    if (tipEl && window.bootstrap && bootstrap.Tooltip) {
-                        var inst = bootstrap.Tooltip.getInstance(tipEl);
-                        if (inst) inst.dispose();
-                        new bootstrap.Tooltip(tipEl);
+                if (data && data.hasFork) {
+                    var label = 'GitHub User Fork (' + data.user + '/fpp)';
+                    var value = data.user;
+                    if ($remoteSel.find('option[value="' + value + '"]').length === 0) {
+                        $remoteSel.append($('<option>').attr('value', value).attr('data-fork', '1').text(label));
+                    } else {
+                        $remoteSel.find('option[value="' + value + '"]').attr('data-fork', '1').text(label);
                     }
-                    // Stay on the branch that was switched to instead of jumping back to Use Official Branches
-                    if (currentGitBranch && currentGitRemote && data.user && currentGitRemote.toLowerCase() === data.user.toLowerCase() && data.branches.indexOf(currentGitBranch) !== -1) {
-                        $sel.val(currentGitBranch);
+                    var savedRemote = $remoteSel.val();
+                    var shouldSelectFork = false;
+                    if (savedRemote && savedRemote.toLowerCase() === data.user.toLowerCase()) {
+                        shouldSelectFork = true;
+                    } else if (currentGitRemote && currentGitRemote.toLowerCase() === data.user.toLowerCase()) {
+                        shouldSelectFork = true;
+                        $remoteSel.val(value);
                     }
-                    $('#gitHubForkBranchRow').show();
-                } else if (data && data.hasFork) {
-                    // Fork exists but no branches (or all filtered) - still show dropdown with default only
-                    var $sel = $('#gitHubForkBranch');
-                    $sel.empty();
-                    $sel.append($('<option>').attr('value', '').prop('selected', true).text('Use Official Branches'));
-                    $('#gitHubForkRepoLabel').text(data.user + '/fpp');
-                    var tipText2 = "Switch to a branch from your fork (" + data.user + ") or use official branches.";
-                    $('#gitHubForkBranch_tip').attr('data-bs-title', tipText2);
-                    var tipEl2 = document.getElementById('gitHubForkBranch_tip');
-                    if (tipEl2 && window.bootstrap && bootstrap.Tooltip) {
-                        var inst2 = bootstrap.Tooltip.getInstance(tipEl2);
-                        if (inst2) inst2.dispose();
-                        new bootstrap.Tooltip(tipEl2);
+                    if (shouldSelectFork) {
+                        reloadGitBranches(value);
                     }
-                    if (currentGitBranch && currentGitRemote && data.user && currentGitRemote.toLowerCase() === data.user.toLowerCase()) {
-                        // Current branch is on this fork but has no listed branches (filtered) - keep default
-                    }
-                    $('#gitHubForkBranchRow').show();
                 } else {
-                    $('#gitHubForkBranchRow').hide();
+                    $remoteSel.find('option[data-fork="1"]').remove();
                 }
             },
             error: function () {
-                $('#gitHubForkBranchRow').hide();
+                $remoteSel.find('option[data-fork="1"]').remove();
             }
         });
     }
 
     $(document).ready(function () {
         reloadGitStatus();
-        loadGitHubForkBranches();
+        loadGitRemoteForkOption();
 
-        // Listen for changes to the git remote setting
+        // Listen for changes to the git remote setting - supports origin/newfeatures and fork user
         $('#gitRemote').on('change', function () {
-            var remote = $(this).val();
-            // Extract the remote name from the value (in case it contains description text)
-            if (remote.indexOf('newfeatures') !== -1) {
-                remote = 'newfeatures';
-            } else if (remote.indexOf('origin') !== -1) {
-                remote = 'origin';
+            var $opt = $(this).find('option:selected');
+            var remote;
+            if ($opt.attr('data-fork') === '1') {
+                remote = $opt.val();
+            } else {
+                remote = $(this).val();
+                if (remote.indexOf('newfeatures') !== -1) {
+                    remote = 'newfeatures';
+                } else if (remote.indexOf('origin') !== -1) {
+                    remote = 'origin';
+                }
             }
             reloadGitBranches(remote);
         });
 
-        // Reload fork branches when GitHub credentials change (saved via SetSetting)
-        // The inputs use onChange to call SetSetting; poll for a short time after change
+        // Reload fork option when GitHub credentials change (saved via SetSetting)
         var forkReloadTimer = null;
         function scheduleForkReload() {
             if (forkReloadTimer) clearTimeout(forkReloadTimer);
-            forkReloadTimer = setTimeout(loadGitHubForkBranches, 800);
+            forkReloadTimer = setTimeout(loadGitRemoteForkOption, 800);
         }
         $('#gitHubUser, #gitHubPAT').on('change blur', scheduleForkReload);
-        // Also observe after SetSetting completes - hook into the global SetSetting if available
         var origSetSetting = window.SetSetting;
         if (typeof origSetSetting === 'function') {
             window.SetSetting = function () {
@@ -287,21 +259,6 @@ function PrintGitBranchOptions()
     PrintSetting('DistributedCompile');
     PrintSetting('DistccHosts');
     ?>
-    <div class="row" id="gitHubForkBranchRow" style="display:none">
-        <div class='printSettingLabelCol col-md-4 col-lg-3 col-xxxl-2 align-top'>
-            <div class="description"><i class='fas fa-fw fa-code fa-nbsp ui-level-3' title='Developer Level Setting'></i>GitHub Fork Branch:</div>
-        </div>
-        <div class='printSettingFieldCol col-md'>
-            <select id='gitHubForkBranch' onChange="ChangeGitHubForkBranch($('#gitHubForkBranch').val());">
-                <option value="" selected>Use Official Branches</option>
-            </select>
-            <a href="#" class="btn btn-sm btn-outline-secondary ms-2" title="Reload selected fork branch" onclick="ReloadGitHubForkBranch(); return false;"><i class="fas fa-sync-alt" aria-hidden="true"></i></a>
-            <span id="gitHubForkBranch_tip" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="auto" data-bs-title="Switch to a branch from your fork or use official branches."><img id="gitHubForkBranch_img" src="images/redesign/help-icon.svg" class="icon-help" alt="help icon"></span>
-            <div class="callout callout-secondary mt-1">
-                <b>Note:</b> Shows branches from <code id="gitHubForkRepoLabel">your fork</code> on GitHub.
-            </div>
-        </div>
-    </div>
     <div class="row">
         <div class='printSettingLabelCol col-md-4 col-lg-3 col-xxxl-2 align-top'>
             <div class="description"><i class='fas fa-fw fa-code fa-nbsp ui-level-3' title='Developer Level Setting'></i>Git Branch:</div>
@@ -309,7 +266,6 @@ function PrintGitBranchOptions()
         <div class='printSettingFieldCol col-md'>
             <select id='gitBranch'
                 onChange="ChangeGitBranch($('#gitBranch').val());"><? PrintGitBranchOptions(); ?></select>
-            <a href="#" class="btn btn-sm btn-outline-secondary ms-2" title="Reload selected branch" onclick="ReloadGitBranch(); return false;"><i class="fas fa-sync-alt" aria-hidden="true"></i></a>
             <? PrintToolTip('gitBranch'); ?>
             <div class="callout callout-danger mt-1">
                 <b>Note: </b>Changing branches may take a couple minutes to recompile and may not work if you have any

--- a/www/settings-developer.php
+++ b/www/settings-developer.php
@@ -7,6 +7,20 @@ if ($return_val != 0)
     $git_branch = "Unknown";
 unset($output);
 
+$git_branch_remote = "";
+if ($git_branch !== "Unknown" && $git_branch !== "") {
+    $tmpRemote = exec("$SUDO git --git-dir=" . dirname(dirname(__FILE__)) . "/.git/ config --get branch." . escapeshellarg($git_branch) . ".remote 2>/dev/null", $out_tmp, $ret_tmp);
+    if ($ret_tmp === 0 && trim($tmpRemote) !== "") {
+        $git_branch_remote = trim($tmpRemote);
+    } else {
+        $upstream = exec("$SUDO git --git-dir=" . dirname(dirname(__FILE__)) . "/.git/ rev-parse --abbrev-ref --symbolic-full-name \\@{u} 2>/dev/null", $out3, $ret3);
+        if ($ret3 === 0 && strpos($upstream, '/') !== false) {
+            $git_branch_remote = substr($upstream, 0, strpos($upstream, '/'));
+        }
+    }
+    unset($out_tmp); unset($out3); unset($tmpRemote); unset($upstream);
+}
+
 function filterBranch($branch)
 {
     if (
@@ -127,8 +141,88 @@ function PrintGitBranchOptions()
         });
     }
 
+    function ChangeGitHubForkBranch(branch) {
+        if (!branch) {
+            return;
+        }
+        var user = $('#gitHubUser').val() || '';
+        user = user.trim();
+        if (!user) {
+            alert('GitHub user not set');
+            return;
+        }
+        // Reuse the same confirmation as ChangeGitBranch but indicate fork remote
+        if (confirm("Are you really sure you want to switch to the '" + branch + "' branch from your fork (" + user + "/fpp)?  This may take some time and it may not be fully compatible with this FPP OS version.  Click 'OK' to continue.")) {
+            location.href = 'changebranch.php?branch=' + encodeURIComponent(branch) + '&remote=' + encodeURIComponent(user);
+        } else {
+            $('#gitHubForkBranch').val('');
+        }
+    }
+
+    function ReloadGitBranch() {
+        var branch = $('#gitBranch').val();
+        if (!branch) return;
+        ChangeGitBranch(branch);
+    }
+
+    function ReloadGitHubForkBranch() {
+        var branch = $('#gitHubForkBranch').val();
+        if (!branch) return; // Use Official Branches selected -> do nothing
+        ChangeGitHubForkBranch(branch);
+    }
+
+    var currentGitBranch = "<?php echo addslashes($git_branch); ?>";
+    var currentGitRemote = "<?php echo addslashes($git_branch_remote); ?>";
+
+    function loadGitHubForkBranches() {
+        var user = $('#gitHubUser').val();
+        var pat = $('#gitHubPAT').val();
+        if (!user || !pat || $.trim(user) === '' || $.trim(pat) === '') {
+            $('#gitHubForkBranchRow').hide();
+            return;
+        }
+        $.ajax({
+            url: 'api/git/forkBranches',
+            type: 'GET',
+            success: function (data) {
+                if (data && data.hasFork && data.branches && data.branches.length > 0) {
+                    var $sel = $('#gitHubForkBranch');
+                    $sel.empty();
+                    $sel.append($('<option>').attr('value', '').prop('selected', true).text('Use Official Branches'));
+                    data.branches.forEach(function (branch) {
+                        $sel.append($('<option>').attr('value', branch).text(branch));
+                    });
+                    $('#gitHubForkUserLabel').text(data.user);
+                    $('#gitHubForkRepoLabel').text(data.user + '/fpp');
+                    // Stay on the branch that was switched to instead of jumping back to Use Official Branches
+                    if (currentGitBranch && currentGitRemote && data.user && currentGitRemote.toLowerCase() === data.user.toLowerCase() && data.branches.indexOf(currentGitBranch) !== -1) {
+                        $sel.val(currentGitBranch);
+                    }
+                    $('#gitHubForkBranchRow').show();
+                } else if (data && data.hasFork) {
+                    // Fork exists but no branches (or all filtered) - still show dropdown with default only
+                    var $sel = $('#gitHubForkBranch');
+                    $sel.empty();
+                    $sel.append($('<option>').attr('value', '').prop('selected', true).text('Use Official Branches'));
+                    $('#gitHubForkUserLabel').text(data.user);
+                    $('#gitHubForkRepoLabel').text(data.user + '/fpp');
+                    if (currentGitBranch && currentGitRemote && data.user && currentGitRemote.toLowerCase() === data.user.toLowerCase()) {
+                        // Current branch is on this fork but has no listed branches (filtered) - keep default
+                    }
+                    $('#gitHubForkBranchRow').show();
+                } else {
+                    $('#gitHubForkBranchRow').hide();
+                }
+            },
+            error: function () {
+                $('#gitHubForkBranchRow').hide();
+            }
+        });
+    }
+
     $(document).ready(function () {
         reloadGitStatus();
+        loadGitHubForkBranches();
 
         // Listen for changes to the git remote setting
         $('#gitRemote').on('change', function () {
@@ -141,6 +235,31 @@ function PrintGitBranchOptions()
             }
             reloadGitBranches(remote);
         });
+
+        // Reload fork branches when GitHub credentials change (saved via SetSetting)
+        // The inputs use onChange to call SetSetting; poll for a short time after change
+        var forkReloadTimer = null;
+        function scheduleForkReload() {
+            if (forkReloadTimer) clearTimeout(forkReloadTimer);
+            forkReloadTimer = setTimeout(loadGitHubForkBranches, 800);
+        }
+        $('#gitHubUser, #gitHubPAT').on('change blur', scheduleForkReload);
+        // Also observe after SetSetting completes - hook into the global SetSetting if available
+        var origSetSetting = window.SetSetting;
+        if (typeof origSetSetting === 'function') {
+            window.SetSetting = function () {
+                var args = Array.prototype.slice.call(arguments);
+                var setting = args[0];
+                var origCb = args[6];
+                args[6] = function () {
+                    if (typeof origCb === 'function') origCb.apply(this, arguments);
+                    if (setting === 'gitHubUser' || setting === 'gitHubPAT') {
+                        scheduleForkReload();
+                    }
+                };
+                return origSetSetting.apply(this, args);
+            };
+        }
     });
 
 </script>
@@ -154,13 +273,29 @@ function PrintGitBranchOptions()
     PrintSetting('DistributedCompile');
     PrintSetting('DistccHosts');
     ?>
+    <div class="row" id="gitHubForkBranchRow" style="display:none">
+        <div class='printSettingLabelCol col-md-4 col-lg-3 col-xxxl-2 align-top'>
+            <div class="description"><i class='fas fa-fw fa-code fa-nbsp ui-level-3' title='Developer Level Setting'></i>GitHub Fork Branch:</div>
+        </div>
+        <div class='printSettingFieldCol col-md'>
+            <select id='gitHubForkBranch' onChange="ChangeGitHubForkBranch($('#gitHubForkBranch').val());">
+                <option value="" selected>Use Official Branches</option>
+            </select>
+            <a href="#" class="btn btn-sm btn-outline-secondary ms-2" title="Reload selected fork branch" onclick="ReloadGitHubForkBranch(); return false;"><i class="fas fa-sync-alt" aria-hidden="true"></i></a>
+            <span class="small text-muted ms-2">Switch to a branch from your fork (<span id="gitHubForkUserLabel"></span>) or use official branches.</span>
+            <div class="callout callout-secondary mt-1">
+                <b>Note:</b> Shows branches from <code id="gitHubForkRepoLabel">your fork</code> on GitHub.
+            </div>
+        </div>
+    </div>
     <div class="row">
         <div class='printSettingLabelCol col-md-4 col-lg-3 col-xxxl-2 align-top'>
-            <div class="description"><i class='fas fa-fw fa-nbsp ui-level-0'></i>Git Branch:</div>
+            <div class="description"><i class='fas fa-fw fa-code fa-nbsp ui-level-3' title='Developer Level Setting'></i>Git Branch:</div>
         </div>
         <div class='printSettingFieldCol col-md'>
             <select id='gitBranch'
                 onChange="ChangeGitBranch($('#gitBranch').val());"><? PrintGitBranchOptions(); ?></select>
+            <a href="#" class="btn btn-sm btn-outline-secondary ms-2" title="Reload selected branch" onclick="ReloadGitBranch(); return false;"><i class="fas fa-sync-alt" aria-hidden="true"></i></a>
             <? PrintToolTip('gitBranch'); ?>
             <div class="callout callout-danger mt-1">
                 <b>Note: </b>Changing branches may take a couple minutes to recompile and may not work if you have any
@@ -173,7 +308,7 @@ function PrintGitBranchOptions()
     </div>
     <div class="row">
         <div class='printSettingLabelCol col-md-4 col-lg-3 col-xxxl-2 align-top'>
-            <div class="description"><i class='fas fa-fw fa-nbsp ui-level-0'></i>Git Status:</div>
+            <div class="description"><i class='fas fa-fw fa-code fa-nbsp ui-level-3' title='Developer Level Setting'></i>Git Status:</div>
         </div>
         <div class='printSettingFieldCol col-md'>
             <input type='button' class="buttons btn-outline-danger" value='Reset Local Changes' onClick='GitReset();'>
@@ -189,7 +324,7 @@ function PrintGitBranchOptions()
     </div>
     <div class="row mt-2">
         <div class='printSettingLabelCol col-md-4 col-lg-3 col-xxxl-2 align-top'>
-            <div class="description"><i class='fas fa-fw fa-nbsp ui-level-0'></i>FPP Rebuild</div>
+            <div class="description"><i class='fas fa-fw fa-code fa-nbsp ui-level-3' title='Developer Level Setting'></i>FPP Rebuild</div>
         </div>
         <div class='printSettingFieldCol col-md'>
             <input type='button' class="buttons btn-outline-danger" value='Rebuild FPP' onClick='RebuildFPPSource();'>

--- a/www/settings.json
+++ b/www/settings.json
@@ -1712,7 +1712,7 @@
 			"name": "gitRemote",
 			"description": "Git Remote Repository",
 			"gatherStats": true,
-			"tip": "Select the git remote repository to use for branch selection. 'origin' is the main FPP repository, 'newfeatures' is for new feature testing.",
+			"tip": "Select the git remote repository to use for branch selection. 'FPP Releases' is the main FPP repository, 'FPP New Feature Testing' is for new feature testing. 'GitHub User Fork' is for user forks if valid GitHub credentials containing a fork is detected.",
 			"default": "origin",
 			"type": "select",
 			"options": {


### PR DESCRIPTION
# feat(developer): Add GitHub fork branch switching when exists on GitHub credentials

## Summary
On `settings.php#settings-developer`, when a saved GitHub username (`gitHubUser`) and Personal Access Token (`gitHubPAT`) point to a fork containing `fpp` (`github.com/<user>/fpp`), show a fork-branch switcher that defaults to **Use Official Branches** and allows switching to any branch from that fork. Also adds reload controls and corrects developer-level icon to match the rest of the settings UI.

## Changes

### UI — `www/settings-developer.php`
- **GitHub Fork Branch row** (`#gitHubForkBranchRow`, hidden by default): visible only when `api/git/forkBranches` returns `hasFork:true`.
  - Dropdown `#gitHubForkBranch` populated from fork branches, sorted, filtered like official branches (`v0`–`v6`, `dependabot/`, `HEAD` excluded). Default option `Use Official Branches` (`value="" selected`).
  - Helper text shows `user/fpp` (`#gitHubForkUserLabel` / `#gitHubForkRepoLabel`).
  - `ChangeGitHubForkBranch(branch)` → `changebranch.php?branch=<branch>&remote=<user>` (same confirm flow as `ChangeGitBranch`).
  - **Reload icon** (`fa-sync-alt`) to the right of the dropdown: `ReloadGitHubForkBranch()` — no-op when `Use Official Branches` selected.
  - **Sticky selection**: on load, detects current checked-out branch/remote (`git config --get branch.<branch>.remote` → fallback `rev-parse --symbolic-full-name @{u}`) and if `currentGitRemote` matches the fork user (case-insensitive) and `currentGitBranch` is in the fork list, pre-selects it instead of snapping back to `Use Official Branches`.
- **Git Branch row**: added adjacent reload icon → `ReloadGitBranch()` re-invokes `ChangeGitBranch` for the currently selected official branch.
- **Icons**: changed `GitHub Fork Branch`, `Git Branch`, `Git Status`, `FPP Rebuild` from `fa-nbsp ui-level-0` to developer level `fa-code fa-nbsp ui-level-3` (`title="Developer Level Setting"`), fixing missing `fa-nbsp` spacing (`margin-right:0.4em`) to be consistent with `common.php:PrintIcon()`.

### API — `www/api/controllers/git.php`
- New endpoint `GET /api/git/forkBranches` (`GitForkBranches()`):
  - Validates `gitHubUser` (`^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$`) and rejects CRLF in `gitHubPAT`.
  - Probes `https://api.github.com/repos/<user>/fpp` (`Authorization: token <PAT>`, `User-Agent: FPP`) then `.../branches?per_page=100`.
  - Falls back to local `git branch -r` when GitHub is unreachable or returns `404` but a local remote `<user>` exists (covers offline/CIs and pre-fetched forks).
  - Returns `{hasFork: bool, user: string, branches: string[]}` — never leaks PAT.

### Routing — `www/api/index.php`
- Added `dispatch_get('/git/forkBranches','GitForkBranches')`.

### Branch switching — `www/changebranch.php` + `scripts/git_branch`
- `www/changebranch.php`: when `remote` matches saved `gitHubUser` (case-insensitive), ensures remote exists (`git remote add` / `set-url` with `https://<user>:<PAT>@github.com/<user>/fpp.git`), then **pre-fetches** it under `flock -w 60` on `media/tmp/fpp-git-repo.lock` (same lock as `git_fetch`/`git_branch`) so `git_branch`’s `show-ref` check succeeds for newly-added forks.
- `scripts/git_branch`: added pre-fetch for non-`origin`/`newfeatures` remotes before `CNT=$(git show-ref | grep "refs/remotes/$REMOTE" | grep -i $1)` validation.

## Behavior
- No saved `gitHubUser`/`gitHubPAT` or no fork → row stays `display:none` (no UI change).
- `hasFork:true` but zero branches → row still shown with only `Use Official Branches` (no empty state).
- Selecting `Use Official Branches` → `ChangeGitHubForkBranch` early-returns; reload icon also no-ops.
- After switching to a fork branch, the fork dropdown remains on that branch (remote-aware) instead of jumping back to `Use Official Branches`; on official branches it stays on `Use Official Branches`.
- Official branch flow (`origin`/`newfeatures`) unchanged.

## Testing
- `php -l www/settings-developer.php www/api/controllers/git.php www/api/index.php www/changebranch.php && bash -n scripts/git_branch` — syntax OK.
- Manual: set `gitHubUser`/`gitHubPAT` to a user with `fpp` fork → Developer tab shows fork dropdown, `Use Official Branches` selected by default, fork branches listed, reload icon respects empty selection.
- Fork switch: select `fixoverflow` for `jessica12ryan` → `changebranch.php?branch=fixoverflow&remote=jessica12ryan` fetches remote then `git_branch` succeeds.
- Official branch switch and `GitBranches`/`GitStatus`/`GitReset` unaffected.

## Risk
Low — additive UI/API, no schema changes, no breaking changes to existing endpoints or branch filtering. Fork remote URL contains PAT only in local git config (same pattern as existing private-repo handling).

## Screenshot
<img width="1497" height="1150" alt="ss_featGitForks" src="https://github.com/user-attachments/assets/318fcb7d-0e85-4792-b879-192002299b40" />

## Additional Comments
This reuses existing credentials to show fork branches (only if an fpp fork is present on the supplied credentials, otherwise the dropdown does not appear).

With many contributors using AI, this provides an easy way to switch between personal dev branches to verify and test your work before creating a PR. This dropdown will never appear unless UI is set to developer mode, GitHub credentials are entered and valid, and the GitHub account contains an fpp fork.

This is a great enhancement for developers and contributors.