### PR TITLE
Report HinksPix firmware version on MultiSync page

### DIFF
--- a/src/NetworkController.cpp
+++ b/src/NetworkController.cpp
@@ -666,8 +666,36 @@ void NetworkController::DetectHinksPixController(Detection* st) {
     typeStr = "HinksPix";
     systemMode = BRIDGE_MODE;
 
-    DumpControllerInfo();
-    st->matched();
+    // The status page renders its firmware info via JS/AJAX, so it never
+    // shows up in the initial HTML fetch above. xLights identifies these
+    // controllers via the same endpoint (src-core/controllers/HinksPix.cpp):
+    // each of MCPU/PCPU/ECPU/WEB is a 3-char prefix ("MS_"/"PS_"/"EZ_"/"WF_")
+    // followed by a bare build number, not a dotted version -- so majorVersion
+    // is that build number directly and there is no separate minor version.
+    st->fetch(buildHttpURL(st->ip, "/XLights_BoardInfo.cgi"), [this, st](bool ok, const std::string& resp) {
+        Json::Value v;
+        if (ok && LoadJsonFromString(resp, v, JsonRoot::Object) && JsonHas(v, "MCPU")) {
+            auto stripPrefix = [](const std::string& s) {
+                return s.size() > 3 ? s.substr(3) : s;
+            };
+            std::string mcpu = stripPrefix(v["MCPU"].asString());
+            majorVersion = atoi(mcpu.c_str());
+
+            version = "MAIN:" + mcpu;
+            if (JsonHas(v, "PCPU")) {
+                version += ",POWER:" + stripPrefix(v["PCPU"].asString());
+            }
+            if (JsonHas(v, "ECPU")) {
+                version += ",WIFI:" + stripPrefix(v["ECPU"].asString());
+            }
+            if (JsonHas(v, "WEB")) {
+                version += ",WEB:" + stripPrefix(v["WEB"].asString());
+            }
+        }
+
+        DumpControllerInfo();
+        st->matched();
+    });
 }
 
 void NetworkController::DetectDIYLEDExpressController(Detection* st) {


### PR DESCRIPTION
## Summary
- `DetectHinksPixController()` only matched the controller's HTML title and never populated `version`/`majorVersion`, so HinksPix controllers always showed a blank/Unknown version on the MultiSync page even though the controller type itself was correctly detected.
- The status page renders firmware info via JS/AJAX, so it never appears in the initial HTML fetch used for detection. This follows up with a fetch to `/XLights_BoardInfo.cgi`, the same endpoint xLights uses to identify these controllers (`src-core/controllers/HinksPix.cpp`): each of `MCPU`/`PCPU`/`ECPU`/`WEB` is a 3-char prefix (`"MS_"`/`"PS_"`/`"EZ_"`/`"WF_"`) followed by a bare build number, not a dotted version, so `majorVersion` is set directly from the MCPU (main CPU) build number and `version` is formatted the same way xLights displays it (e.g. `"MAIN:135,POWER:18,WIFI:40,WEB:113"`).

## Test plan
- [x] Verified against a live HinksPix PRO 80 controller: `/XLights_BoardInfo.cgi` returned `{"MCPU":"MS_135","PCPU":"PS_18","ECPU":"EZ_40","WEB":"WF_113",...}`, cross-checked against the same values embedded in the device's own status text (`GetInfo.cgi` `ROW:906`: `"...Main CPU 135   Power CPU  18    WIFI CPU  40    Web  113..."`).
- [ ] Confirm the version now renders correctly in the MultiSync page's Version column against a real controller (I don't have a build environment to run fppd itself for this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2ib7vgHKM43kPApAPENiC