### PR TITLE
fix(plugins): pass FPPDIR to uninstall scripts as env; make scripts/common set -u safe

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -71,7 +71,7 @@ export FPPUSER
 export FPPGROUP
 export FPPPLATFORM
 export PATH=${PATHDIRS}:${PATH}
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${FPPDIR}/external/RF24:${FPPDIR}/lib:${FPPDIR}/src
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:${FPPDIR}/external/RF24:${FPPDIR}/lib:${FPPDIR}/src
 
 SUDO=${SUDO:-sudo -E}
 export SRCDIR="${FPPDIR}/src"
@@ -469,7 +469,7 @@ gracefullyReloadApacheConf() {
 #
 # Example: /opt/fpp/scripts/common setSetting Key Value
 BASENAME=$(basename -- $0)
-if [ "${BASENAME}" = "common" -a -n "$1" ]
+if [ "${BASENAME}" = "common" -a -n "${1:-}" ]
 then
     $@
 fi

--- a/scripts/uninstall_plugin
+++ b/scripts/uninstall_plugin
@@ -12,15 +12,23 @@ fi
 
 startPluginLog uninstall "$1"
 
+# Pass FPPDIR/SRCDIR through sudo as environment assignments AND as trailing
+# arguments, matching install_plugin/upgrade_plugin. The args-only form never
+# set them as env vars, and the Plugin Manager exports SUDO="sudo" (no -E,
+# sudoers env_reset) which strips the exported FPPDIR, so an uninstall script
+# doing `source ${FPPDIR}/scripts/common` got "/scripts/common: No such file"
+# -- and one running under `set -u` (fpp-live-follow) aborted outright with
+# "FPPDIR: unbound variable" before removing its service/proxy config. The
+# trailing args stay for plugins that parse them.
 if [ -x "${PLUGINDIR}/$1/scripts/fpp_uninstall.sh" ]
 then
 	echo "Running fpp_uninstall.sh script for $1"
-	$SUDO ${PLUGINDIR}/$1/scripts/fpp_uninstall.sh FPPDIR=${FPPDIR} SRCDIR=${FPPDIR}/src
+	$SUDO FPPDIR=${FPPDIR} SRCDIR=${FPPDIR}/src ${PLUGINDIR}/$1/scripts/fpp_uninstall.sh FPPDIR=${FPPDIR} SRCDIR=${FPPDIR}/src
 else
 	if [ -x "${PLUGINDIR}/$1/fpp_uninstall.sh" ]
 	then
 		echo "Running fpp_uninstall.sh script for $1"
-		$SUDO ${PLUGINDIR}/$1/fpp_uninstall.sh FPPDIR=${FPPDIR} SRCDIR=${FPPDIR}/src
+		$SUDO FPPDIR=${FPPDIR} SRCDIR=${FPPDIR}/src ${PLUGINDIR}/$1/fpp_uninstall.sh FPPDIR=${FPPDIR} SRCDIR=${FPPDIR}/src
 	fi
 fi
 


### PR DESCRIPTION
## Summary
Found while reviewing FalconChristmas/fpp-data#231 (fpp-live-follow). Plugin guidelines tell install/uninstall scripts to `source ${FPPDIR}/scripts/common; setSetting restartFlag 1`; two FPP-side problems break that for any plugin script running under `set -u`:

1. **`scripts/uninstall_plugin`** passed `FPPDIR`/`SRCDIR` only as trailing *arguments*, never as env. The Plugin Manager runs it with `SUDO="sudo"` (no `-E`, sudoers `env_reset`) which strips the exported `FPPDIR`, so `fpp_uninstall.sh` saw it unset and aborted with `FPPDIR: unbound variable` before disabling its systemd service / removing its Apache proxy conf. `install_plugin` and `upgrade_plugin` already use the env-assignment form (see the comment in `install_plugin` for the history) - this makes `uninstall_plugin` match.
2. **`scripts/common`** is not `set -u` clean: line 74 expands a bare `$LD_LIBRARY_PATH` (always stripped by sudo) and the direct-call shim at the bottom tests `"$1"` unguarded. So even with `FPPDIR` set, sourcing common from a `set -u` script died. Net effect: fpp-live-follow's `fpp_install.sh` has exited right after its first `echo` since it added the restartFlag line on Aug 25 (error hidden by its `2>/dev/null`). Both now use `${VAR:-}`.

## Test plan
- [x] `sudo env -i FPPDIR=... bash -c 'set -uo pipefail; source scripts/common'` succeeds as root and as fpp (failed before with `LD_LIBRARY_PATH: unbound variable`)
- [x] `scripts/common getSetting HostName` direct-call unchanged
- [x] `bash scripts/common` with no args exits 0
- [x] A `set -u` `fpp_uninstall.sh` that sources common, run via `SUDO=sudo PLUGINDIR=<tmp> scripts/uninstall_plugin <plugin>`, reaches its cleanup steps (aborted at line 1 before)
- [x] The first 12 lines of fpp-live-follow's `fpp_install.sh`, invoked exactly as `install_plugin` does, now get past the restartFlag line (rc=1 before, rc=0 after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HAfsVJ9TEPVPf46XsMqJ1