### PR TITLE
mqtt: fix swapped retain/qos arguments in MosquittoClient::Publish()

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -258,7 +258,10 @@ int MosquittoClient::Init(const std::string& username, const std::string& passwo
 }
 
 /*
- *
+ * Publish to an absolute topic.  Note the parameter order is (retain, qos);
+ * the Publish() overloads below must pass them through in that order.
+ * This signature is used directly by plugins (e.g. fpp-HomeAssistant) and
+ * must not change.
  */
 int MosquittoClient::PublishRaw(const std::string& topic, const std::string& msg, const bool retain, const int qos) {
     LogDebug(VB_CONTROL, "Publishing message '%s' on topic '%s'\n", msg.c_str(), topic.c_str());
@@ -284,20 +287,24 @@ int MosquittoClient::PublishRaw(const std::string& topic, const std::string& msg
     return 1;
 }
 
+// Two-argument overloads used by Events::Publish() and by plugins.
+//
+// Everything published through here is retained (QoS 1).  Historically the
+// four-argument overloads below passed retain/qos to PublishRaw() in the wrong
+// order, which had the effect of retaining every message regardless of the
+// flag requested.  Consumers such as Home Assistant depend on that: retained
+// state topics (status, playlist/*, fppd_status, plugin light/switch state...)
+// are what let a subscriber recover the current state on (re)connect instead
+// of showing "unknown" until the next change.  Keep retaining state topics so
+// fixing the argument order does not change what is stored on the broker.
 bool MosquittoClient::Publish(const std::string& topic, const std::string& data) {
-    if (topic == "version" || topic == "branch" || topic == "warnings") {
-        return Publish(topic, data, true, 1);
-    }
-    return Publish(topic, data, false, 1);
+    return Publish(topic, data, true, 1);
 }
 bool MosquittoClient::Publish(const std::string& topic, const int value) {
-    if (topic == MQTT_READY_TOPIC_NAME) {
-        if (value) {
-            SetReady();
-        }
-        return Publish(topic, value, true, 1);
+    if (topic == MQTT_READY_TOPIC_NAME && value) {
+        SetReady();
     }
-    return Publish(topic, value, false, 1);
+    return Publish(topic, value, true, 1);
 }
 
 /*
@@ -306,7 +313,7 @@ bool MosquittoClient::Publish(const std::string& topic, const int value) {
 int MosquittoClient::Publish(const std::string& subTopic, const std::string& msg, const bool retain, const int qos) {
     std::string topic = m_baseTopic + "/" + subTopic;
 
-    return PublishRaw(topic, msg, qos, retain);
+    return PublishRaw(topic, msg, retain, qos);
 }
 
 /*
@@ -316,7 +323,7 @@ int MosquittoClient::Publish(const std::string& subTopic, const int value, const
     std::string topic = m_baseTopic + "/" + subTopic;
     std::string msg = std::to_string(value);
 
-    return PublishRaw(topic, msg, qos, retain);
+    return PublishRaw(topic, msg, retain, qos);
 }
 
 /*

--- a/www/help/mqtt.php
+++ b/www/help/mqtt.php
@@ -25,7 +25,7 @@ require_once '../config.php';
 <tr><td>ready</td><td>1 when fppd starts, 0 when fppd stops. Has "last will" set to 0.</td><td>Yes</td></tr>
 <tr><td>version</td><td>Current full version of FPP software</td><td>Yes</td></tr>
 <tr><td>branch</td><td>Git branch currently in use</td><td>Yes</td></tr>
-<tr><td>status</td><td>Current player status: <code>idle</code> or <code>playing</code></td><td>No</td></tr>
+<tr><td>status</td><td>Current player status: <code>idle</code> or <code>playing</code></td><td>Yes</td></tr>
 <tr><td>warnings</td><td>JSON array of warning messages</td><td>Yes</td></tr>
 </tbody>
 </table>


### PR DESCRIPTION
`Publish(subTopic, msg, retain, qos)` has called `PublishRaw(topic, msg, qos, retain)` since 9c37023ed (2021) reversed the parameter names in the signatures without updating the body of `Publish()`.

Every caller passes `qos=1`, so on the wire every message was retained (`retain` received the int 1) and the "non-retained" topics went out at QoS 0 (`qos` received the bool `false`). The topic list in the two-arg overloads (`version`/`branch`/`warnings`/`ready`) therefore never affected retention, only QoS.

## Change

- Fix the argument order in both four-arg `Publish()` overloads.
- Make the two-arg overloads (used by `Events::Publish()` and plugins) retain unconditionally. This preserves exactly what is stored on the broker today. Home Assistant users and the fpp-HomeAssistant plugin depend on retained state topics to recover current state on (re)connect instead of showing "unknown", and the plugin's empty-payload clears of its cached `ha/.../config` topics only work because they are retained. Flipping the default would leave stale retained values on every user's broker indefinitely, since a non-retained publish never replaces a retained one.
- Correct `www/help/mqtt.php`: `status` has always been retained.

## Net effect

`status`, `playlist/*`, `fppd_status`, `playlist_details`, `port_status`, `command/*` and `gpio/*` move from QoS 0 to QoS 1, which is what every caller requested. No topic gains or loses retention, so no broker cleanup or migration is needed.

`PublishRaw()`'s signature is unchanged so existing plugin binaries keep loading. The `MQTT` command and `MQTTOutput` call `PublishRaw()` directly and were never affected.

## Verifying

`mosquitto_sub -v -t '<prefix>falcon/player/<host>/#' -F '%t %q %r %p'` — before this change most topics show `q=0 r=1`; after, all show `q=1 r=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
