### PR TITLE
FPP PTP lock requires valid management evidence

### DIFF
--- a/src/mediaoutput/AES67Manager.cpp
+++ b/src/mediaoutput/AES67Manager.cpp
@@ -1119,7 +1119,8 @@ void AES67Manager::RefreshPtpCache(bool force) {
             std::string val;
             ls >> val;
             fresh.gmPresent = (val == "true");
-            fresh.valid = true;
+            fresh.gmPresentValid = (val == "true" || val == "false");
+            fresh.valid = fresh.gmPresentValid;
         } else if (key == "gmIdentity") {
             std::string val;
             ls >> val;
@@ -1131,9 +1132,11 @@ void AES67Manager::RefreshPtpCache(bool force) {
             std::string val;
             ls >> val;
             try {
-                fresh.offsetNs = std::stoll(val);
+                size_t consumed = 0;
+                fresh.offsetNs = std::stoll(val, &consumed);
+                fresh.offsetValid = (consumed == val.size());
             } catch (...) {
-                // leave offsetNs at 0 on parse failure
+                fresh.offsetValid = false;
             }
         }
     }
@@ -1232,11 +1235,15 @@ bool AES67Manager::WaitForPtpLock(int timeoutMs) {
         std::string portState;
         int64_t offsetNs = 0;
         bool gmPresent = false;
+        bool gmPresentValid = false;
+        bool offsetValid = false;
         {
             std::lock_guard<std::mutex> lock(m_ptpCacheMutex);
             portState = m_ptpCache.portState;
             offsetNs = m_ptpCache.offsetNs;
             gmPresent = m_ptpCache.gmPresent;
+            gmPresentValid = m_ptpCache.gmPresentValid;
+            offsetValid = m_ptpCache.offsetValid;
         }
 
         // One line per transition, not per poll: this runs four times a second
@@ -1257,8 +1264,11 @@ bool AES67Manager::WaitForPtpLock(int timeoutMs) {
                     waitedS);
             return true;
         }
-        const int64_t absOffset = offsetNs < 0 ? -offsetNs : offsetNs;
-        if (portState == "SLAVE" && absOffset < AES67::PTP_LOCK_OFFSET_NS) {
+        // Missing/malformed management data is not a zero offset. Compare
+        // signed bounds directly so INT64_MIN cannot overflow on negation.
+        if (portState == "SLAVE" && gmPresentValid && gmPresent && offsetValid &&
+            offsetNs > -AES67::PTP_LOCK_OFFSET_NS &&
+            offsetNs < AES67::PTP_LOCK_OFFSET_NS) {
             LogInfo(VB_MEDIAOUT,
                     "AES67Manager: PTP settled after %.1fs — SLAVE, offset "
                     "%+lldns\n", waitedS, (long long)offsetNs);
@@ -1267,7 +1277,7 @@ bool AES67Manager::WaitForPtpLock(int timeoutMs) {
 
         const auto now = std::chrono::steady_clock::now();
         if (now >= deadline) {
-            if (portState == "LISTENING" && !gmPresent) {
+            if (portState == "LISTENING" && gmPresentValid && !gmPresent) {
                 LogInfo(VB_MEDIAOUT,
                         "AES67Manager: no PTP grandmaster on domain %d after "
                         "%.1fs — nothing to step this clock, carrying on\n",

--- a/src/mediaoutput/AES67Manager.h
+++ b/src/mediaoutput/AES67Manager.h
@@ -1197,8 +1197,10 @@ private:
         std::chrono::steady_clock::time_point when{};
         bool valid = false;
         bool gmPresent = false;
+        bool gmPresentValid = false;
         std::string gmIdentity;
         int64_t offsetNs = 0;
+        bool offsetValid = false;
         std::string portState;
     };
     PtpQueryCache m_ptpCache;


### PR DESCRIPTION
A missing or malformed master_offset defaults to zero and falsely settles SLAVE; a failed TIME_STATUS_NP query also falsely settles LISTENING. This is a separate lock-validation defect found while investigating the software-PTP epoch issue.

## Change

Track offset and grandmaster-presence validity separately; require valid follower evidence and compare signed offset bounds directly.

Related issue: https://github.com/FalconChristmas/fpp/issues/2848

## Reproduction and acceptance

Compile the pinned upstream RefreshPtpCache and WaitForPtpLock methods with simulated pmc replies, including missing offset and failed query.

Reject invalid or missing synchronization evidence, keep valid master and standalone behavior, and avoid signed overflow for INT64_MIN.

## BCL evidence

Run: https://github.com/iibaranov-IG/broadcast-control-lab/actions/runs/34597438408

Artifact: `fpp-2848-ptp-lock-evidence`
BCL revision: `6dc929a5bcfe836d6b132278e498ee298547e985`
Tested baseline: `FalconChristmas/fpp@8ef364ce1d79a5380bc1a757492b11023b629d16`
Candidate SHA-256: `6588fcb99e6e30295ebb8f7f6abfa194903061f69db466768d08e750269efd10`

- PASS: Negative control: baseline falsely locks with missing offset
- PASS: Negative control: baseline treats failed query as no grandmaster
- PASS: Missing offset
- PASS: Empty offset
- PASS: Nonnumeric offset
- PASS: Numeric prefix is not a valid offset
- PASS: Out-of-range offset
- PASS: INT64_MIN does not overflow
- PASS: INT64_MAX stays unsettled
- PASS: Missing grandmaster field
- PASS: Absent grandmaster
- PASS: Malformed grandmaster field
- PASS: Failed query while listening
- PASS: Malformed query while listening
- PASS: Explicit no grandmaster at deadline
- PASS: Grandmaster still present while listening
- PASS: Zero offset locks
- PASS: Positive offset inside tolerance
- PASS: Negative offset inside tolerance
- PASS: Positive boundary does not lock
- PASS: Negative boundary does not lock
- PASS: Master role preserved
- PASS: Grandmaster role preserved
- PASS: Premaster remains transitional
- PASS: Uncalibrated is not locked

## Owner check

Build patched FPP, verify normal master/follower startup and management-query failures. Keep issue #2848 open: collect NIC timestamping capability, PTP status and UTC date before designing and testing separate media/system clocks.

Extracted real cache and wait methods compiled under UBSan; pmc, process checks and logging are stubbed. No full FPP build, PTP traffic, GStreamer playback or physical audio qualification. Does not fix CLOCK_REALTIME discipline into 1970 or guarantee freshness of a valid linuxptp measurement.

Hardware verified: false. Full application verified: false.

The evidence artifact contains HARDWARE-CHECK.md and owner-result.json. Automated checks do not certify hardware.

<!-- bcl:fpp-2848-ptp-lock:6588fcb99e6e30295ebb8f7f6abfa194903061f69db466768d08e750269efd10 -->
