### PR TITLE
fix(RF24): Use SPIDEV as default Linux driver and fix Pi 64-bit bcm2835 build warnings #2937

### DIFF
--- a/src/channeloutput/SPInRF24L01.cpp
+++ b/src/channeloutput/SPInRF24L01.cpp
@@ -30,6 +30,14 @@
 
 #ifdef USENRF
 #include "RF24.h"
+// SPIDEV driver uses Hz (e.g. 8000000), BCM driver uses BCM2835_SPI_SPEED_8MHZ enum (4).
+// Keep wiring hard-coded on CE=GPIO22/P1_15, CSN=GPIO7/P1_26, bus spidev0.0 — no JSON change.
+// FPP_SPIDEV is set via -DFPP_SPIDEV when RF24 is built with DRIVER=SPIDEV (see modules.mk).
+#ifdef FPP_SPIDEV
+#define FPP_RF24_SPI_SPEED 8000000
+#else
+#define FPP_RF24_SPI_SPEED BCM2835_SPI_SPEED_8MHZ
+#endif
 #else
 #include "stdint.h"
 
@@ -41,6 +49,7 @@
 #define RPI_V2_GPIO_P1_24 3
 #define RPI_V2_GPIO_P1_26 7
 #define BCM2835_SPI_SPEED_8MHZ 4
+#define FPP_RF24_SPI_SPEED BCM2835_SPI_SPEED_8MHZ
 #define RF24_CRC_16 5
 #define RF24_PA_MAX 6
 
@@ -146,7 +155,7 @@ int SPInRF24L01Output::Init(Json::Value config) {
         return 0;
     }
 
-    RF24* radio = new RF24(RPI_V2_GPIO_P1_15, RPI_V2_GPIO_P1_26, BCM2835_SPI_SPEED_8MHZ);
+    RF24* radio = new RF24(RPI_V2_GPIO_P1_15, RPI_V2_GPIO_P1_26, FPP_RF24_SPI_SPEED);
     if (!radio) {
         LogErr(VB_CHANNELOUT, "Failed to create our radio instance, unable to continue!\n");
         WarningHolder::AddWarning(40, "nRF24 radio output: could not create radio instance");

--- a/src/makefiles/modules.mk
+++ b/src/makefiles/modules.mk
@@ -30,11 +30,41 @@ else ifneq ($(findstring arm,$(PI_TARGET_TRIPLE)),)
 else
     RF24_CCFLAGS := -Ofast
 endif
-RF24_CCFLAGS += -Wno-parentheses -Wno-unused-value -Wno-misleading-indentation
+RF24_CCFLAGS += -Wno-parentheses -Wno-unused-value -Wno-misleading-indentation -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
+
+# RF24 driver selection — SPIDEV is the upstream default (nRF24/RF24#971) and
+# fixes Pi5/RP1 + kernel 6.18 strict pinmux + /dev/mem issues. Keep soname
+# librf24-bcm.so forever for plugin ABI compat (may change later). The
+# FalconChristmas/RF24 fork is currently BCM-only (utility/SPIDEV missing);
+# when it gains SPIDEV support this will automatically use it. Override with
+# `make RF24_DRIVER=RPi` to force BCM for testing.
+RF24_DRIVER ?= SPIDEV
+# Detect whether the checked-out fork actually has SPIDEV sources
+ifneq (,$(wildcard ../external/RF24/utility/SPIDEV/spi.cpp))
+    RF24_HAS_SPIDEV := 1
+else
+    RF24_HAS_SPIDEV := 0
+endif
+ifeq ($(RF24_DRIVER),SPIDEV)
+    ifeq ($(RF24_HAS_SPIDEV),1)
+        RF24_ACTUAL_DRIVER := SPIDEV
+        RF24_CCFLAGS += -DFPP_SPIDEV
+        CXXFLAGS_channeloutput/SPInRF24L01.o += -DFPP_SPIDEV
+    else
+        $(warning RF24: SPIDEV requested but utility/SPIDEV missing in FalconChristmas/RF24 fork — falling back to RPi/BCM build. Sync fork with upstream nRF24/RF24 to enable SPIDEV.)
+        RF24_ACTUAL_DRIVER := RPi
+    endif
+else
+    RF24_ACTUAL_DRIVER := $(RF24_DRIVER)
+endif
 
 ../external/RF24/librf24-bcm.so: ../external/RF24/.git $(PCH_FILE)
-	@echo "Building RF24 library"
-	@CC="ccache gcc" CXX="ccache g++" $(MAKE) -C ../external/RF24/ CCFLAGS="$(RF24_CCFLAGS)"
+	@echo "Building RF24 library (driver: $(RF24_ACTUAL_DRIVER), requested: $(RF24_DRIVER))"
+	@if [ "$(RF24_ACTUAL_DRIVER)" = "SPIDEV" ]; then \
+		CC="ccache gcc" CXX="ccache g++" $(MAKE) -C ../external/RF24/ CCFLAGS="$(RF24_CCFLAGS)" DRIVER=SPIDEV LIB=librf24-bcm; \
+	else \
+		CC="ccache gcc" CXX="ccache g++" $(MAKE) -C ../external/RF24/ CCFLAGS="$(RF24_CCFLAGS)"; \
+	fi
 	@ln -sf librf24-bcm.so.1.0 ../external/RF24/librf24-bcm.so.1
 	@ln -sf librf24-bcm.so.1 ../external/RF24/librf24-bcm.so
 


### PR DESCRIPTION
# fix(RF24): Use SPIDEV as default Linux driver and fix Pi 64-bit bcm2835 build warnings #2937

## Summary

Fixes build warnings on Raspberry Pi 64-bit (`RPi/bcm2835.c` `-Wpointer-to-int-cast` / `-Wint-to-pointer-cast`) and aligns FPP's RF24 build with the upstream default: **SPIDEV is now the default Linux driver** per `nRF24/RF24#971`. The `FalconChristmas/RF24` fork is still BCM-only, so the change is bundled with a safe fallback — existing installs keep building BCM warning-free until the fork gains `utility/SPIDEV` support, at which point SPIDEV is used automatically.

Soname is intentionally kept as `librf24-bcm.so` forever (`-lrf24-bcm`) for plugin ABI compatibility.

This is in response to issue #2937.

## Issue

* **#2937** — `external/RF24/RPi/bcm2835.c` emits on `aarch64` (`-march=armv8-a`):
  ```
  RPi/bcm2835.c:111: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  RPi/bcm2835.c:1249: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
  RPi/bcm2835.c:1269: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  ```
  Triggered for `bcm2835_peri_read` / `bcm2835_peri_read_nb` / `bcm2835_peri_write` / `bcm2835_peri_write_nb` debug prints `printf("%08X", (unsigned)paddr)` and `mapmem(..., (uint32_t)bcm2835_peripherals_base)` — both truncate 64-bit pointers.

* Upstream `nRF24/RF24` has moved to `SPIDEV` as the **only future Linux driver** — `BCM2835`, `pigpio`, `wiringPi`, `MRAA`, `LittleWire` are being phased out (see `nrf24.github.io/RF24/md_docs_2using__cmake.html` and `nRF24/RF24#971`). FPP's `FalconChristmas/RF24` fork is still pinned to the BCM driver, which is broken on Pi 5 / RP1 (wrong `BCM2835_PERI_BASE` / `mmap("/dev/mem")`) and bypasses kernel pinmux on 6.18 strict configurations.

## Changes

### `src/makefiles/modules.mk`

* `-Wno-pointer-to-int-cast -Wno-int-to-pointer-cast` appended to `RF24_CCFLAGS` — silences the 64-bit truncation warnings for any `RPi/bcm2835.c` build (fallback or explicit `RF24_DRIVER=RPi`).
* Driver selection:
  ```make
  RF24_DRIVER ?= SPIDEV
  RF24_HAS_SPIDEV := $(wildcard ../external/RF24/utility/SPIDEV/spi.cpp)
  # SPIDEV + fork has it  -> DRIVER=SPIDEV LIB=librf24-bcm CCFLAGS+=-DFPP_SPIDEV
  # SPIDEV + fork lacks it -> warning + fallback to RPi/BCM (current behavior)
  # RPi explicitly      -> RPi/BCM build (test path)
  ```
  Keeps target/symlinks as `librf24-bcm.so.1.0` / `.so.1` / `.so` — no `.gitignore` / rpath churn.
* `CXXFLAGS_channeloutput/SPInRF24L01.o += -DFPP_SPIDEV` when actually building SPIDEV, so the channel output can pick the correct SPI speed constant.

### `src/channeloutput/SPInRF24L01.cpp`

* Extracted `FPP_RF24_SPI_SPEED`:
  ```cpp
  #ifdef FPP_SPIDEV
  #define FPP_RF24_SPI_SPEED 8000000        // SPIDEV: Hz via ioctl(SPI_IOC_WR_MAX_SPEED_HZ)
  #else
  #define FPP_RF24_SPI_SPEED BCM2835_SPI_SPEED_8MHZ // BCM: divider enum 4
  #endif
  ```
  Stub (`!USENRF`) also defines `FPP_RF24_SPI_SPEED`. Constructor at `SPInRF24L01.cpp:158` now uses `FPP_RF24_SPI_SPEED` instead of hard-coded `BCM2835_SPI_SPEED_8MHZ`. Wiring stays `CE=GPIO22 (RPI_V2_GPIO_P1_15)`, `CSN=GPIO7 (RPI_V2_GPIO_P1_26)`, `spidev0.0` — no new `config/channeloutputs.json` keys.

## Why SPIDEV Now

| Aspect | BCM2835 (`RPi/bcm2835.c`) | SPIDEV (`utility/SPIDEV/spi.cpp` + `gpio.cpp`) |
|---|---|---|
| Kernel | `mmap("/dev/mem")` `BCM2835_PERI_BASE` (0x20000000 / 0x3F000000) — requires `root` + `CAP_SYS_RAWIO`, fails under `CONFIG_STRICT_DEVMEM` / lockdown | `open("/dev/spidev0.x")` + `ioctl(SPI_IOC_MESSAGE)` + `libgpiod` on `/dev/gpiochip*` — no `/dev/mem`, respects DT |
| Pi 5 / RP1 | Broken — old fork hard-codes Pi 1-4 bases, RP1 SPI moved | Works — kernel `spi-bcm2835` + `pinctrl-rp1` knows topology |
| 6.18 strict pinmux | Races `spi0` DT pin claims, can wedge display/SPI | Respects `spidev` as safe child via `PiGPIOUtils.cpp:120,156-214` |
| SPI sharing | Direct register poke, no locking — conflicts with `GenericSPI` / `SPIws2801` | Kernel-serialized via `spidev` |
| Install | Already `dtparam=spi=on` + `dtoverlay=spi0-0cs` in `SD/FPP_Install.sh:1134` + `modprobe spidev` in `scripts/detect_cape:19` — no image change | Same DT requirements, already present |

## Why Keep `librf24-bcm.so`

Upstream SPIDEV builds default to `librf24.so`, but `src/makefiles/libfpp-co-SPInRF24L01.mk:8,10` links `-lrf24-bcm` and `DT_NEEDED=librf24-bcm.so` with rpaths in `src/makefiles/fppd.mk:19`, `src/fppd.sh:5`, `scripts/common:74`. Renaming would break `dlopen("libfpp-co-SPI-nRF24L01.so")` on field installs and any out-of-tree plugin that links `-lrf24-bcm`. We pass `LIB=librf24-bcm` even for SPIDEV builds (upstream `configure --libname=rf24-bcm` supports this). May change later in a major.

## Technical Details

* Issue root: `external/RF24/RPi/bcm2835.c:111,129,143,160` `(unsigned)paddr` + `%08X` and `1249,1269` `(uint32_t)base` truncate 64-bit. Flag added at `src/makefiles/modules.mk:33` covers both `aarch64` (`-march=armv8-a`) and future BCM builds.
* `SPInRF24L01.cpp:149` previously `RF24(RPI_V2_GPIO_P1_15, RPI_V2_GPIO_P1_26, BCM2835_SPI_SPEED_8MHZ)` where `BCM2835_SPI_SPEED_8MHZ=4` is a divider enum, not Hz. SPIDEV variant expects Hz (`RF24(ce, csn, 8000000)` in `nRF24/RF24`). `FPP_RF24_SPI_SPEED` bridges this without changing `RF24.h` API.
* Wiring unchanged: `pipes[2] = {0xF0F0F0F0E1, 0xF0F0F0F0D2}` at `src/channeloutput/SPInRF24L01.cpp:72-74`, channel `0-125` validation at `:143-146`, speed map `0->250K,1->1M,2->2M` at `:121-132`.

## Testing

### Build matrix (verified via `make -n`)

* `make ARCH="Raspberry Pi" -n ../external/RF24/librf24-bcm.so` without `utility/SPIDEV` — fallback: `warning: SPIDEV requested but utility/SPIDEV missing ... falling back to RPi` / `Building RF24 library (driver: RPi, requested: SPIDEV)` with `-Wno-pointer-to-int-cast`.
* `make ARCH="Raspberry Pi" RF24_DRIVER=RPi -n ...` — explicit BCM: `driver: RPi, requested: RPi`.
* With fake `../external/RF24/utility/SPIDEV/spi.cpp` present — `driver: SPIDEV, requested: SPIDEV` with `CCFLAGS+=-DFPP_SPIDEV DRIVER=SPIDEV LIB=librf24-bcm` and `CXXFLAGS_channeloutput/SPInRF24L01.o=-DFPP_SPIDEV`.
* `make ARCH="Linux"` — no `../external/RF24/librf24-bcm.so` target (correct, Pi-only at `src/makefiles/modules.mk:2`).
* `clang++ -fsyntax-only -I src src/channeloutput/SPInRF24L01.cpp` (stub, `!USENRF`) — passes.
* `clang++ -fsyntax-only -DUSENRF -I/tmp/fakeRF24 -I src src/channeloutput/SPInRF24L01.cpp` with both `-DFPP_SPIDEV` (8000000) and without (enum 4) — passes (real `RF24.h` provides `RPI_V2_GPIO_*` / `rf24_datarate_e`).

## Backward Compatibility / Breaking Changes

* **None.** Soname, rpaths, `channeloutputs.json` schema (`speed`/`channel`), wiring, and `pipes` addresses are unchanged. Field SD cards with old `FalconChristmas/RF24` checkout continue to build BCM warning-free. New installs with updated fork automatically get SPIDEV without reconfiguration. `make RF24_DRIVER=RPi` remains as escape hatch.

## Follow-ups

* Sync `FalconChristmas/RF24` fork with upstream `nRF24/RF24` to populate `utility/SPIDEV/` (currently BCM-only — see `https://github.com/FalconChristmas/RF24` `Makefile` vs `https://github.com/nRF24/RF24/blob/master/Makefile`). Until then, fallback is automatic.
* Optional later: expose `spiBus` / `spiSpeed` in `config/channeloutputs.json` (currently deferred — hard-coded `8000000` / `spidev0.0` keeps compatibility).

## Files Changed

* `src/makefiles/modules.mk` — warning suppressions, `RF24_DRIVER ?= SPIDEV` with fallback, `LIB=librf24-bcm` preserved, `-DFPP_SPIDEV` propagation
* `src/channeloutput/SPInRF24L01.cpp` — `FPP_RF24_SPI_SPEED` abstraction, constructor uses `FPP_RF24_SPI_SPEED`

## Checklist

- [x] No soname / `DT_NEEDED` change (`librf24-bcm.so` forever)
- [x] No `settings.json` / `interface-settings.json` / `pii` changes
- [x] No `www/help/` drift (RF24 has no help page)
- [x] `src/makefiles/modules.mk:33` silences `bcm2835.c` 64-bit truncation on `aarch64`
- [x] SPIDEV path respects existing `SD/FPP_Install.sh:1134` `dtparam=spi=on` / `dtoverlay=spi0-0cs` and `scripts/detect_cape:19` `modprobe spidev`
- [x] `make ARCH="Raspberry Pi" -n` verified for both `RPi` and `SPIDEV` (when available) with `librf24-bcm.so` preserved

## Additional Comments

I'm not 100% sure about this one so requesting that it be reviewed. It suggests to update the FalconChristmas/RF24 fork with upstream nRF24/RF24.

I don't have the equipment to test this. It does fix the build warnings.
