### PR TITLE
fix(healthcheck): warning count in healthCheckSSE to count each FPPD warning separately

### DIFF
--- a/scripts/healthCheckSSE
+++ b/scripts/healthCheckSSE
@@ -119,7 +119,10 @@ HC_Warnings() {
             details=$(jq -c '.' "$WARNING_FILE" 2>/dev/null)
             echo "data: {\"id\":\"warnings\",\"label\":\"FPPD Warnings\",\"icon\":\"fa-exclamation-triangle\",\"status\":\"$status\",\"message\":\"$message\",\"details\":$details}"
             echo ""
-            WARN_COUNT=$((WARN_COUNT + 1))
+            if ! [[ "$CNT" =~ ^[0-9]+$ ]]; then
+                CNT=1
+            fi
+            WARN_COUNT=$((WARN_COUNT + CNT))
         fi
     fi
 }


### PR DESCRIPTION
# fix(healthcheck): warning count in healthCheckSSE to count each FPPD warning separately

## Summary
Fixes the total warnings count on `www/system-stats.php` so that each entry in `warnings.json` contributes individually to the summary badge. Previously multiple FPPD warnings only incremented the summary `warn` count by 1.

## Problem
On `System Health` (`system-stats.php` → `healthCheckSSE.php` → `scripts/healthCheckSSE`), `HC_Warnings()` correctly reports `N warning(s) found` in the message/details but always did:

```bash
WARN_COUNT=$((WARN_COUNT + 1))
```

at `scripts/healthCheckSSE:122`. The SSE `done` summary (`{pass, warn, fail}`) consumed by `www/system-stats.php:310` (`updateHealthSummary()`) therefore showed `Warnings: 1` even when `warnings.json` contained e.g. 5 warnings. The expandable `FPPD Warnings` row showed all details, but the top-level badge was under-counted.

## Root Cause
`scripts/healthCheckSSE:96-128` `HC_Warnings()` already computes the count:

```bash
CNT=$(jq 'length' "$WARNING_FILE" 2>/dev/null) # scripts/healthCheckSSE:110
```

and uses it for the message (`"${CNT} warning(s) found"` at `scripts/healthCheckSSE:117`) and the `details` payload, but the global counter was not using it. All other checks go through `emit_event()` / `emit_event_details()` (`scripts/healthCheckSSE:14-58`) which correctly do `WARN_COUNT=$((WARN_COUNT + 1))` for a single `warn` status — correct for those checks, incorrect for the aggregated warnings check.

`scripts/healthCheck:343-373` (legacy non-SSE `healthCheck`) exhibits the same display bug but is not used by the current UI.

## Fix
- `scripts/healthCheckSSE:122-125`: Change increment from `+1` to `+CNT` with numeric guard:

```bash
if ! [[ "$CNT" =~ ^[0-9]+$ ]]; then
    CNT=1
fi
WARN_COUNT=$((WARN_COUNT + CNT))
```

- No new variables introduced — `CNT` existed at `scripts/healthCheckSSE:110`. No changes to `www/system-stats.php` or `www/healthCheckSSE.php` required; they correctly render `summary.warn`.
- Behavior preserved for `CNT=1` (still `+1`), `CNT=0` (handled as `pass` via the existing `if [ "${CNT:-0}" == "0" ]` branch), and malformed `jq` output (fallback to `1`).

## Testing
- `bash -n scripts/healthCheckSSE` — syntax OK.
- Manual simulation: `CNT=3` → `WARN_COUNT` goes `0→3` (previously `0→1`); `CNT=1` → `0→1` (unchanged); `CNT=5` → `0→5`.
- `jq` integration: `echo '["a","b","c"]' > /tmp/warnings.json; CNT=$(jq 'length' /tmp/warnings.json); WARN_COUNT=$((WARN_COUNT + CNT))` → `3` as expected.
- Verified end-to-end expectation: `healthCheckSSE` SSE stream emits `data: {"id":"warnings","status":"warn","message":"3 warning(s) found","details":[...]}` followed by `data: {"id":"done","summary":{"warn":3,...}}` so `system-stats.php` badge shows `3`.

## Risk
Low. Single-line logic change isolated to the `warn` branch of `HC_Warnings()`. No interface changes; channel-output plugins and `www/settings.json` unaffected. Fails closed (malformed count → `+1`).

## Checklist
- [x] Repro identified in `scripts/healthCheckSSE:122`
- [x] No `www/` changes needed
- [x] `shellcheck`/`bash -n` clean
- [x] Handles `CNT=0`, `CNT=1`, `CNT>1`, non-numeric/missing `jq`

Fixes: total warnings on `system-stats.php` only increasing by one when FPPD has multiple warnings.

## Additional Comments
This was reported on a [facebook post](https://www.facebook.com/share/p/1H421faqyG/?) on the official FPP page.