### PR TITLE
BBShiftString: keep a V4 (send-only) chain's port 1 off during the packet phase

### DIFF
--- a/src/non-gpl/BBShiftString/BBShiftString.cpp
+++ b/src/non-gpl/BBShiftString/BBShiftString.cpp
@@ -1813,6 +1813,13 @@ void BBShiftStringOutput::setupFalconV5Support(const Json::Value& root, uint8_t*
             // and must have edges that are aligned.  Need to turn OFF the 2-4 ports during
             // the config packet
             p1->m_gpioCommands.clear();
+            if (sendOnly) {
+                // A V4 chain is never queried, but the packet phase is clocked out
+                // on every pin of the cape. Keep its port 1 off during that phase,
+                // as ports 2-4 already are, or a V4 receiver next to a V5 chain
+                // reads the V5 query packets as a chain break plus pixel data.
+                p1->m_gpioCommands.emplace_back(1, max, 0, 0);
+            }
             if (p2) {
                 p2->m_gpioCommands.clear();
                 p2->m_gpioCommands.emplace_back(2, max, 0, 0);


### PR DESCRIPTION
Fixes #2948.

A FalconV5 chain's query frames are clocked out on every pin of the cape; a FalconV4 chain on another group reads them as a chain break plus pixel data and shows garbage on its tail pixels. Ports 2-4 of every chain are already switched off for the packet phase through the GPIO command table; this does the same for port 1 of a send-only chain, which is never queried and has nothing to receive in that phase.

Seven lines in `setupFalconV5Support()`, no PRU change, no new setting.

Verified on a K32-Max with a Genius V4 receiver (1,392 px over two outputs) and an SRx1 v5 (985 px over two ports) on the same cape: five 40 fps sequences from a master over multisync, 39.98-39.99 fps mean, no second below 39.8, zero frames declined by the back-pressure gate, V5 telemetry live throughout, V4 chain clean. Details and the two experiments that narrowed it down are in #2948.

Open point, stated in the issue: the V4 chain then never receives its startup config packet. The Genius does not need one; a V4 receiver that does would need the mask lifted for the initial config packets.
